### PR TITLE
exchanges recreated if vhost is not default /

### DIFF
--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -1,6 +1,7 @@
 require 'puppet'
 Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin) do
 
+  commands :rabbitmqctl => '/usr/sbin/rabbitmqctl'
   commands :rabbitmqadmin => '/usr/local/bin/rabbitmqadmin'
   defaultfor :feature => :posix
 
@@ -12,23 +13,49 @@ Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin) do
     end
   end
 
+  def self.all_vhosts
+    vhosts = []
+    parse_command(rabbitmqctl('list_vhosts')).collect do |vhost|
+        vhosts.push(vhost)
+    end
+    vhosts
+  end
+
+  def self.all_exchanges(vhost)
+    exchanges = []
+    parse_command(rabbitmqctl('list_exchanges', '-p', vhost, 'name', 'type'))
+  end
+
+  def self.parse_command(cmd_output)
+    # first line is:
+    # Listing exchanges/vhosts ...
+    # while the last line is
+    # ...done.
+    #
+    cmd_output.split(/\n/)[1..-2]
+  end
+
   def self.instances
     resources = []
-    rabbitmqadmin('list', 'exchanges').split(/\n/)[3..-2].collect do |line|
-      if line =~ /^\|\s+(\S+)\s+\|\s+(\S+)?\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|\s+(\S+)\s+\|$/
-        entry = {
-          :ensure => :present,
-          :name   => "%s@%s" % [$2, $1],
-          :type   => $3
-        }
-        resources << new(entry) if entry[:type]
-      else
-        raise Puppet::Error, "Cannot parse invalid exchange line: #{line}"
-      end
+    all_vhosts.each do |vhost|
+        all_exchanges(vhost).collect do |line|
+            name, type = line.split()
+            if type.nil?
+                # if name is empty, it will wrongly get the type's value.
+                # This way type will get the correct value
+                type = name
+                name = ''
+            end
+            exchange = {
+              :type   => type,
+              :ensure => :present,
+              :name   => "%s@%s" % [name, vhost],
+            }
+            resources << new(exchange) if exchange[:type]
+        end
     end
     resources
   end
-
 
   def self.prefetch(resources)
     packages = instances

--- a/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
@@ -14,19 +14,22 @@ describe provider_class do
   end
 
   it 'should return instances' do
-    provider_class.expects(:rabbitmqadmin).with('list', 'exchanges').returns <<-EOT
-+--------------+-----------------------+---------+-------------+---------+----------+
-|    vhost     |         name          |  type   | auto_delete | durable | internal |
-+--------------+-----------------------+---------+-------------+---------+----------+
-| /            |                       | direct  | False       | True    | False    |
-| /            | amq.direct            | direct  | False       | True    | False    |
-| /            | amq.fanout            | fanout  | False       | True    | False    |
-| /            | amq.headers           | headers | False       | True    | False    |
-| /            | amq.match             | headers | False       | True    | False    |
-| /            | amq.rabbitmq.log      | topic   | False       | True    | False    |
-| /            | amq.rabbitmq.trace    | topic   | False       | True    | False    |
-| /            | amq.topic             | topic   | False       | True    | False    |
-+--------------+-----------------------+---------+-------------+---------+----------+
+    provider_class.expects(:rabbitmqctl).with('list_vhosts').returns <<-EOT
+Listing vhosts ...
+/
+...done.
+EOT
+    provider_class.expects(:rabbitmqctl).with('list_exchanges', '-p', '/', 'name', 'type').returns <<-EOT
+Listing exchanges ...
+        direct
+	amq.direct      direct
+	amq.fanout      fanout
+	amq.headers     headers
+	amq.match       headers
+	amq.rabbitmq.log        topic
+	amq.rabbitmq.trace      topic
+	amq.topic       topic
+	...done.
 EOT
     instances = provider_class.instances
     instances.size.should == 8


### PR DESCRIPTION
This should fix issue 173:
https://github.com/puppetlabs/puppetlabs-rabbitmq/issues/173

self.instances would only return the list of exchanges for the default
vhost /, this would cause a problem as any other exchange would be
recreated in every Puppet run.
Also, rabbitmqctl was used instead of rabbitmqadmin because the latest
requires the username and password of the admin user to list the
exchanges, while the first does not.
