### PR TITLE
Fix specs to remove the specific check for ArgumentError.  This started

### DIFF
--- a/spec/unit/puppet/type/rabbitmq_exchange_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_exchange_spec.rb
@@ -34,7 +34,7 @@ describe Puppet::Type.type(:rabbitmq_exchange) do
   it 'should require a type' do
     expect {
       Puppet::Type.type(:rabbitmq_exchange).new(:name => 'foo@bar')
-    }.to raise_error(ArgumentError, /.*must set type when creating exchange.*/)
+    }.to raise_error(/.*must set type when creating exchange.*/)
   end
   it 'should not require a type when destroying' do
     expect {

--- a/spec/unit/puppet/type/rabbitmq_user_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_user_spec.rb
@@ -16,7 +16,7 @@ describe Puppet::Type.type(:rabbitmq_user) do
   it 'should require a password' do
     expect {
       Puppet::Type.type(:rabbitmq_user).new(:name => 'foo')
-    }.to raise_error(ArgumentError, /must set password/)
+    }.to raise_error(/must set password/)
   end
   it 'should require a name' do
     expect {


### PR DESCRIPTION
failing on Puppet 3.2.
