### PR TITLE
Fixes RPM GPG-key import exec at every puppet run

### DIFF
--- a/manifests/repo/rhel.pp
+++ b/manifests/repo/rhel.pp
@@ -4,7 +4,8 @@ class rabbitmq::repo::rhel (
     $relversion = "1",
 ) { 
     exec { "rpm --import ${key}":
-        path => ["/bin","/usr/bin","/sbin","/usr/sbin"],
+        path    => ["/bin","/usr/bin","/sbin","/usr/sbin"],
+        onlyif  => 'test `rpm -qa | grep gpg-pubkey-056e8e56-468e43f2 | wc -l` -eq 0';
     }
 
     package { "rabbitmq-server":


### PR DESCRIPTION
Avoids that RPM GPG-Key import is executed at every Puppet run.

Rabbitmq::Repo::Rhel/Exec[rpm --import http://www.rabbitmq.com/rabbitmq-signing-key-public.asc]/returns: executed successfully
