### PR TITLE
Fix for stomp_ensure type error

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,7 +94,7 @@ class rabbitmq(
   validate_re($ssl_management_port, '\d+')
   validate_string($ssl_stomp_port)
   validate_re($ssl_stomp_port, '\d+')
-  validate_re($stomp_ensure, '^(present|absent)$')
+  validate_bool($stomp_ensure)
   validate_bool($ldap_auth)
   validate_string($ldap_server)
   validate_string($ldap_user_dn_pattern)
@@ -124,12 +124,14 @@ class rabbitmq(
   if $admin_enable and $service_manage {
     include '::rabbitmq::install::rabbitmqadmin'
 
-    rabbitmq_plugin { 'rabbitmq_management':
+  if $stomp_ensure {
+    rabbitmq_plugin { 'rabbitmq_stomp':
       ensure  => present,
       require => Class['rabbitmq::install'],
       notify  => Class['rabbitmq::service'],
       provider => 'rabbitmqplugins'
     }
+  }
 
     Class['::rabbitmq::service'] -> Class['::rabbitmq::install::rabbitmqadmin']
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,7 +80,7 @@ class rabbitmq::params {
   $ssl_stomp_port             = '6164'
   $ssl_verify                 = 'verify_none'
   $ssl_fail_if_no_peer_cert   = 'false'
-  $stomp_ensure               = 'absent'
+  $stomp_ensure               = false
   $ldap_auth                  = false
   $ldap_server                = 'ldap'
   $ldap_user_dn_pattern       = 'cn=${username},ou=People,dc=example,dc=com'


### PR DESCRIPTION
Fixing such an error: "Error: Parameter ensure failed on Rabbitmq_plugin[rabbitmq_stomp]: Invalid value true. Valid values are present, absent.".
