### PR TITLE
Add custom key content & service provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ class { '::rabbitmq':
 }
 ```
 
+Or such as offline installation from intranet or local mirrors:
+
+```puppet
+class { '::rabbitmq':
+   key_content      => template('openstack/rabbit.pub.key'),
+   package_gpg_key  => '/tmp/rabbit.pub.key',
+}
+```
+
+And this one will use external package key source for any (apt/rpm) package provider:
+
+```puppet
+class { '::rabbitmq':
+   package_gpg_key  => 'http://www.some_site.some_domain/some_key.pub.key',
+}
+```
+
 ### Environment Variables
 To use RabbitMQ Environment Variables, use the parameters `environment_variables` e.g.:
 
@@ -205,6 +222,11 @@ RabbitMQ Environment Variables in rabbitmq_env.config
 
 The erlang cookie to use for clustering - must be the same between all nodes.
 
+###`key_content`
+
+Uses content method for Debian OS family. Should be a template for apt::source
+class. Overrides `package_gpg_key` behavior, if enabled. Undefined by default.
+
 ####`ldap_auth`
 
 Boolean, set to true to enable LDAP auth.
@@ -248,7 +270,10 @@ be changed to latest.
 
 ####`package_gpg_key`
 
-RPM package GPG key to import.
+RPM package GPG key to import. Uses source method. Should be a URL for Debian/RedHat
+OS family, or a file name for RedHat OS family. 
+Set to http://www.rabbitmq.com/rabbitmq-signing-key-public.asc by default.
+Note, that `key_content`, if specified, would override this parameter for Debian OS family.
 
 ####`package_name`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,7 @@ class rabbitmq(
   $environment_variables      = $rabbitmq::params::environment_variables,
   $config_variables           = $rabbitmq::params::config_variables,
   $config_kernel_variables    = $rabbitmq::params::config_kernel_variables,
+  $key_content                = undef,
 ) inherits rabbitmq::params {
 
   validate_bool($admin_enable)
@@ -122,8 +123,12 @@ class rabbitmq(
     case $::osfamily {
       'RedHat', 'SUSE':
         { include '::rabbitmq::repo::rhel' }
-      'Debian':
-        { include '::rabbitmq::repo::apt' }
+      'Debian': {
+        class { '::rabbitmq::repo::apt' :
+          key_source  => $package_gpg_key,
+          key_content => $key_content,
+        }
+      }
       default:
         { }
     }

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -8,6 +8,7 @@ class rabbitmq::repo::apt(
   $include_src = false,
   $key         = '056E8E56',
   $key_source  = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
+  $key_content = undef,
   ) {
 
   $pin = $rabbitmq::package_apt_pin
@@ -21,6 +22,7 @@ class rabbitmq::repo::apt(
     include_src => $include_src,
     key         => $key,
     key_source  => $key_source,
+    key_content => $key_content,
   }
 
   if $pin {


### PR DESCRIPTION
Add key_content parameter for offline install
- Custom key source/content for Debian (apt module) is
  required in order to allow RabbitMQ being installed
  by Puppet for intranet only faced hosts as well as
  internet faced ones.
  It also elliminates a hardcode for URL which is a kind of
  SPOF and 'limitation' for operators' freedom of choose.
- Update docs

DocImpact
Implements improvement: #MODULES-1408

Signed-off-by: Bogdan Dobrelya bdobrelia@mirantis.com
