### PR TITLE
Prepare a 3.0 release.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,30 @@
+* 2013-07-18 3.0.0
+Summary:
+This release heavily refactors the RabbitMQ and changes functionality in
+several key ways.  Please pay attention to the new README.md file for
+details of how to interact with the class now.  Puppet 3 and RHEL are
+now fully supported.  The default version of RabbitMQ has changed to
+a 3.x release.
+
+Bugfixes:
+- Improve travis testing options.
+- Stop reimporting the GPG key on every run on RHEL and Debian.
+- Fix documentation to make it clear you don't have to set provider => each time.
+- Reference the standard rabbitmq port in the documentation instead of a custom port.
+- Fixes to the README formatting.
+
+Features:
+- Refactor the module to fix RHEL support.  All interaction with the module
+is now done through the main rabbitmq class.
+- Add support for mirrored queues (Only on Debian family distributions currently)
+- Add rabbitmq_exchange provider (using rabbitmqadmin)
+- Add new `rabbitmq` class parameters:
+  -  `manage_service`: Boolean to choose if Puppet should manage the service. (For pacemaker/HA setups)
+
+Incompatible Changes:
+- Rabbitmq::server has been removed and is now rabbitmq::config.  You should
+not use this class directly, only via the main rabbitmq class.
+
 * 2013-04-11 2.1.0
 - remove puppetversion from rabbitmq.config template
 - add cluster support

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-rabbitmq'
-version '2.1.0'
+version '3.0.0-rc.1'
 source 'git://github.com/puppetlabs/puppetlabs-rabbitmq.git'
 author 'puppetlabs'
 license 'Apache'


### PR DESCRIPTION
Hi everyone,

If you're a rabbitmq module user I recommend doing some testing with the latest version here in git. I'm going to cut an RC and mail it out to the list tomorrow but I would appreciate some eyes as we've merged in a bunch of stuff.

I'm still not happy that we have duplicate package resources on RHEL systems (package { 'rabbitmq-server': } is in repo/rhel.pp and server.pp and I want to see this resolved before we release an actual 3.0.  Hopefully one of you kind readers will magically make this happen, if not the 3.0 release will have to wait until I can get it into a sprint cycle to work on.
