### PR TITLE
Optimize check for RHEL GPG key

### DIFF
--- a/manifests/repo/rhel.pp
+++ b/manifests/repo/rhel.pp
@@ -6,7 +6,7 @@ class rabbitmq::repo::rhel {
 
   exec { "rpm --import ${package_gpg_key}":
     path   => ['/bin','/usr/bin','/sbin','/usr/sbin'],
-    onlyif => 'test `rpm -qa | grep gpg-pubkey-056e8e56-468e43f2 | wc -l` -eq 0',
+    unless => 'rpm -q gpg-pubkey-056e8e56-468e43f2 2>/dev/null',
   }
 
 }


### PR DESCRIPTION
Reduces the time to check for presence of
gpg pubkey for RabbitMQ from 1.6s to 0.1s.

Comparison:
$ time rpm -q gpg-pubkey-056e8e56-468e43f2a
package gpg-pubkey-056e8e56-468e43f2a is not installed

real    0m0.116s
user    0m0.008s
sys 0m0.004s

$ time test `rpm -qa | grep gpg-pubkey-056e8e56-468e43f2 | wc -l` -eq 0

real    0m1.650s
user    0m1.569s
sys 0m0.078s
