### PR TITLE
correct read and write parameters order on set_permissions and list_perm...

### DIFF
--- a/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
@@ -96,8 +96,8 @@ Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl) do
       resource[:read_permission]      ||= read_permission
       resource[:write_permission]     ||= write_permission
       rabbitmqctl('set_permissions', '-p', should_vhost, should_user,
-        resource[:configure_permission], resource[:read_permission],
-        resource[:write_permission]
+        resource[:configure_permission], resource[:write_permission],
+        resource[:read_permission]
       )
     end
   end


### PR DESCRIPTION
...issions, read-write perms were in bad order
According to rabbitmqctl manual:
set_permissions [-p vhostpath] {user} {conf} {write} {read}

```
vhostpath

    The name of the virtual host to which to grant the user access, defaulting to /.
user

    The name of the user to grant access to the specified virtual host.
conf

    A regular expression matching resource names for which the user is granted configure permissions.
write

    A regular expression matching resource names for which the user is granted write permissions.
read
```
