### PR TITLE
Use https to download rabbitmqadmin tool when $rabbitmq::ssl => true

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -4,7 +4,7 @@ class rabbitmq::install::rabbitmqadmin {
   $management_port = $rabbitmq::management_port
   $default_user = $rabbitmq::default_user
   $default_pass = $rabbitmq::default_pass
-  $protocol = $rabbitmq::ssl ? { 'true' => 'https', default => 'http' }
+  $protocol = $rabbitmq::ssl ? { false => 'http', default => 'https' }
 
   staging::file { 'rabbitmqadmin':
     target  => '/var/lib/rabbitmq/rabbitmqadmin',


### PR DESCRIPTION
If $rabbitmq::admin_enable is set, the rabbitmqadmin tool is downloaded
via a http URL on the RabbitMQ management service.  However, this fails
when $rabbitmq::ssl is set, because in that case the managment service is
configured for https only (there is no http listener.)
