### PR TITLE
Allow erlang kernel config options in rabbitmq.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ class { 'rabbitmq':
 }
 ```
 
+To change Erlang Kernel Config Variables in rabbitmq.config, use the parameters 
+`config_kernel_variables` e.g.:
+
+```puppet
+class { 'rabbitmq':
+  port              => '5672',
+  kernel_config_options => {
+    'inet_dist_listen_min' => 9100,
+    'inet_dist_listen_max' => 9105,
+  }
+}
+```
+
 ### Clustering
 To use RabbitMQ clustering and H/A facilities, use the rabbitmq::server
 parameters `config_cluster`, `cluster_nodes`, and `cluster_node_type`, e.g.:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,6 +26,7 @@ class rabbitmq::config {
   $stomp_port                 = $rabbitmq::stomp_port
   $wipe_db_on_cookie_change   = $rabbitmq::wipe_db_on_cookie_change
   $config_variables           = $rabbitmq::config_variables
+  $config_kernel_variables    = $rabbitmq::config_kernel_variables
   $cluster_partition_handling = $rabbitmq::cluster_partition_handling
   $default_env_variables      =  {
     'RABBITMQ_NODE_PORT'        => $port,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,7 @@ class rabbitmq(
   $cluster_partition_handling = $rabbitmq::params::cluster_partition_handling,
   $environment_variables      = $rabbitmq::params::environment_variables,
   $config_variables           = $rabbitmq::params::config_variables,
+  $config_kernel_variables    = $rabbitmq::params::config_kernel_variables,
 ) inherits rabbitmq::params {
 
   validate_bool($admin_enable)
@@ -92,6 +93,7 @@ class rabbitmq(
   validate_re($ssl_stomp_port, '\d+')
   validate_hash($environment_variables)
   validate_hash($config_variables)
+  validate_hash($config_kernel_variables)
 
   if $erlang_manage {
     include '::erlang'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,4 +77,5 @@ class rabbitmq::params {
   $cluster_partition_handling = 'ignore'
   $environment_variables      = {}
   $config_variables           = {}
+  $config_kernel_variables    = {}
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -275,6 +275,18 @@ describe 'rabbitmq' do
         end
       end
 
+      describe 'config_kernel_variables options' do
+        let(:params) {{ :config_kernel_variables => {
+            'inet_dist_listen_min'      => 9100,
+            'inet_dist_listen_max'      => 9105,
+        }}}
+        it 'should set config variables' do
+          should contain_file('rabbitmq.config') \
+            .with_content(/\{inet_dist_listen_min, 9100\}/) \
+            .with_content(/\{inet_dist_listen_max, 9105\}/) 
+        end
+      end
+
       context 'delete_guest_user' do
         describe 'should do nothing by default' do
           it { should_not contain_rabbitmq_user('guest') }

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -21,7 +21,11 @@
 <%- end -%>
     {default_user, <<"<%= @default_user %>">>},
     {default_pass, <<"<%= @default_pass %>">>}
+  ]}<% if @config_kernel_variables -%>,
+  {kernel, [
+    <%= @config_kernel_variables.sort.map{|k,v| "{#{k}, #{v}}"}.join(",\n    ") %>
   ]}
+<%- end -%>
 <% if @config_stomp -%>,
 % Configure the Stomp Plugin listening port
   {rabbitmq_stomp, [


### PR DESCRIPTION
Added a new param "config_kernel_options" in order to add erlang kernel variables such as:

  {kernel, [
    {inet_dist_listen_max, 9105},
    {inet_dist_listen_min, 9100}
  ]}
