### PR TITLE
config file is now at /etc/rabbitmq/rabbitmq.config

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,7 @@ class rabbitmq::params {
   $config                   = 'rabbitmq/rabbitmq.config.erb'
   $config_cluster           = false
   $config_mirrored_queues   = false
-  $config_path              = '/etc/rabbitmq/rabbitmq.conf'
+  $config_path              = '/etc/rabbitmq/rabbitmq.config'
   $config_stomp             = false
   $delete_guest_user        = false
   $env_config               = 'rabbitmq/rabbitmq-env.conf.erb'


### PR DESCRIPTION
Not sure why the RabbitMQ people decided to change the name of the config file for rabbitmq-server, but there it is.
