### PR TITLE
Resolve rabbitmq_exchange type error

### DIFF
--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -2,7 +2,9 @@ require 'puppet'
 Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin) do
 
   commands :rabbitmqctl => '/usr/sbin/rabbitmqctl'
-  commands :rabbitmqadmin => '/usr/local/bin/rabbitmqadmin'
+  has_command(:rabbitmqadmin, '/usr/local/bin/rabbitmqadmin') do
+    environment( { 'HOME' => '' })
+  end
   defaultfor :feature => :posix
 
   def should_vhost


### PR DESCRIPTION
Rabbitmqadmin relies on one of two environment variables being set (to anything really) when running.  

Puppet 3.x and above appears to strip these environment variables from the provider's environment when run which then causes rabbitmq_exchange to type error out when creating an exchange.

Setting HOME to nil will allow rabbitmqadmin to run normally, check for a file that doesn't exist, and proceed. 
