### PR TITLE
Allow to not manage the service (eg. for HA setup)

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -25,7 +25,7 @@
 #  stdlib
 # Sample Usage:
 #
-#  
+#
 #
 #
 # [Remember: No empty lines between comments and class definition]
@@ -36,6 +36,7 @@ class rabbitmq::server(
   $version = 'UNSET',
   $service_name = 'rabbitmq-server',
   $service_ensure = 'running',
+  $manage_service = true,
   $config_stomp = false,
   $stomp_port = '6163',
   $config_cluster = false,
@@ -134,8 +135,9 @@ class rabbitmq::server(
   }
 
   class { 'rabbitmq::service':
-    service_name => $service_name,
-    ensure       => $service_ensure,
+    ensure         => $service_ensure,
+    service_name   => $service_name,
+    manage_service => $manage_service
   }
 
   if $delete_guest_user {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -14,27 +14,31 @@
 # Sample Usage:
 #
 class rabbitmq::service(
-  $service_name = 'rabbitmq-server',
-  $ensure='running'
+  $ensure         = 'running',
+  $service_name   = 'rabbitmq-server',
+  $manage_service = true
 ) {
 
   validate_re($ensure, '^(running|stopped)$')
-  if $ensure == 'running' {
-    Class['rabbitmq::service'] -> Rabbitmq_user<| |>
-    Class['rabbitmq::service'] -> Rabbitmq_vhost<| |>
-    Class['rabbitmq::service'] -> Rabbitmq_user_permissions<| |>
-    $ensure_real = 'running'
-    $enable_real = true
-  } else {
-    $ensure_real = 'stopped'
-    $enable_real = false
-  }
+  validate_bool($manage_service)
+  if ($manage_service) {
+    if $ensure == 'running' {
+      Class['rabbitmq::service'] -> Rabbitmq_user<| |>
+      Class['rabbitmq::service'] -> Rabbitmq_vhost<| |>
+      Class['rabbitmq::service'] -> Rabbitmq_user_permissions<| |>
+      $ensure_real = 'running'
+      $enable_real = true
+    } else {
+      $ensure_real = 'stopped'
+      $enable_real = false
+    }
 
-  service { $service_name:
-    ensure     => $ensure_real,
-    enable     => $enable_real,
-    hasstatus  => true,
-    hasrestart => true,
+    service { $service_name:
+      ensure     => $ensure_real,
+      enable     => $enable_real,
+      hasstatus  => true,
+      hasrestart => true,
+    }
   }
 
 }

--- a/spec/classes/rabbitmq_server_spec.rb
+++ b/spec/classes/rabbitmq_server_spec.rb
@@ -4,7 +4,7 @@ describe 'rabbitmq::server' do
 
   let :facts do
     # Needed for statement in rabbitmq.config template.
-    { :puppetversion => '2.7.14' } 
+    { :puppetversion => '2.7.14' }
   end
 
   describe 'package with default params' do
@@ -14,7 +14,7 @@ describe 'rabbitmq::server' do
   end
 
   describe 'package with specified ensure' do
-  	let :params do 
+  	let :params do
   	  { :version => "2.3.0" }
   	end
   	it { should contain_package('rabbitmq-server').with(
@@ -27,7 +27,7 @@ describe 'rabbitmq::server' do
   end
 
   describe 'deleting guest user' do
-  	let :params do 
+  	let :params do
   	  { :delete_guest_user => true }
   	end
   	it { should contain_rabbitmq_user('guest').with(
@@ -38,20 +38,23 @@ describe 'rabbitmq::server' do
 
   describe 'default service include' do
   	it { should contain_class('rabbitmq::service').with(
-  	  'service_name' => 'rabbitmq-server',
-  	  'ensure'       => 'running'
+  	  'ensure'         => 'running',
+  	  'service_name'   => 'rabbitmq-server',
+      'manage_service' => 'true'
   	) }
   end
 
   describe 'overriding service paramters' do
   	let :params do
-  	  { 'service_name' => 'custom-rabbitmq-server',
-        'service_ensure' => 'stopped'
+  	  { 'service_name'   => 'custom-rabbitmq-server',
+        'service_ensure' => 'stopped',
+        'manage_service' => false
       }
   	end
   	it { should contain_class('rabbitmq::service').with(
-  	  'service_name' => 'custom-rabbitmq-server',
-  	  'ensure'       => 'stopped'
+  	  'ensure'         => 'stopped',
+  	  'service_name'   => 'custom-rabbitmq-server',
+      'manage_service' => false
   	) }
   end
 
@@ -68,7 +71,7 @@ describe 'rabbitmq::server' do
   describe 'not configuring stomp by default' do
   	it 'should not specify stomp parameters in rabbitmq.config' do
       verify_contents(subject, 'rabbitmq.config',
-        ['[','].'])  	
+        ['[','].'])
   	end
   end
 
@@ -80,7 +83,7 @@ describe 'rabbitmq::server' do
   	end
   	it 'should specify stomp port in rabbitmq.config' do
       verify_contents(subject, 'rabbitmq.config',
-        ['[','{rabbitmq_stomp, [{tcp_listeners, [5679]} ]}','].'])  	
+        ['[','{rabbitmq_stomp, [{tcp_listeners, [5679]} ]}','].'])
   	end
 
   end
@@ -93,7 +96,7 @@ describe 'rabbitmq::server' do
   	end
   	it 'should specify cluster nodes in rabbitmq.config' do
       verify_contents(subject, 'rabbitmq.config',
-        ['[',"{rabbit, [{cluster_nodes, ['rabbit@hare-1', 'rabbit@hare-2']}]}", '].'])  	
+        ['[',"{rabbit, [{cluster_nodes, ['rabbit@hare-1', 'rabbit@hare-2']}]}", '].'])
   	end
   	it 'should have the default erlang cookie' do
       verify_contents(subject, 'erlang_cookie',

--- a/spec/classes/rabbitmq_service_spec.rb
+++ b/spec/classes/rabbitmq_service_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'rabbitmq::service' do
+
+  describe 'service with default params' do
+    it { should contain_service('rabbitmq-server').with(
+      'ensure'     => 'running',
+      'enable'     => 'true',
+      'hasstatus'  => 'true',
+      'hasrestart' => 'true'
+    )}
+  end
+
+  describe 'service with ensure stopped' do
+    let :params do
+      { :ensure => 'stopped' }
+    end
+
+    it { should contain_service('rabbitmq-server').with(
+      'ensure'    => 'stopped',
+      'enable'    => false
+    ) }
+  end
+
+  describe 'service with ensure neither running neither stopped' do
+    let :params do
+      { :ensure => 'foo' }
+    end
+
+    it 'should raise an error' do
+      expect {
+        should contain_service('rabbitmq-server').with(
+          'ensure' => 'stopped' )
+      }.to raise_error(Puppet::Error, /validate_re\(\): "foo" does not match "\^\(running\|stopped\)\$"/)
+    end
+  end
+
+  describe 'service with manage_service equal to false' do
+    let :params do
+      { :manage_service => false }
+    end
+
+    it { should_not contain_service('rabbitmq-server') }
+  end
+
+end


### PR DESCRIPTION
This changeset allows to ensure the service is not managed by the OS and is neither started nor stopped by Puppet in case it would be managed by pacemaker for example.
