### PR TITLE
Using the default-port in Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Sets up an apt repo source for the vendor rabbitmq packages
 Class for installing rabbitmq-server:
 
     class { 'rabbitmq::server':
-      port              => '5673',
+      port              => '5672',
       delete_guest_user => true,
     }
 


### PR DESCRIPTION
Why you change the port without explicitly mention it in the docs?
