### PR TITLE
add support for setting arbitrary user tags on a rabbitmq_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ query all current users: `$ puppet resource rabbitmq_user`
     rabbitmq_user { 'dan':
       admin    => true,
       password => 'bar',
+      user_tags=> 'monitor',
       provider => 'rabbitmqctl',
     }
 

--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -6,7 +6,7 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
 
   def self.instances
     rabbitmqctl('list_users').split(/\n/)[1..-2].collect do |line|
-      if line =~ /^(\S+)(\s+\S+|)$/
+      if line =~ /^(\S+)(\s+\[.*\]|)$/
         new(:name => $1)
       else
         raise Puppet::Error, "Cannot parse invalid user line: #{line}"
@@ -16,8 +16,8 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
 
   def create
     rabbitmqctl('add_user', resource[:name], resource[:password])
-    if resource[:admin] == :true
-      make_user_admin()
+    if resource[:admin] == :true or not user_tags_get().empty?
+      set_user_tags()
     end
   end
 
@@ -27,7 +27,7 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
 
   def exists?
     out = rabbitmqctl('list_users').split(/\n/)[1..-2].detect do |line|
-      line.match(/^#{Regexp.escape(resource[:name])}(\s+\S+|)$/)
+      line.match(/^#{Regexp.escape(resource[:name])}(\s+\[.*\]|)$/)
     end
   end
 
@@ -35,25 +35,69 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
   # def password=()
   def admin
     match = rabbitmqctl('list_users').split(/\n/)[1..-2].collect do |line|
-      line.match(/^#{Regexp.escape(resource[:name])}\s+\[(administrator)?\]/)
+      line.match(/^#{Regexp.escape(resource[:name])}\s+\[(.*)\]/)
     end.compact.first
     if match
-      (:true if match[1].to_s == 'administrator') || :false
+      if match[1].to_s.split(/,\s*/).index('administrator')
+        unless resource[:admin]==:false and user_tags_get().index("administrator")
+          :true 
+        else
+          # admin and user_tags can conflict if admin is unset but the user 
+          # tags include administrator.  This confuses puppet.  So don't report
+          # the administrator tag in this case even though present
+          :false
+        end
+      else 
+        # really not found
+        :false
+      end
     else
       raise Puppet::Error, "Could not match line '#{resource[:name]} (true|false)' from list_users (perhaps you are running on an older version of rabbitmq that does not support admin users?)"
     end
   end
 
   def admin=(state)
-    if state == :true
-      make_user_admin()
+    set_user_tags()
+  end
+
+  def user_tags_get
+    # there is probaby a better or more appropriate place to put this,
+    # but my knowledge of ruby and puppet isn't good enough to take risks
+    tags = resource[:user_tags]
+    tags = [tags] unless tags.is_a?(Array) # array-ify
+    tags
+  end
+
+  def user_tags
+    match = rabbitmqctl('list_users').split(/\n/)[1..-2].collect do |line|
+      line.match(/^#{Regexp.escape(resource[:name])}\s+\[(.*)\]/)
+    end.compact.first
+    if match
+      tags=match[1].to_s.split(/,\s*/)
+      unless resource[:admin]==:true and !user_tags_get().index("administrator")
+        tags
+      else
+        # admin and user_tags can conflict if admin is set but the user tags 
+        # don't include administrator.  This confuses puppet.  So don't report
+        # the administrator tag in this case even though present
+        tags.delete("administrator")
+        tags
+      end
     else
-      rabbitmqctl('set_user_tags', resource[:name])
+      raise Puppet::Error, "Could not match line '#{resource[:name]} (true|false)' from list_users (perhaps you are running on an older version of rabbitmq that does not support user tags?)"
     end
   end
 
-  def make_user_admin
-    rabbitmqctl('set_user_tags', resource[:name], 'administrator')
+  def user_tags=(state)
+    set_user_tags()
+  end
+
+  def set_user_tags
+    tags=user_tags_get()
+    if resource[:admin]==:true and !tags.index("administrator")
+      tags.push("administrator") 
+    end
+    rabbitmqctl('set_user_tags', resource[:name], tags)
   end
 
 end

--- a/lib/puppet/type/rabbitmq_user.rb
+++ b/lib/puppet/type/rabbitmq_user.rb
@@ -21,6 +21,12 @@ Puppet::Type.newtype(:rabbitmq_user) do
     desc 'User password to be set *on creation*'
   end
 
+  newproperty(:user_tags, :array_matching => :all) do
+    desc 'Tags to be applied to the user'
+    newvalues(/^\S+$/)
+    defaultto []
+  end
+
   newproperty(:admin) do
     desc 'rather or not user should be an admin'
     newvalues(/true|false/)


### PR DESCRIPTION
This commit adds support for setting arbitrary user tags on a rabbitmq_user.

Note that this creates potential conflicts with the admin property.  It tries to be smart about such conflicts.  But I would say that ideally, admin and user_tags should not be defined on the same object.

This is my first pull request.  Please let me know if I'm doing anything wrong.  Thanks!
