### PR TITLE
allow port to be 'UNSET'.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@ class rabbitmq(
   validate_re($management_port, '\d+')
   validate_string($node_ip_address)
   validate_absolute_path($plugin_dir)
-  validate_re($port, '\d+')
+  validate_re($port, ['\d+','UNSET'])
   validate_re($stomp_port, '\d+')
   validate_bool($wipe_db_on_cookie_change)
   # Validate service parameters.


### PR DESCRIPTION
This allows to have a setup where rabbitmq is not listening
on an non ssl port.
eg:
  class { '::rabbitmq':
    ssl                      => true,
    ssl_cacert               => '/etc/rabbitmq/ssl/cacert.pem',
    ssl_cert                 => '/etc/rabbitmq/ssl/cert.pem',
    ssl_key                  => '/etc/rabbitmq/ssl/key.pem',
    config_variables         => { tcp_listeners => '[]' },
    port                     => 'UNSET',
  }
