### PR TITLE
Use valid ensure value similar to ldap_auth when stomp_ensure = true

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,7 +136,7 @@ class rabbitmq(
 
   if $stomp_ensure {
     rabbitmq_plugin { 'rabbitmq_stomp':
-      ensure  => $stomp_ensure,
+      ensure  => present,
       require => Class['rabbitmq::install'],
       notify  => Class['rabbitmq::service'],
       provider => 'rabbitmqplugins'


### PR DESCRIPTION
Stomp_ensure only takes a Boolean variable and attempts to pass it to ensure.  This of course fails since it's expecting present or absent.

Leverage a similar Boolean setup to ldap_auth
