### PR TITLE
Allow to disable ssl on stomp.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@ class rabbitmq(
   $ssl_key                    = $rabbitmq::params::ssl_key,
   $ssl_port                   = $rabbitmq::params::ssl_port,
   $ssl_management_port        = $rabbitmq::params::ssl_management_port,
+  $ssl_stomp                  = $rabbitmq::params::ssl_stomp,
   $ssl_stomp_port             = $rabbitmq::params::ssl_stomp_port,
   $ssl_verify                 = $rabbitmq::params::ssl_verify,
   $ssl_fail_if_no_peer_cert   = $rabbitmq::params::ssl_fail_if_no_peer_cert,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,6 +80,7 @@ class rabbitmq::params {
   $ssl_key                    = 'UNSET'
   $ssl_port                   = '5671'
   $ssl_management_port        = '15671'
+  $ssl_stomp                  = true,
   $ssl_stomp_port             = '6164'
   $ssl_verify                 = 'verify_none'
   $ssl_fail_if_no_peer_cert   = 'false'

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -54,7 +54,7 @@
 % Configure the Stomp Plugin listening port
   {rabbitmq_stomp, [
     {tcp_listeners, [<%= @stomp_port %>]}
-  <%- if @ssl_stomp_port -%>,
+  <%- if @ssl_stomp -%>,
     {ssl_listeners, [<%= @ssl_stomp_port %>]}
   <%- end -%>
   ]}


### PR DESCRIPTION
As the $ssl_stomp_port is required to be a string and must be '\d+', i added a ssl_stomp to disable ssl on stomp protocol (erlang ssl library on debian wheezy is buggy)
