### PR TITLE
add missing Exec resource path attribute

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -180,6 +180,7 @@ class rabbitmq::server(
 
   exec { 'Download rabbitmqadmin':
     command => "curl http://${default_user}:${default_pass}@localhost:5${port}/cli/rabbitmqadmin -o /var/tmp/rabbitmqadmin",
+    path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
     creates => '/var/tmp/rabbitmqadmin',
     require => [
       Class['rabbitmq::service'],


### PR DESCRIPTION
path attribute must be specified since curl commands is not fully qualified
