### PR TITLE
Configure ssl_listener in stomp only for ssl

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,6 +113,10 @@ class rabbitmq(
     fail('$ssl_only => true requires that $ssl => true')
   }
 
+  if $config_stomp and $ssl_stomp_port and ! $ssl {
+    warning('$ssl_stomp_port requires that $ssl => true and will be ignored')
+  }
+
   include '::rabbitmq::install'
   include '::rabbitmq::config'
   include '::rabbitmq::service'

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -255,11 +255,19 @@ describe 'rabbitmq' do
             })
           end
         end
+        describe 'stomp when set ssl port w/o ssl enabled' do
+          let(:params) {{ :config_stomp => true, :stomp_port => 5679, :ssl => false, :ssl_stomp_port => 5680 }}
+          it 'should not configure ssl_listeners in rabbitmq.config' do
+            should contain_file('rabbitmq.config').without({
+              'content' => /rabbitmq_stomp.*ssl_listeners, \[5680\]/m,
+            })
+          end
+        end
         describe 'stomp when set with ssl' do
-          let(:params) {{ :config_stomp => true, :stomp_port => 5679, :ssl_stomp_port => 5680 }}
+          let(:params) {{ :config_stomp => true, :stomp_port => 5679, :ssl => true, :ssl_stomp_port => 5680 }}
           it 'should specify stomp port and ssl stomp port in rabbitmq.config' do
-            contain_file('rabbitmq.config').with({
-              'content' => /rabbitmq_stomp.*tcp_listeners, \[5679\].*ssl_listeners, \[5680\]/,
+            should contain_file('rabbitmq.config').with({
+              'content' => /rabbitmq_stomp.*tcp_listeners, \[5679\].*ssl_listeners, \[5680\]/m,
             })
           end
         end

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -54,7 +54,7 @@
 % Configure the Stomp Plugin listening port
   {rabbitmq_stomp, [
     {tcp_listeners, [<%= @stomp_port %>]}
-  <%- if @ssl_stomp_port -%>,
+  <%- if @ssl && @ssl_stomp_port -%>,
     {ssl_listeners, [<%= @ssl_stomp_port %>]}
   <%- end -%>
   ]}


### PR DESCRIPTION
W/o this patch puppet will always configure
ssl_listener for stomp and rabbitmq service will
fail to start, if ssl => false.

The solution is to ignore ssl_stomp_port in
config_stomp stanza then ssl was not enabled
and issue a puppet warn about that as well.

Closes-bug: #MODULES-1414

Signed-off-by: Bogdan Dobrelya bdobrelia@mirantis.com
