### PR TITLE
Calling rabbitmq::server fails

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -176,6 +176,7 @@ class rabbitmq::server(
 
   rabbitmq_plugin { 'rabbitmq_management':
     ensure => present,
+    provider => 'rabbitmqctl',
     notify => Class['rabbitmq::service'],
   }
 


### PR DESCRIPTION
Provider was not set for rabbitmq_plugin, which is required. 
