### PR TITLE
Test no set admin

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -35,7 +35,7 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
   # def password=()
   def admin
     match = rabbitmqctl('list_users').split(/\n/)[1..-2].collect do |line|
-      line.match(/^#{resource[:name]}\s+[(administrator|)]$/)
+      line.match(/^#{resource[:name]}\s+\[(administrator|)\]$/)
     end.compact.first
     if match
       match[1] == 'administrator'


### PR DESCRIPTION
In rabbitmq 2.6 there is no set_admin or clear_admin command and the way to check if an user is administrator change (change in regex). http://www.rabbitmq.com/man/rabbitmqctl.1.man.html

I change the code to work with 2.6 but there is not backward compatibility, I don't currently know how to get the variable $version from puppet in the library in ruby to make the change. If you can tell me how to do it I will, and also there is not tests, and I have no idea how to test puppet code, so, I will need some help too with that.

I opened an issue yesterday with this: https://github.com/puppetlabs/puppetlabs-rabbitmq/issues/9

Thanks.
