### PR TITLE
Disable the admin interface when service is unmanaged.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,7 +106,7 @@ class rabbitmq(
       { }
   }
 
-  if $admin_enable {
+  if $admin_enable and $service_manage {
     include '::rabbitmq::install::rabbitmqadmin'
 
     rabbitmq_plugin { 'rabbitmq_management':

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -33,12 +33,21 @@ describe 'rabbitmq' do
 
     context 'with admin_enable set to true' do
       let(:params) {{ :admin_enable => true }}
-      it 'we enable the admin interface by default' do
-        should contain_class('rabbitmq::install::rabbitmqadmin')
-        should contain_rabbitmq_plugin('rabbitmq_management').with(
-          'require' => 'Class[Rabbitmq::Install]',
-          'notify'  => 'Class[Rabbitmq::Service]'
-        )
+      context 'with service_manage set to true' do
+        it 'we enable the admin interface by default' do
+          should contain_class('rabbitmq::install::rabbitmqadmin')
+          should contain_rabbitmq_plugin('rabbitmq_management').with(
+            'require' => 'Class[Rabbitmq::Install]',
+            'notify'  => 'Class[Rabbitmq::Service]'
+          )
+        end
+      end
+      context 'with service_manage set to false' do
+        let(:params) {{ :admin_enable => true, :service_manage => false }}
+        it 'should do nothing' do
+          should_not contain_class('rabbitmq::install::rabbitmqadmin')
+          should_not contain_rabbitmq_plugin('rabbitmq_management')
+        end
       end
     end
 

--- a/spec/system/rabbitmqadmin_spec.rb
+++ b/spec/system/rabbitmqadmin_spec.rb
@@ -5,12 +5,32 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
     node.facts['osfamily']
   }
 
-  puppet_apply(%{
-    class { 'rabbitmq': }
-  })
+  describe 'does nothing if service is unmanaged' do
+    puppet_apply(%{
+      class { 'rabbitmq':
+        admin_enable   => true,
+        manage_service => false,
+      }
+    })
 
-  describe file('/var/lib/rabbitmq/rabbitmqadmin') do
-    it { should be_file }
+    describe file('/var/lib/rabbitmq/rabbitmqadmin') do
+      it { should_not be_file }
+    end
+  end
+
+  describe 'downloads the cli tools' do
+
+    puppet_apply(%{
+      class { 'rabbitmq':
+        admin_enable   => true,
+        manage_service => true,
+      }
+    })
+
+    describe file('/var/lib/rabbitmq/rabbitmqadmin') do
+      it { should be_file }
+    end
+
   end
 
 end


### PR DESCRIPTION
I'm not 100% sure of the best way to handle this but we cannot
be sure the service is running if we're not managing the service
so err on the side of caution and disable this functionality
compeletely in those cases to stop failures.
