### PR TITLE
Puppet 3.4 compatibility fix

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,9 +42,9 @@ class rabbitmq::config {
       message => 'WARNING: The cluster_disk_nodes is deprecated.
        Use cluster_nodes instead.',
     }
-    $_cluster_nodes = $cluster_disk_nodes
+    $r_cluster_nodes = $cluster_disk_nodes
   } else {
-    $_cluster_nodes = $cluster_nodes
+    $r_cluster_nodes = $cluster_nodes
   }
 
   file { '/etc/rabbitmq':

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -6,7 +6,7 @@
     {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_ldap]},
 <% end -%>
 <% if @config_cluster -%>
-    {cluster_nodes, {[<%= @_cluster_nodes.map { |n| "\'rabbit@#{n}\'" }.join(', ') %>], <%= @cluster_node_type %>}},
+    {cluster_nodes, {[<%= @r_cluster_nodes.map { |n| "\'rabbit@#{n}\'" }.join(', ') %>], <%= @cluster_node_type %>}},
     {cluster_partition_handling, <%= @cluster_partition_handling %>},
 <% end -%>
 <%- if @ssl %>


### PR DESCRIPTION
Puppet 3.4 doesn't like variable names which start in _
