### PR TITLE
Updates to rabbitmq apt repo

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -2,19 +2,22 @@
 # requires
 #   puppetlabs-apt
 class rabbitmq::repo::apt(
-  $pin = UNSET
+  $pin = undef
 ) {
-  
+
+  Class['rabbitmq::repo::apt'] -> Package<| title == 'rabbitmq-server' |>
+
   apt::source { 'rabbitmq':
     location    => 'http://www.rabbitmq.com/debian/',
     release     => 'testing',
     repos       => 'main',
     include_src => false,
     key         => 'RabbitMQ Release Signing Key <info@rabbitmq.com>',
-    key_content => template('rabbitmq/rabbit.pub.key')
+    key_content => template('rabbitmq/rabbit.pub.key'),
+    pin         => $pin,
   }
 
-  if ! ($pin == 'UNSET') {
+  if ! ($pin == undef) {
     validate_re($pin, '\d\d\d')
     apt::pin { 'rabbitmq':
       packages => 'rabbitmq-server',


### PR DESCRIPTION
Ensures that pin is set correctly for source.

Ensures that repo is configured before package
is installed.
