### PR TITLE
Removed trailing whitespace causing lint error

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,7 +45,7 @@ class rabbitmq::params {
   $package_gpg_key            = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc'
   $service_ensure             = 'running'
   $service_manage             = true
-  #config 
+  #config
   $cluster_disk_nodes         = []
   $cluster_node_type          = 'disc'
   $cluster_nodes              = []


### PR DESCRIPTION
Removed a single whitespace char to fix puppet-lint error.

I know its a small fix, however it was required to pass puppet-lint without errors.
:)
