### PR TITLE
Replace confines with autorequire.

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -10,14 +10,6 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
   end
 
   defaultfor :feature => :posix
-  confine :false =>
-  begin
-    rabbitmqctl('list_users', '-q').find {|line|
-      line =~ /unable to connect to node/
-    }
-  rescue Puppet::Error => error
-    true
-  end
 
   def self.instances
     rabbitmqctl('list_users').split(/\n/)[1..-2].collect do |line|

--- a/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
@@ -9,14 +9,6 @@ Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl) do
   end
 
   defaultfor :feature=> :posix
-  confine :false =>
-  begin
-    rabbitmqctl('list_users', '-q').find {|line|
-      line =~ /unable to connect to node/
-    }
-  rescue Puppet::Error => error
-    true
-  end
 
   # cache users permissions
   def self.users(name, vhost)

--- a/lib/puppet/type/rabbitmq_user.rb
+++ b/lib/puppet/type/rabbitmq_user.rb
@@ -11,6 +11,8 @@ Puppet::Type.newtype(:rabbitmq_user) do
     end
   end
 
+  autorequire(:service) { 'rabbitmq-server' }
+
   newparam(:name, :namevar => true) do
     desc 'Name of user'
     newvalues(/^\S+$/)

--- a/lib/puppet/type/rabbitmq_user_permissions.rb
+++ b/lib/puppet/type/rabbitmq_user_permissions.rb
@@ -11,8 +11,10 @@ Puppet::Type.newtype(:rabbitmq_user_permissions) do
     end
   end
 
+  autorequire(:service) { 'rabbitmq-server' }
+
   newparam(:name, :namevar => true) do
-    'combination of user@vhost to grant privileges to'
+    desc 'combination of user@vhost to grant privileges to'
     newvalues(/^\S+@\S+$/)
   end
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,7 +113,5 @@ class rabbitmq(
   # Make sure the various providers have their requirements in place.
   Class['::rabbitmq::install'] -> Rabbitmq_plugin<| |>
   Class['::rabbitmq::install::rabbitmqadmin'] -> Rabbitmq_exchange<| |>
-  Class['::rabbitmq::service'] -> Rabbitmq_user<| |>
-  Class['::rabbitmq::service'] -> Rabbitmq_user_permissions<| |>
 
 }


### PR DESCRIPTION
This replaces the confines block with an autorequire on the service. I
avoided doing this originally because it requires a single resource
rather than a class, but the confines block fails on first runs.
