### PR TITLE
Remove unused config_mirrored_queues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ class { 'rabbitmq':
 }
 ```
 
-To change Erlang Kernel Config Variables in rabbitmq.config, use the parameters 
+To change Erlang Kernel Config Variables in rabbitmq.config, use the parameters
 `config_kernel_variables` e.g.:
 
 ```puppet
@@ -100,28 +100,14 @@ class { 'rabbitmq':
 ```
 
 ### Clustering
-To use RabbitMQ clustering and H/A facilities, use the rabbitmq::server
-parameters `config_cluster`, `cluster_nodes`, and `cluster_node_type`, e.g.:
+To use RabbitMQ clustering facilities, use the rabbitmq parameters
+`config_cluster`, `cluster_nodes`, and `cluster_node_type`, e.g.:
 
 ```puppet
 class { 'rabbitmq':
-  config_cluster    => true, 
+  config_cluster    => true,
   cluster_nodes     => ['rabbit1', 'rabbit2'],
   cluster_node_type => 'ram',
-}
-```
-
-**NOTE:** You still need to use `x-ha-policy: all` in your client 
-applications for any particular queue to take advantage of H/A.
-
-You should set the 'config_mirrored_queues' parameter if you plan
-on using RabbitMQ Mirrored Queues within your cluster:
-
-```puppet
-class { 'rabbitmq':
-  config_cluster         => true,
-  config_mirrored_queues => true,
-  cluster_nodes          => ['rabbit1', 'rabbit2'],
 }
 ```
 
@@ -165,7 +151,11 @@ Boolean to enable or disable clustering support.
 
 ####`config_mirrored_queues`
 
-Boolean to enable or disable mirrored queues.
+DEPRECATED
+
+Configuring queue mirroring should be done by setting the according policy for
+the queue. You can read more about it
+[here](http://www.rabbitmq.com/ha.html#genesis)
 
 ####`config_path`
 
@@ -327,13 +317,13 @@ Testing on other platforms has been light and cannot be guaranteed.
 To have a suitable erlang version installed on RedHat systems,
 you have to install another puppet module from http://forge.puppetlabs.com/garethr/erlang with:
 
-	puppet module install garethr-erlang
+    puppet module install garethr-erlang
 
 This module handles the packages for erlang.
 To use the module, add the following snippet to your site.pp or an appropriate profile class:
 
-	include 'erlang'
-	class { 'erlang': epel_enable => true}
+    include 'erlang'
+    class { 'erlang': epel_enable => true}
 
 ##Development
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,6 @@ class rabbitmq::config {
   $config                     = $rabbitmq::config
   $config_cluster             = $rabbitmq::config_cluster
   $config_path                = $rabbitmq::config_path
-  $config_mirrored_queues     = $rabbitmq::config_mirrored_queues
   $config_stomp               = $rabbitmq::config_stomp
   $default_user               = $rabbitmq::default_user
   $default_pass               = $rabbitmq::default_pass

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,6 @@ class rabbitmq(
   $cluster_nodes              = $rabbitmq::params::cluster_nodes,
   $config                     = $rabbitmq::params::config,
   $config_cluster             = $rabbitmq::params::config_cluster,
-  $config_mirrored_queues     = $rabbitmq::params::config_mirrored_queues,
   $config_path                = $rabbitmq::params::config_path,
   $config_stomp               = $rabbitmq::params::config_stomp,
   $default_user               = $rabbitmq::params::default_user,
@@ -69,7 +68,6 @@ class rabbitmq(
   validate_string($config)
   validate_absolute_path($config_path)
   validate_bool($config_cluster)
-  validate_bool($config_mirrored_queues)
   validate_bool($config_stomp)
   validate_string($default_user)
   validate_string($default_pass)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,7 +61,6 @@ class rabbitmq::params {
   $cluster_nodes              = []
   $config                     = 'rabbitmq/rabbitmq.config.erb'
   $config_cluster             = false
-  $config_mirrored_queues     = false
   $config_path                = '/etc/rabbitmq/rabbitmq.config'
   $config_stomp               = false
   $default_user               = 'guest'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -14,7 +14,7 @@
 #  [*config*] - contents of config file
 #  [*env_config*] - contents of env-config file
 #  [*config_cluster*] - whether to configure a RabbitMQ cluster
-#  [*config_mirrored_queues*] - whether to configure RabbitMQ mirrored queues within a Rabbit Cluster.
+#  [*config_mirrored_queues*] - DEPRECATED (doesn't do anything)
 #  [*cluster_disk_nodes*] - DEPRECATED (use cluster_nodes instead)
 #  [*cluster_nodes*] - which nodes to cluster with (including the current one)
 #  [*cluster_node_type*] - Type of cluster node (disc or ram)
@@ -45,7 +45,6 @@ class rabbitmq::server(
   $config_stomp             = $rabbitmq::params::config_stomp,
   $stomp_port               = $rabbitmq::params::stomp_port,
   $config_cluster           = $rabbitmq::params::config_cluster,
-  $config_mirrored_queues   = $rabbitmq::params::config_mirrored_queues,
   $cluster_disk_nodes       = $rabbitmq::params::cluster_disk_nodes,
   $cluster_nodes            = $rabbitmq::params::cluster_nodes,
   $cluster_node_type        = $rabbitmq::params::cluster_node_type,
@@ -56,6 +55,7 @@ class rabbitmq::server(
   $wipe_db_on_cookie_change = $rabbitmq::params::wipe_db_on_cookie_change,
   # DEPRECATED
   $manage_service           = undef,
+  $config_mirrored_queues   = undef,
 ) inherits rabbitmq::params {
 
   if $manage_service != undef {
@@ -64,6 +64,11 @@ class rabbitmq::server(
   } else {
     $_service_manage = $service_manage
   }
+
+  if $config_mirrored_queues != undef {
+    warning('The $config_mirrored_queues parameter is deprecated; it does not affect anything')
+  }
+
   anchor {'before::rabbimq::class':
     before => Class['rabbitmq'],
   }
@@ -83,7 +88,6 @@ class rabbitmq::server(
     config_stomp              => $config_stomp,
     stomp_port                => $stomp_port,
     config_cluster            => $config_cluster,
-    config_mirrored_queues    => $config_mirrored_queues,
     cluster_disk_nodes        => $cluster_disk_nodes,
     cluster_nodes             => $cluster_nodes,
     cluster_node_type         => $cluster_node_type,


### PR DESCRIPTION
Configuring queue mirroring should be done by setting the correct policy on a queue. Looking at the code this actually hasn't worked in forever, it's not even doing anything with the variable.

I've deprecated the variable in rabbitmq::server and removed it from rabbitmq. I doubt anyone was using this anyone as it wasn't doing a thing.

No tests are affected by this as there aren't any that covered this attribute.
