### PR TITLE
Some modules still use rabbitmq::server class

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -8,8 +8,7 @@ class rabbitmq::install::rabbitmqadmin {
     source  => "http://localhost:${management_port}/cli/rabbitmqadmin",
     require => [
       Class['rabbitmq::service'],
-      Rabbitmq_plugin['rabbitmq_management'],
-      Package['curl'],
+      Rabbitmq_plugin['rabbitmq_management']
     ],
   }
 


### PR DESCRIPTION
There are modules which depend on rabbitmq::server class. 
