### PR TITLE
user vhost and perm require service is started.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -120,8 +120,7 @@ class rabbitmq::server(
     # delete the default guest user
     rabbitmq_user{ 'guest':
       ensure   => absent,
-      provider => 'rabbitmqctl', 
-      require  => Class['rabbitmq::service']
+      provider => 'rabbitmqctl',
     }
   }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,10 +18,13 @@ class rabbitmq::service(
   $ensure='running'
 ) {
 
-  $service_name_real = $service_name 
+  $service_name_real = $service_name
 
   validate_re($ensure, '^(running|stopped)$')
   if $ensure == 'running' {
+    Class['rabbitmq::service'] -> Rabbitmq_user<| |>
+    Class['rabbitmq::service'] -> Rabbitmq_vhost<| |>
+    Class['rabbitmq::service']  -> Rabbitmq_user_permissions<| |>
     $ensure_real = 'running'
     $enable_real = true
   } else {


### PR DESCRIPTION
All rabbitmq operations require that the rabbitmq service is
started.

I have explicitly added the requirement to the rabbitmq::service class.
