### PR TITLE
make use of the user and password parameters

### DIFF
--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -46,14 +46,14 @@ Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin) do
   def create
     vhost_opt = should_vhost ? "--vhost=#{should_vhost}" : ''
     name = resource[:name].split('@')[0]
-    rabbitmqadmin('declare', 'exchange', vhost_opt, "name=#{name}", "type=#{resource[:type]}")
+    rabbitmqadmin('declare', 'exchange', vhost_opt, "--user=#{resource[:user]}", "--password=#{resource[:password]}", "name=#{name}", "type=#{resource[:type]}")
     @property_hash[:ensure] = :present
   end
 
   def destroy
     vhost_opt = should_vhost ? "--vhost=#{should_vhost}" : ''
     name = resource[:name].split('@')[0]
-    rabbitmqadmin('delete', 'exchange', vhost_opt, "name=#{name}")
+    rabbitmqadmin('delete', 'exchange', vhost_opt, "--user=#{resource[:user]}", "--password=#{resource[:password]}", "name=#{name}")
     @property_hash[:ensure] = :absent
   end
 

--- a/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
@@ -33,12 +33,30 @@ EOT
   end
 
   it 'should call rabbitmqadmin to create' do
-    @provider.expects(:rabbitmqadmin).with('declare', 'exchange', '--vhost=/', 'name=amq.direct', 'type=topic')
+    @provider.expects(:rabbitmqadmin).with('declare', 'exchange', '--vhost=/', '--user=guest', '--password=guest', 'name=amq.direct', 'type=topic')
     @provider.create
   end
 
   it 'should call rabbitmqadmin to destroy' do
-    @provider.expects(:rabbitmqadmin).with('delete', 'exchange', '--vhost=/', 'name=amq.direct')
+    @provider.expects(:rabbitmqadmin).with('delete', 'exchange', '--vhost=/', '--user=guest', '--password=guest', 'name=amq.direct')
     @provider.destroy
+  end
+
+  context 'specifying credentials' do
+    before :each do
+      @resource = Puppet::Type::Rabbitmq_exchange.new(
+        {:name => 'amq.direct@/',
+        :type => :topic,
+        :user => 'colin',
+        :password => 'secret',
+        }
+      )
+      @provider = provider_class.new(@resource)
+    end
+
+    it 'should call rabbitmqadmin to create' do
+      @provider.expects(:rabbitmqadmin).with('declare', 'exchange', '--vhost=/', '--user=colin', '--password=secret', 'name=amq.direct', 'type=topic')
+      @provider.create
+    end
   end
 end


### PR DESCRIPTION
Prior to this patch the exchange creation will fall back to guest/guest, who
may not be an an admin user.

The type already takes the credentials, all we do here is pass them on.
