### PR TITLE
Make curl and wget not go via a proxy (if one is configured) for rabbitmq admin

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -9,6 +9,8 @@ class rabbitmq::install::rabbitmqadmin {
   staging::file { 'rabbitmqadmin':
     target  => '/var/lib/rabbitmq/rabbitmqadmin',
     source  => "${protocol}://${default_user}:${default_pass}@localhost:${management_port}/cli/rabbitmqadmin",
+    curl_option => '--noproxy localhost',
+    wget_option => '--no-proxy',
     require => [
       Class['rabbitmq::service'],
       Rabbitmq_plugin['rabbitmq_management']


### PR DESCRIPTION
If there is a proxy configured in the environment, then the command line curl to the rabbitmq admin will fail.

setting --no-proxy (for wget and curl) ensures we always go to the local machine for localhost
