### PR TITLE
Remove string validation on package source

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,7 +59,6 @@ class rabbitmq(
   validate_string($package_gpg_key)
   validate_string($package_name)
   validate_string($package_provider)
-  validate_string($package_source)
   validate_bool($manage_repos)
   validate_re($version, '^\d+\.\d+\.\d+(-\d+)*$') # Allow 3 digits and optional -n postfix.
   # Validate config parameters.


### PR DESCRIPTION
In rabbitmq::install there is a condition
on the package_source parameter. It is not
possible to set this to false without
validation causing a parser error. This
patch removes the validation.
