### PR TITLE
Set appropriate policy for mirrored queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,23 @@ class { 'rabbitmq':
 }
 ```
 
+**NOTE:** If you are using a version of RabbitMQ less than 3.0,
+you still need to use `x-ha-policy: all` in your client
+applications for any particular queue to take advantage of H/A via
+mirrored queues.
+
+If you are using a version of RabbitMQ >= 3.0 You should set the
+'config_mirrored_queues' parameter if you plan
+on using RabbitMQ Mirrored Queues within your cluster:
+
+```puppet
+class { 'rabbitmq':
+  config_cluster         => true,
+  config_mirrored_queues => true,
+  cluster_nodes          => ['rabbit1', 'rabbit2'],
+}
+```
+
 ##Reference
 
 ##Classes

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class rabbitmq(
   $cluster_nodes              = $rabbitmq::params::cluster_nodes,
   $config                     = $rabbitmq::params::config,
   $config_cluster             = $rabbitmq::params::config_cluster,
+  $config_mirrored_queues     = $rabbitmq::params::config_mirrored_queues,
   $config_path                = $rabbitmq::params::config_path,
   $config_stomp               = $rabbitmq::params::config_stomp,
   $default_user               = $rabbitmq::params::default_user,
@@ -69,6 +70,7 @@ class rabbitmq(
   validate_string($config)
   validate_absolute_path($config_path)
   validate_bool($config_cluster)
+  validate_bool($config_mirrored_queues)
   validate_bool($config_stomp)
   validate_string($default_user)
   validate_string($default_pass)

--- a/manifests/management.pp
+++ b/manifests/management.pp
@@ -10,4 +10,10 @@ class rabbitmq::management {
     }
   }
 
+  if $rabbitmq::config_mirrored_queues {
+    rabbitmq::policy { 'ha-all':
+      pattern  => '.*',
+      definition => '{"ha-mode":"all","ha-sync-mode":"automatic"}'
+    }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,6 +61,7 @@ class rabbitmq::params {
   $cluster_nodes              = []
   $config                     = 'rabbitmq/rabbitmq.config.erb'
   $config_cluster             = false
+  $config_mirrored_queues     = false
   $config_path                = '/etc/rabbitmq/rabbitmq.config'
   $config_stomp               = false
   $default_user               = 'guest'

--- a/manifests/policy.pp
+++ b/manifests/policy.pp
@@ -1,0 +1,15 @@
+define rabbitmq::policy (
+  $pattern,
+  $definition,
+  $vhost    = '/',
+  $priority = 0,
+) {
+
+  exec { "rabbitmq policy: ${title}":
+    command => "rabbitmqctl set_policy -p ${vhost} '${name}' '${pattern}' '${definition}' ${priority}",
+    unless  => "rabbitmqctl list_policies | grep -qE '^${vhost}\\s+${name}\\s+${pattern}\\s+${definition}\\s+${priority}$'",
+    path    => ['/bin','/sbin','/usr/bin','/usr/sbin'],
+    require => Class['rabbitmq::service'],
+    before  => Anchor['rabbitmq::end']
+  }
+}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -66,7 +66,7 @@ class rabbitmq::server(
   }
 
   if $config_mirrored_queues != undef {
-    warning('The $config_mirrored_queues parameter is deprecated; it does not affect anything')
+    warning('The $config_mirrored_queues parameter is deprecated in this class, use the rabbitmq class')
   }
 
   anchor {'before::rabbimq::class':


### PR DESCRIPTION
Previously, the config_mirrored_queues parameter
had no effect. This patch adds a policy defined type
and if mirroring is requested, an appropriate
policy is created. The README has been updated to
clarify the case where this is applicable.

https://github.com/puppetlabs/puppetlabs-rabbitmq/issues/125
