### PR TITLE
Escape resource names in regexp matches

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
 
   def exists?
     out = rabbitmqctl('list_users').split(/\n/)[1..-2].detect do |line|
-      line.match(/^#{resource[:name]}(\s+\S+|)$/)
+      line.match(/^#{Regexp.escape(resource[:name])}(\s+\S+|)$/)
     end
   end
 
@@ -35,7 +35,7 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
   # def password=()
   def admin
     match = rabbitmqctl('list_users').split(/\n/)[1..-2].collect do |line|
-      line.match(/^#{resource[:name]}\s+\[(administrator)?\]/)
+      line.match(/^#{Regexp.escape(resource[:name])}\s+\[(administrator)?\]/)
     end.compact.first
     if match
       (:true if match[1].to_s == 'administrator') || :false

--- a/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl) do
 
   def exists?
     out = rabbitmqctl('list_vhosts').split(/\n/)[1..-2].detect do |line|
-      line.match(/^#{resource[:name]}$/)
+      line.match(/^#{Regexp.escape(resource[:name])}$/)
     end
   end
 


### PR DESCRIPTION
Regexp.escape resource names in regexp matches as they may contain characters that also translate to regexp

I discovered this when I used a base64 encoded string as a user name which contained a '+' character.
