### PR TITLE
Update config.pp

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,9 +42,9 @@ class rabbitmq::config {
       message => 'WARNING: The cluster_disk_nodes is deprecated.
        Use cluster_nodes instead.',
     }
-    $_cluster_nodes = $cluster_disk_nodes
+    $cluster_nodes_o = $cluster_disk_nodes
   } else {
-    $_cluster_nodes = $cluster_nodes
+    $cluster_nodes_o = $cluster_nodes
   }
 
   file { '/etc/rabbitmq':


### PR DESCRIPTION
Vagrant error:
Error: Illegal name. The given name _cluster_nodes does not conform to the naming rule \A((::)?[a-z0-9]w_)(::[a-z0-9]w_)_\z at /etc/puppet/modules/rabbitmq/manifests/config.pp:45:5
Error: Illegal name. The given name _cluster_nodes does not conform to the naming rule \A((::)?[a-z0-9]w_)(::[a-z0-9]w_)_\z at /etc/puppet/modules/rabbitmq/manifests/config.pp:47:5
Error: Found 2 errors. Giving up at /etc/puppet/modules/rabbitmq/manifests/config.pp:2 on node packer-virtualbox.vagrantup.com
Error: Found 2 errors. Giving up at /etc/puppet/modules/rabbitmq/manifests/config.pp:2 on node packer-virtualbox.vagrantup.com
