### PR TITLE
add rabbitmq service refresh after plugin resource change

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -176,6 +176,7 @@ class rabbitmq::server(
 
   rabbitmq_plugin { 'rabbitmq_management':
     ensure => present,
+    notify => Class['rabbitmq::service'],
   }
 
   exec { 'Download rabbitmqadmin':


### PR DESCRIPTION
Enabling or disabling plugins has no effect on a running RabbitMQ server; thus, it needs to be restarted for enabled plugins to be activated.
