### PR TITLE
Add custom key source, service provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ class { '::rabbitmq':
 }
 ```
 
+Or such as using custom Puppet service providers and offline installation from intranet
+or local mirrors:
+
+```puppet
+class { '::rabbitmq':
+   key_content      => template('openstack/rabbit.pub.key'),
+   package_gpg_key  => '/tmp/rabbit.pub.key',
+   service_provider => 'pacemaker',
+}
+```
+
+And this one will use default Puppet service ptype provider and external package key source
+for any (apt/rpm) package provider:
+
+```puppet
+class { '::rabbitmq':
+   package_gpg_key  => 'http://www.some_site.some_domain/some_key.pub.key',
+}
+```
+
 ### Environment Variables
 To use RabbitMQ Environment Variables, use the parameters `environment_variables` e.g.:
 
@@ -205,6 +225,11 @@ RabbitMQ Environment Variables in rabbitmq_env.config
 
 The erlang cookie to use for clustering - must be the same between all nodes.
 
+###`key_content`
+
+Uses content method for Debian OS family. Should be a template for apt::source
+class. Overrides `package_gpg_key` behavior, if enabled. Undefined by default.
+
 ####`ldap_auth`
 
 Boolean, set to true to enable LDAP auth.
@@ -248,7 +273,10 @@ be changed to latest.
 
 ####`package_gpg_key`
 
-RPM package GPG key to import.
+RPM package GPG key to import. Uses source method. Should be a file name for RHEL/SUSE
+or URL for Debian OS family. 
+Set to http://www.rabbitmq.com/rabbitmq-signing-key-public.asc by default.
+Note, that `key_content`, if specified, would override this parameter for Debian OS family.
 
 ####`package_name`
 
@@ -281,6 +309,11 @@ Determines if the service is managed.
 ####`service_name`
 
 The name of the service to manage.
+
+####`service_provider`
+
+The type of Puppet service provider to be used for RabbitMQ service definition.
+Undefined by default (will use Puppet default provider type).
 
 ####`ssl`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,8 @@ class rabbitmq(
   $environment_variables      = $rabbitmq::params::environment_variables,
   $config_variables           = $rabbitmq::params::config_variables,
   $config_kernel_variables    = $rabbitmq::params::config_kernel_variables,
+  $service_provider           = undef,
+  $key_content                = undef,
 ) inherits rabbitmq::params {
 
   validate_bool($admin_enable)
@@ -122,8 +124,12 @@ class rabbitmq(
     case $::osfamily {
       'RedHat', 'SUSE':
         { include '::rabbitmq::repo::rhel' }
-      'Debian':
-        { include '::rabbitmq::repo::apt' }
+      'Debian': {
+        class { '::rabbitmq::repo::apt' :
+          key_source  => $package_gpg_key,
+          key_content => $key_content,
+        }
+      }
       default:
         { }
     }

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -7,9 +7,10 @@ class rabbitmq::repo::apt(
   $repos       = 'main',
   $include_src = false,
   $key         = '056E8E56',
-  $key_source  = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
+  $key_content = undef,
   ) {
 
+  $package_gpg_key = $rabbitmq::package_gpg_key
   $pin = $rabbitmq::package_apt_pin
 
   Class['rabbitmq::repo::apt'] -> Package<| title == 'rabbitmq-server' |>
@@ -20,7 +21,8 @@ class rabbitmq::repo::apt(
     repos       => $repos,
     include_src => $include_src,
     key         => $key,
-    key_source  => $key_source,
+    key_source  => $package_gpg_key,
+    key_content => $key_content,
   }
 
   if $pin {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,9 +11,10 @@
 # Sample Usage:
 #
 class rabbitmq::service(
-  $service_ensure = $rabbitmq::service_ensure,
-  $service_manage = $rabbitmq::service_manage,
-  $service_name   = $rabbitmq::service_name,
+  $service_ensure   = $rabbitmq::service_ensure,
+  $service_manage   = $rabbitmq::service_manage,
+  $service_name     = $rabbitmq::service_name,
+  $service_provider = $rabbitmq::service_provider,
 ) inherits rabbitmq {
 
   validate_re($service_ensure, '^(running|stopped)$')
@@ -28,12 +29,23 @@ class rabbitmq::service(
       $enable_real = false
     }
 
-    service { 'rabbitmq-server':
-      ensure     => $ensure_real,
-      enable     => $enable_real,
-      hasstatus  => true,
-      hasrestart => true,
-      name       => $service_name,
+    if ($service_provider) {
+      service { 'rabbitmq-server':
+        ensure     => $ensure_real,
+        enable     => $enable_real,
+        hasstatus  => true,
+        hasrestart => true,
+        provider   => $service_provider,
+        name       => $service_name,
+      }
+    } else {
+      service { 'rabbitmq-server':
+        ensure     => $ensure_real,
+        enable     => $enable_real,
+        hasstatus  => true,
+        hasrestart => true,
+        name       => $service_name,
+      }
     }
   }
 


### PR DESCRIPTION
- Custom service provider types allow RabbitMQ being
  installed by Puppet in a much more flexible ways,
  an HA configurations with Pacemaker, for example.
  (Note, that for given example with Pacemaker, Pupet
  service type should be additionally enhanced by
  new provider type for Pacemaker)
- Custom key source for Debian(apt) is required in order
  to allow rabbitmq being installed by Puppet for intranet
  only faced hosts as well as internet faced ones.
  It also elliminates a hardcode for URL which is a kind of
  SPOF and 'limitation' for operators' freedom of choose.

Implements improvement: #MODULES-1407
Implements improvement: #MODULES-1408

Signed-off-by: Bogdan Dobrelya bdobrelia@mirantis.com
