### PR TITLE
Introduced install_class parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,7 @@ class rabbitmq(
   $environment_variables      = $rabbitmq::params::environment_variables,
   $config_variables           = $rabbitmq::params::config_variables,
   $config_kernel_variables    = $rabbitmq::params::config_kernel_variables,
+  $install_class              = $rabbitmq::params::install_class
 ) inherits rabbitmq::params {
 
   validate_bool($admin_enable)
@@ -110,7 +111,9 @@ class rabbitmq(
     fail('$ssl_only => true requires that $ssl => true')
   }
 
-  include '::rabbitmq::install'
+  if $install_class {
+    include $install_class
+  }
   include '::rabbitmq::config'
   include '::rabbitmq::service'
   include '::rabbitmq::management'
@@ -131,7 +134,7 @@ class rabbitmq(
 
     rabbitmq_plugin { 'rabbitmq_management':
       ensure  => present,
-      require => Class['rabbitmq::install'],
+      require => Class[$install_class],
       notify  => Class['rabbitmq::service'],
       provider => 'rabbitmqplugins'
     }
@@ -142,7 +145,7 @@ class rabbitmq(
   if $stomp_ensure {
     rabbitmq_plugin { 'rabbitmq_stomp':
       ensure  => present,
-      require => Class['rabbitmq::install'],
+      require => Class[$install_class],
       notify  => Class['rabbitmq::service'],
       provider => 'rabbitmqplugins'
     }
@@ -151,7 +154,7 @@ class rabbitmq(
   if ($ldap_auth) {
     rabbitmq_plugin { 'rabbitmq_auth_backend_ldap':
       ensure   => present,
-      require  => Class['rabbitmq::install'],
+      require  => Class[$install_class],
       notify   => Class['rabbitmq::service'],
       provider => 'rabbitmqplugins',
     }
@@ -163,12 +166,12 @@ class rabbitmq(
   anchor { 'rabbitmq::begin': }
   anchor { 'rabbitmq::end': }
 
-  Anchor['rabbitmq::begin'] -> Class['::rabbitmq::install']
+  Anchor['rabbitmq::begin'] -> Class[$install_class]
     -> Class['::rabbitmq::config'] ~> Class['::rabbitmq::service']
     -> Class['::rabbitmq::management'] -> Anchor['rabbitmq::end']
 
   # Make sure the various providers have their requirements in place.
-  Class['::rabbitmq::install'] -> Rabbitmq_plugin<| |>
+  Class[$install_class] -> Rabbitmq_plugin<| |>
   Class['::rabbitmq::install::rabbitmqadmin'] -> Rabbitmq_exchange<| |>
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -94,4 +94,5 @@ class rabbitmq::params {
   $environment_variables      = {}
   $config_variables           = {}
   $config_kernel_variables    = {}
+  $install_class              = '::rabbitmq::install'
 }


### PR DESCRIPTION
This module works perfectly, but doesn't fit at least a specific use case (installation of 3.1.4 on Debian osfamily). I'd like to avoid the creation and maintenance of a fork. 
This PR introduces is a quick reusability feature that allows to manage installations of rabbitmq using alternative approaches / sources by providing a custom install_class parameter without modifying the module.
I can refine the PR, for example adding specific spec tests, if you think that such an option might be accepted. Just let me know.
