### PR TITLE
Fixed bug with rabbitmq_plugins failing to locate correct provider

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -175,8 +175,9 @@ class rabbitmq::server(
   }
 
   rabbitmq_plugin { 'rabbitmq_management':
-    ensure => present,
-    notify => Class['rabbitmq::service'],
+    ensure   => present,
+    notify   => Class['rabbitmq::service'],
+    provider => 'rabbitmqplugins',
   }
 
   exec { 'Download rabbitmqadmin':


### PR DESCRIPTION
Current rabbitmq_plugin requires to receive proper provider.
By not providing it, it fails to enable the plugin by throwing a notice:

```
Could not evaluate: This is just the default provider for rabbitmq_plugin, all it does is fail
```

This patch fixes it by adding the provider to `rabbitmq_management` plugin.
