### PR TITLE
Remove puppetversion from rabbitmq.config template

### DIFF
--- a/templates/rabbitmq.config
+++ b/templates/rabbitmq.config
@@ -1,4 +1,4 @@
-% This file managed by Puppet <%= puppetversion %>
+% This file managed by Puppet
 % Template Path: <%= module_name %>/templates/rabbitmq.config
 [
 <% if config_cluster -%>


### PR DESCRIPTION
Hey,
- There is no reason puppet version should be included in the template
- It causes unnecessary configuration reload during puppet version change
