### PR TITLE
Fix apt key not being a key

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -13,7 +13,7 @@ class rabbitmq::repo::apt(
     release     => 'testing',
     repos       => 'main',
     include_src => false,
-    key         => 'RabbitMQ Release Signing Key <info@rabbitmq.com>',
+    key         => '056E8E56',
     key_content => template('rabbitmq/rabbit.pub.key'),
     pin         => $pin,
   }


### PR DESCRIPTION
This prevents the key from being constantly re-added every time puppet is run due to apt not detecting that the key is already present.

I'm not sure if this is the best of doing it as now the key signature is hard coded and would need to get changed if/whenever the public key is changed.
