### PR TITLE
Adding missing ssl_ parameters from rabbitmq::config class

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,8 +22,8 @@ class rabbitmq::config {
   $ssl_key                    = $rabbitmq::ssl_key
   $ssl_management_port        = $rabbitmq::ssl_management_port
   $ssl_stomp_port             = $rabbitmq::ssl_stomp_port
-  $ssl_verify                 = $rabbitmq::ssl_verify,
-  $ssl_fail_if_no_peer_cert   = $rabbitmq::ssl_fail_if_no_peer_cert,
+  $ssl_verify                 = $rabbitmq::ssl_verify
+  $ssl_fail_if_no_peer_cert   = $rabbitmq::ssl_fail_if_no_peer_cert
   $stomp_port                 = $rabbitmq::stomp_port
   $wipe_db_on_cookie_change   = $rabbitmq::wipe_db_on_cookie_change
   $config_variables           = $rabbitmq::config_variables


### PR DESCRIPTION
$ssl_verify and  $ssl_fail_if_no_peer_cert were missing from rabbitmq::config
class.  This was causing the 'false' values to not be populated in
rabbitmq.config (at least for the future parser in Puppet 3.5.1)
