### PR TITLE
Strip backslashes from the output of rabbitmqctl

### DIFF
--- a/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
@@ -52,7 +52,7 @@ Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl) do
     resource[:configure_permission] ||= "''"
     resource[:read_permission]      ||= "''"
     resource[:write_permission]     ||= "''"
-    rabbitmqctl('set_permissions', '-p', should_vhost, should_user, resource[:configure_permission], resource[:write_permission], resource[:read_permission]) 
+    rabbitmqctl('set_permissions', '-p', should_vhost, should_user, resource[:configure_permission], resource[:write_permission], resource[:read_permission])
   end
 
   def destroy


### PR DESCRIPTION
The output of `rabbitmqctl(1)` escapes backslashes. This was documented
in the `rabbitmqctl` man page[1] but was removed when the manpage was
converted to DocBook XML[2].

This change causes extraneous backslashes to be stripped to prevent
this module from misreading escaped characters in regular expressions
and repeatedly applying the same change.

[1]:
https://github.com/rabbitmq/rabbitmq-server/blob/16418a9488e15c4d8ef3bfa9fce69190fb8ec796/docs/rabbitmqctl.1.pod#output-escaping
[2]:
https://github.com/rabbitmq/rabbitmq-server/commit/60c14baa96118e587b12716b49f7d66e487a5939#diff-b96d4e7ccd3d984656b8ab3534e6b460
