### PR TITLE
rabbitmq-plugins location fix when RHEL and puppet version is < 3

### DIFF
--- a/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
+++ b/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
@@ -1,7 +1,11 @@
 Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins) do
 
   if Puppet::PUPPETVERSION.to_f < 3
-    commands :rabbitmqplugins => 'rabbitmq-plugins'
+    if Facter.value(:osfamily) == 'RedHat'
+      commands :rabbitmqplugins => '/usr/lib/rabbitmq/bin/rabbitmq-plugins'
+    else
+      commands :rabbitmqplugins => 'rabbitmq-plugins'
+    end
   else
     if Facter.value(:osfamily) == 'RedHat'
       has_command(:rabbitmqplugins, '/usr/lib/rabbitmq/bin/rabbitmq-plugins') do


### PR DESCRIPTION
Fix for RHEL specific rabbitmq-plugins locations similar to this pull - https://github.com/puppetlabs/puppetlabs-rabbitmq/pull/194
