### PR TITLE
Remove garethr/erlang dependency

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -10,5 +10,4 @@ project_page 'http://github.com/puppetlabs/puppetlabs-rabbitmq'
 ## Add dependencies, if any:
 dependency 'puppetlabs/stdlib', '>= 2.0.0'
 dependency 'puppetlabs/apt', '>= 1.0.0'
-dependency 'garethr/erlang', '>= 0.1.0'
 dependency 'nanliu/staging', '>= 0.3.1'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 4. [Usage - Configuration options and additional functionality](#usage)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 5. [Limitations - OS compatibility, etc.](#limitations)
+   * [RedHat module dependencies](#redhat-module-dependecies)
 6. [Development - Guide for contributing to the module](#development)
 
 ##Overview
@@ -314,6 +315,19 @@ The module has been tested on:
 * Ubuntu 12.04
 
 Testing on other platforms has been light and cannot be guaranteed.
+
+### RedHat module dependencies
+To have a suitable erlang version installed on RedHat systems,
+you have to install another puppet module from http://forge.puppetlabs.com/garethr/erlang with:
+
+	puppet module install garethr-erlang
+
+This module handles the packages for erlang.
+To use the module, add the following snippet to your site.pp or an appropriate profile class:
+
+	include 'erlang'
+	class { 'erlang': epel_enable => true}
+	Class['erlang'] -> Class['rabbitmq']
 
 ##Development
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,6 @@ class rabbitmq(
   $env_config                 = $rabbitmq::params::env_config,
   $env_config_path            = $rabbitmq::params::env_config_path,
   $erlang_cookie              = $rabbitmq::params::erlang_cookie,
-  $erlang_manage              = $rabbitmq::params::erlang_manage,
   $manage_service             = $rabbitmq::params::manage_service,
   $management_port            = $rabbitmq::params::management_port,
   $node_ip_address            = $rabbitmq::params::node_ip_address,
@@ -54,7 +53,6 @@ class rabbitmq(
 ) inherits rabbitmq::params {
 
   validate_bool($admin_enable)
-  validate_bool($erlang_manage)
   # Validate install parameters.
   validate_re($package_apt_pin, '^(|\d+)$')
   validate_string($package_ensure)
@@ -106,11 +104,6 @@ class rabbitmq(
   validate_hash($environment_variables)
   validate_hash($config_variables)
   validate_hash($config_kernel_variables)
-
-  if $erlang_manage {
-    include '::erlang'
-    Class['::erlang'] -> Class['::rabbitmq::install']
-  }
 
   include '::rabbitmq::install'
   include '::rabbitmq::config'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,7 +39,6 @@ class rabbitmq::params {
 
   #install
   $admin_enable               = true
-  $erlang_manage              = false
   $management_port            = '15672'
   $package_apt_pin            = ''
   $package_gpg_key            = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc'

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -76,21 +76,6 @@ describe 'rabbitmq' do
         end
       end
 
-      context 'with erlang_manage set to true' do
-        let(:params) {{ :erlang_manage => true }}
-        it 'includes erlang' do
-          should contain_class('erlang')
-        end
-      end
-
-      context 'with erlang_manage set to false' do
-        let(:params) {{ :erlang_manage => false }}
-        it 'doesnt include erlang' do
-          should_not contain_class('erlang')
-        end
-      end
-
-
       context 'deprecated parameters' do
         describe 'cluster_disk_nodes' do
           let(:params) {{ :cluster_disk_nodes => ['node1', 'node2'] }}

--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -22,11 +22,11 @@ RSpec.configure do |c|
     # We need EPEL for erlang.
     if node.facts['osfamily'] == 'RedHat'
       shell('rpm -i http://mirrors.rit.edu/epel/6/i386/epel-release-6-8.noarch.rpm')
+      shell('yum -y install erlang')
     end
 
     # Install modules and dependencies
     puppet_module_install(:source => proj_root, :module_name => 'rabbitmq')
-    shell('puppet module install garethr-erlang')
     shell('puppet module install puppetlabs-stdlib')
     shell('puppet module install puppetlabs-apt')
     shell('puppet module install nanliu-staging')

--- a/spec/system/class_spec.rb
+++ b/spec/system/class_spec.rb
@@ -3,9 +3,7 @@ require 'spec_helper_system'
 describe "rabbitmq class:" do
   context 'should run successfully' do
     pp="
-      class { 'erlang': epel_enable => true}
       class { 'rabbitmq': }
-      Class['erlang'] -> Class['rabbitmq']
     "
 
     context puppet_apply(pp) do

--- a/spec/system/clustering_spec.rb
+++ b/spec/system/clustering_spec.rb
@@ -3,14 +3,12 @@ require 'spec_helper_system'
 describe "rabbitmq class:" do
   context 'should run successfully' do
     pp="
-      class { 'erlang': epel_enable => true}
       class { 'rabbitmq':
         config_cluster           => true,
         cluster_nodes            => ['rabbit1', 'rabbit2'],
         cluster_node_type        => 'ram',
         wipe_db_on_cookie_change => true,
       }
-      Class['erlang'] -> Class['rabbitmq']
     "
 
     context puppet_apply(pp) do

--- a/tests/erlang_deps.pp
+++ b/tests/erlang_deps.pp
@@ -1,0 +1,5 @@
+# install first the garethr-erlang module. See README.md
+include 'erlang'
+
+class { 'erlang': epel_enable => true}
+Class['erlang'] -> Class['rabbitmq']


### PR DESCRIPTION
Most of the distributions handle the erlang installation automatically.
The garethr/erlang dependency is not needed there and can be added
manually in case it's needed.

On Debian/Ubuntu for example, the current dependency tree (puppetlabs/rabbitmq->garethr/erlang->stahnma/epel) introduces on theses systems a puppet modul for epel (see http://fedoraproject.org/wiki/EPEL) which is Fedora/RedHat specific.
Imho such things should be handled by hand and not automatically by a module which should handle rabbitmq.
