### PR TITLE
Add support for Mirrored Queues within a Rabbit Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,20 @@ parameters `config_cluster` and `cluster_disk_nodes`, e.g.:
 Currently all cluster nodes are registered as disk nodes (not ram).
 
 **NOTE:** You still need to use `x-ha-policy: all` in your client 
-applications for any particular queue to take advantage of H/A, this module 
-merely clusters RabbitMQ instances.
+applications for any particular queue to take advantage of H/A.
+
+You should set the 'config_mirrored_queues' parameter if you plan
+on using RabbitMQ Mirrored Queues within your cluster:
+
+    class { 'rabbitmq::server':
+      config_cluster => true,
+      config_mirrored_queues => true,
+      cluster_disk_nodes => ['rabbit1', 'rabbit2'],
+    }
+
+By setting mirrored queues to true, the rabbitmq-server 2.8.7-1 package
+will be used.  This package version addressed several mirrored queues
+bugs and is the most widely tested.
 
 ## Native Types
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,17 @@
+# Class: rabbitmq::params
+#
+#   The RabbitMQ Module configuration settings.
+#
+class rabbitmq::params {
+
+  case $::osfamily {
+    'Debian': {
+      if $config_mirrored_queues {
+        $mirrored_queues_pkg_name = 'rabbitmq-server_2.8.7-1_all.deb',
+        $mirrored_queues_pkg_url  = 'http://www.rabbitmq.com/releases/rabbitmq-server/v2.8.7/',
+        $erlang_pkg_name          = 'erlang-nox'
+      }
+    }
+  }
+
+}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -14,6 +14,7 @@
 #  [*config*] - contents of config file
 #  [*env_config*] - contents of env-config file
 #  [*config_cluster*] - whether to configure a RabbitMQ cluster
+#  [*config_mirrored_queues*] - whether to configure RabbitMQ mirrored queues within a Rabbit Cluster.
 #  [*cluster_disk_nodes*] - which nodes to cluster with (including the current one)
 #  [*erlang_cookie*] - erlang cookie, must be the same for all nodes in a cluster
 #  [*wipe_db_on_cookie_change*] - whether to wipe the RabbitMQ data if the specified
@@ -39,6 +40,7 @@ class rabbitmq::server(
   $config_stomp = false,
   $stomp_port = '6163',
   $config_cluster = false,
+  $config_mirrored_queues = false,
   $cluster_disk_nodes = [],
   $node_ip_address = 'UNSET',
   $config='UNSET',
@@ -70,11 +72,6 @@ class rabbitmq::server(
   }
 
   $plugin_dir = "/usr/lib/rabbitmq/lib/rabbitmq_server-${version_real}/plugins"
-
-  package { $package_name:
-    ensure => $pkg_ensure_real,
-    notify => Class['rabbitmq::service'],
-  }
 
   file { '/etc/rabbitmq':
     ensure  => directory,
@@ -120,6 +117,35 @@ class rabbitmq::server(
         require => Package[$package_name],
         unless  => "/bin/grep -qx ${erlang_cookie} /var/lib/rabbitmq/.erlang.cookie"
       }
+    }
+    if $config_mirrored_queues {
+
+      $mirrored_queues_pkg_name = $rabbitmq::params::mirrored_queues_pkg_name
+      $mirrored_queues_pkg_url  = $rabbitmq::params::mirrored_queues_pkg_url
+      $erlang_pkg_name          = $rabbitmq::params::erlang_pkg_name
+
+      exec { 'download-rabbit':
+        command => "wget -O /tmp/${mirrored_queues_pkg_name} ${mirrored_queues_pkg_url}${mirrored_queues_pkg_name} --no-check-certificate",
+        path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+        creates => "/tmp/${mirrored_queues_pkg_name}",
+      }
+
+      package { $erlang_pkg_name:
+        ensure   => $pkg_ensure_real,
+      }
+
+      package { $package_name:
+        ensure   => $pkg_ensure_real,
+        provider => 'dpkg',
+        require  => [Exec['download-rabbit'],Package[$erlang_pkg_name]],
+        source   => "/tmp/${mirrored_queues_pkg_name}",
+        notify   => Class['rabbitmq::service'],
+      }
+    }
+  } else {
+    package { $package_name:
+      ensure => $pkg_ensure_real,
+      notify => Class['rabbitmq::service'],
     }
   }
 

--- a/spec/classes/rabbitmq_server_spec.rb
+++ b/spec/classes/rabbitmq_server_spec.rb
@@ -113,4 +113,13 @@ describe 'rabbitmq::server' do
     end
   end
 
+  describe 'configure mirrored queues in cluster mode' do
+        let :params do
+          { :config_cluster => true,
+            :config_mirrored_queues => true
+          }
+        end
+    it { should contain_package('rabbitmq-server').with('ensure' => 'present') }
+  end
+
 end


### PR DESCRIPTION
Prior to this patch, mirrored queues would not behave properly.
Rabbit mirrored queues had several bugs that were fixed in 2.8.7:
  https://www.rabbitmq.com/release-notes/README-2.8.7.txt

rabbitmq::repo::apt can not be used since 2.8.7 is not the latest version:
  http://www.rabbitmq.com/install-debian.html

The patch adds a new paramater [_config_mirrored_queues_] that will install
the rabbitmq-server 2.8.7 package and required dependencies when
config_cluster is true.
