### PR TITLE
Use warning instead of notify when inform about deprecation.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,10 +44,7 @@ class rabbitmq::config {
 
   # Handle deprecated option.
   if $cluster_disk_nodes != [] {
-    notify { 'cluster_disk_nodes':
-      message => 'WARNING: The cluster_disk_nodes is deprecated.
-       Use cluster_nodes instead.',
-    }
+    warning('The $cluster_disk_nodes is deprecated. Use $cluster_nodes instead.')
     $r_cluster_nodes = $cluster_disk_nodes
   } else {
     $r_cluster_nodes = $cluster_nodes

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -108,14 +108,6 @@ describe 'rabbitmq' do
         end
       end
 
-      context 'deprecated parameters' do
-        describe 'cluster_disk_nodes' do
-          let(:params) {{ :cluster_disk_nodes => ['node1', 'node2'] }}
-
-          it { should contain_notify('cluster_disk_nodes') }
-        end
-      end
-
       describe 'manages configuration directory correctly' do
         it { should contain_file('/etc/rabbitmq').with(
           'ensure' => 'directory'


### PR DESCRIPTION
Some modules ex. puppet-nova still use $cluster_disk_nodes, and when
notify is used to inform about deprecation every puppet runs cause
rabbitmq server restart.
