### PR TITLE
Remove problematic package dependency

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,7 +15,6 @@ class rabbitmq::install {
   if $package_source {
     Package['rabbitmq-server'] {
       source  => $package_source,
-      require => Class['rabbitmq::repo::rhel'],
     }
   }
 


### PR DESCRIPTION
This dependency is already defined in the rabbitmq::repo::rhel class
and fails altogether when $manage_repos is set to false. I don't
understand why the tests don't catch that though.
