### PR TITLE
Drop 3.1 and 3.0:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ rvm:
 env:
   matrix:
     - PUPPET_GEM_VERSION="~> 2.7.0"
-    - PUPPET_GEM_VERSION="~> 3.0.0"
-    - PUPPET_GEM_VERSION="~> 3.1.0"
     - PUPPET_GEM_VERSION="~> 3.2.0"
   global:
     - PUBLISHER_LOGIN=puppetlabs
@@ -30,11 +28,5 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 2.7.0"
     - rvm: 2.0.0
       env: PUPPET_GEM_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.0.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 3.2.0"
 notifications:
   email: false


### PR DESCRIPTION
Remove 3.0 and 3.1 support, fix excludes so ruby 1.8 tests against 3.2.
