### PR TITLE
Let rabbitmq authenticate through LDAP

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,12 @@ class rabbitmq(
   $ssl_stomp_port             = $rabbitmq::params::ssl_stomp_port,
   $ssl_verify                 = $rabbitmq::params::ssl_verify,
   $ssl_fail_if_no_peer_cert   = $rabbitmq::params::ssl_fail_if_no_peer_cert,
+  $ldap_auth                  = $rabbitmq::params::ldap_auth,
+  $ldap_server                = $rabbitmq::params::ldap_server,
+  $ldap_user_dn_pattern       = $rabbitmq::params::ldap_user_dn_pattern,
+  $ldap_use_ssl               = $rabbitmq::params::ldap_use_ssl,
+  $ldap_port                  = $rabbitmq::params::ldap_port,
+  $ldap_log                   = $rabbitmq::params::ldap_log,
   $stomp_port                 = $rabbitmq::params::stomp_port,
   $version                    = $rabbitmq::params::version,
   $wipe_db_on_cookie_change   = $rabbitmq::params::wipe_db_on_cookie_change,
@@ -90,6 +96,12 @@ class rabbitmq(
   validate_re($ssl_management_port, '\d+')
   validate_string($ssl_stomp_port)
   validate_re($ssl_stomp_port, '\d+')
+  validate_bool($ldap_auth)
+  validate_string($ldap_server)
+  validate_string($ldap_user_dn_pattern)
+  validate_bool($ldap_use_ssl)
+  validate_re($ldap_port, '\d+')
+  validate_bool($ldap_log)
   validate_hash($environment_variables)
   validate_hash($config_variables)
 
@@ -123,6 +135,15 @@ class rabbitmq(
     }
 
     Class['::rabbitmq::service'] -> Class['::rabbitmq::install::rabbitmqadmin']
+  }
+
+  if ($ldap_auth) {
+    rabbitmq_plugin { 'rabbitmq_auth_backend_ldap':
+      ensure   => present,
+      require  => Class['rabbitmq::install'],
+      notify   => Class['rabbitmq::service'],
+      provider => 'rabbitmqplugins',
+    }
   }
 
   # Anchor this as per #8040 - this ensures that classes won't float off and

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,6 +72,12 @@ class rabbitmq::params {
   $ssl_stomp_port             = '6164'
   $ssl_verify                 = 'verify_none'
   $ssl_fail_if_no_peer_cert   = 'false'
+  $ldap_auth                  = false
+  $ldap_server                = 'ldap'
+  $ldap_user_dn_pattern       = 'cn=${username},ou=People,dc=example,dc=com'
+  $ldap_use_ssl               = false
+  $ldap_port                  = '389'
+  $ldap_log                   = false
   $stomp_port                 = '6163'
   $wipe_db_on_cookie_change   = false
   $cluster_partition_handling = 'ignore'

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -229,6 +229,30 @@ describe 'rabbitmq' do
         end
       end
 
+      describe 'configuring ldap authentication' do
+        let :params do
+          { :config_stomp         => true,
+            :ldap_auth            => true,
+            :ldap_server          => 'ldap.example.com',
+            :ldap_user_dn_pattern => 'ou=users,dc=example,dc=com',
+            :ldap_use_ssl         => false,
+            :ldap_port            => '389',
+            :ldap_log             => true
+          }
+        end
+
+        it { should contain_rabbitmq_plugin('rabbitmq_auth_backend_ldap') }
+
+        it 'should contain ldap parameters' do
+          verify_contents(subject, 'rabbitmq.config', 
+                          ['[', '  {rabbit, [', '    {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_ldap]},', '  ]}',
+                            '  {rabbitmq_auth_backend_ldap, [', '    {other_bind, anon},',
+                            '    {servers, ["ldap.example.com"]},',
+                            '    {user_dn_pattern, "ou=users,dc=example,dc=com"},', '    {use_ssl, false},',
+                            '    {port, 389},', '    {log, true}'])
+        end
+      end
+
       describe 'default_user and default_pass set' do
         let(:params) {{ :default_user => 'foo', :default_pass => 'bar' }}
         it 'should set default_user and default_pass to specified values' do

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -2,6 +2,9 @@
 % Template Path: <%= @module_name %>/templates/rabbitmq.config
 [
   {rabbit, [
+<% if @ldap_auth -%>
+    {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_ldap]},
+<% end -%>
 <% if @config_cluster -%>
     {cluster_nodes, {[<%= @_cluster_nodes.map { |n| "\'rabbit@#{n}\'" }.join(', ') %>], <%= @cluster_node_type %>}},
     {cluster_partition_handling, <%= @cluster_partition_handling %>},
@@ -30,6 +33,17 @@
     {ssl_listeners, [<%= @ssl_stomp_port %>]}
   <%- end -%>
   ]}
+<%- if @ldap_auth -%>,
+% Configure the LDAP authentication plugin
+  {rabbitmq_auth_backend_ldap, [
+    {other_bind, anon},
+    {servers, ["<%= @ldap_server %>"]},
+    {user_dn_pattern, "<%= @ldap_user_dn_pattern %>"},
+    {use_ssl, <%= @ldap_use_ssl %>},
+    {port, <%= @ldap_port %>},
+    {log, <%= @ldap_log %>}
+  ]}
+<% end -%>
 <%- end -%>
 ].
 % EOF


### PR DESCRIPTION
This Pull Request adds support for LDAP authentication in `rabbitmq::server`.

To make merging easier, this PR depends on https://github.com/puppetlabs/puppetlabs-rabbitmq/pull/33 since they both touch the same files.
