### PR TITLE
ignore extra tags on the user

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -56,14 +56,14 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
     else
       usertags = get_user_tags
       usertags.delete('administrator')
-      rabbitmqctl('set_user_tags', resource[:name], usertags.entries)
+      rabbitmqctl('set_user_tags', resource[:name], usertags.entries.sort)
     end
   end
 
   def make_user_admin
     usertags = get_user_tags
     usertags.add('administrator')
-    rabbitmqctl('set_user_tags', resource[:name], usertags.entries)
+    rabbitmqctl('set_user_tags', resource[:name], usertags.entries.sort)
   end
 
   private

--- a/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
@@ -121,7 +121,7 @@ kitchen []
 kitchen2        [abc, def, ghi]
 ...done.
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['bar','baz', 'administrator']) 
+    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['bar','baz', 'administrator'].sort) 
     @provider.admin=:true
   end
   it 'should be able to unset admin value' do
@@ -144,7 +144,7 @@ kitchen []
 kitchen2        [abc, def, ghi]
 ...done.
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['bar','baz']) 
+    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['bar','baz'].sort) 
     @provider.admin=:false
   end
 end


### PR DESCRIPTION
ignore other tags on the user than administrator. Obviously it would be preferable to be able to manage _all_ of the tags on a user, but this will at least prevent things from breaking if you add additional tags

Fixes: #128 (or should, anyways)
