### PR TITLE
Add redhat specific rabbitmq_plugins provider. 

### DIFF
--- a/lib/puppet/provider/rabbitmq_plugin/redhat.rb
+++ b/lib/puppet/provider/rabbitmq_plugin/redhat.rb
@@ -1,0 +1,36 @@
+Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins) do
+  defaultfor :osfamily => [:redhat, :suse]
+
+  if Puppet::PUPPETVERSION.to_f < 3
+    commands :rabbitmqplugins => '/usr/lib/rabbitmq/bin/rabbitmq-plugins'
+  else
+    has_command(:rabbitmqplugins, '/usr/lib/rabbitmq/bin/rabbitmq-plugins') do
+      environment :HOME => "/tmp"
+    end
+  end
+
+  def self.instances
+    rabbitmqplugins('list', '-E').split(/\n/).map do |line|
+      if line.split(/\s+/)[1] =~ /^(\S+)$/
+        new(:name => $1)
+      else
+        raise Puppet::Error, "Cannot parse invalid plugins line: #{line}"
+      end
+    end
+  end
+
+  def create
+    rabbitmqplugins('enable', resource[:name])
+  end
+
+  def destroy
+    rabbitmqplugins('disable', resource[:name])
+  end
+
+  def exists?
+    rabbitmqplugins('list', '-E').split(/\n/).detect do |line|
+      line.split(/\s+/)[1].match(/^#{resource[:name]}$/)
+    end
+  end
+
+end


### PR DESCRIPTION
This works around an issue where the rabbitmq rpm does not put rabbitmq_plugins into a directory in the default $PATH
