### PR TITLE
Fix Web UI port number

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -180,7 +180,7 @@ class rabbitmq::server(
   }
 
   exec { 'Download rabbitmqadmin':
-    command => "curl http://${default_user}:${default_pass}@localhost:5${port}/cli/rabbitmqadmin -o /var/tmp/rabbitmqadmin",
+    command => "curl http://${default_user}:${default_pass}@localhost:1${port}/cli/rabbitmqadmin -o /var/tmp/rabbitmqadmin",
     path    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin',
     creates => '/var/tmp/rabbitmqadmin',
     require => [


### PR DESCRIPTION
RabbitMQ uses 1XXXX for management Web UI, not 5XXXX which returns a 301 HTTP Status code, making download to fail.
