### PR TITLE
Fix missing 'should' in rspecs

### DIFF
--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -19,7 +19,7 @@ describe 'rabbitmq' do
     describe 'apt::source default values' do
       let(:facts) {{ :osfamily => 'Debian' }}
       it 'should add a repo with defaults values' do
-        contain_file('/etc/apt/sources.list.d/rabbitmq.list')\
+        should contain_file('/etc/apt/sources.list.d/rabbitmq.list')\
           .with_content(%r|deb http\://www\.rabbitmq.com/debian/ testing main|)
       end
     end
@@ -31,7 +31,7 @@ describe 'rabbitmq' do
           :repos => 'main'
         }}
       it 'should add a repo with custom new values' do
-        contain_file('/etc/apt/sources.list.d/rabbitmq.list')\
+        should contain_file('/etc/apt/sources.list.d/rabbitmq.list')\
           .with_content(%r|deb http\://www\.foorepo.com/debian/ unstable main|)
       end
     end
@@ -235,7 +235,7 @@ describe 'rabbitmq' do
         describe 'node_ip_address when set' do
           let(:params) {{ :node_ip_address => '172.0.0.1' }}
           it 'should set RABBITMQ_NODE_IP_ADDRESS to specified value' do
-            contain_file('rabbitmq-env.config').with({
+            should contain_file('rabbitmq-env.config').with({
               'content' => 'RABBITMQ_NODE_IP_ADDRESS=172.0.0.1',
             })
           end
@@ -243,23 +243,23 @@ describe 'rabbitmq' do
 
         describe 'stomp by default' do
           it 'should not specify stomp parameters in rabbitmq.config' do
-            contain_file('rabbitmq.config').without({
+            should contain_file('rabbitmq.config').without({
               'content' => /stomp/,})
           end
         end
         describe 'stomp when set' do
           let(:params) {{ :config_stomp => true, :stomp_port => 5679 }}
           it 'should specify stomp port in rabbitmq.config' do
-            contain_file('rabbitmq.config').with({
-              'content' => /rabbitmq_stomp.*tcp_listeners, \[5679\]/,
+            should contain_file('rabbitmq.config').with({
+              'content' => /rabbitmq_stomp.*tcp_listeners, \[5679\]/m,
             })
           end
         end
         describe 'stomp when set with ssl' do
           let(:params) {{ :config_stomp => true, :stomp_port => 5679, :ssl_stomp_port => 5680 }}
           it 'should specify stomp port and ssl stomp port in rabbitmq.config' do
-            contain_file('rabbitmq.config').with({
-              'content' => /rabbitmq_stomp.*tcp_listeners, \[5679\].*ssl_listeners, \[5680\]/,
+            should contain_file('rabbitmq.config').with({
+              'content' => /rabbitmq_stomp.*tcp_listeners, \[5679\].*ssl_listeners, \[5680\]/m,
             })
           end
         end
@@ -316,8 +316,8 @@ describe 'rabbitmq' do
       describe 'default_user and default_pass set' do
         let(:params) {{ :default_user => 'foo', :default_pass => 'bar' }}
         it 'should set default_user and default_pass to specified values' do
-          contain_file('rabbitmq.config').with({
-            'content' => /default_user, <<"foo">>.*default_pass, <<"bar">>/,
+          should contain_file('rabbitmq.config').with({
+            'content' => /default_user, <<"foo">>.*default_pass, <<"bar">>/m,
           })
         end
       end
@@ -332,7 +332,7 @@ describe 'rabbitmq' do
         } }
 
         it 'should set ssl options to specified values' do
-          contain_file('rabbitmq.config').with({
+          should contain_file('rabbitmq.config').with({
             'content' => %r|ssl_listeners, \[3141\].*
             ssl_options, \[\{cacertfile,"/path/to/cacert".*
             certfile="/path/to/cert".*
@@ -352,7 +352,7 @@ describe 'rabbitmq' do
         } }
 
         it 'should set ssl options to specified values' do
-          contain_file('rabbitmq.config').with({
+          should contain_file('rabbitmq.config').with({
             'content' => %r|tcp_listeners, \[\].*
             ssl_listeners, \[3141\].*
             ssl_options, \[\{cacertfile,"/path/to/cacert".*
@@ -373,7 +373,7 @@ describe 'rabbitmq' do
         } }
 
         it 'should set rabbitmq_management ssl options to specified values' do
-          contain_file('rabbitmq.config').with({
+          should contain_file('rabbitmq.config').with({
             'content' => %r|\{rabbitmq_management, \[.*
                           \{listener, \[.*
                           \{port, 3141\},.*
@@ -394,11 +394,11 @@ describe 'rabbitmq' do
         } }
 
         it 'should set rabbitmq_management  options to specified values' do
-          contain_file('rabbitmq.config').with({
+          should contain_file('rabbitmq.config').with({
             'content' => /\{rabbitmq_management, \[.*
                           \{listener, \[.*
                           \{port, 3141\},.*
-                          \]\}/,
+                          \]\}/m,
           })
         end
       end
@@ -414,7 +414,7 @@ describe 'rabbitmq' do
         } }
 
         it 'should set rabbitmq_management ssl options to specified values' do
-          contain_file('rabbitmq.config').with({
+          should contain_file('rabbitmq.config').with({
             'content' => %r|\{rabbitmq_management, \[.*
                           \{listener, \[.*
                           \{port, 3141\},.*
@@ -435,11 +435,11 @@ describe 'rabbitmq' do
         } }
 
         it 'should set rabbitmq_management  options to specified values' do
-          contain_file('rabbitmq.config').with({
+          should contain_file('rabbitmq.config').with({
             'content' => /\{rabbitmq_management, \[.*
                           \{listener, \[.*
                           \{port, 3141\},.*
-                          \]\}/,
+                          \]\}/m,
           })
         end
       end


### PR DESCRIPTION
W/o this fix, rspec tests will continue
report false positives for many test cases
with config_file involved allowing even
more regressions to be accepted and merged
in master branch.

Fix contains missing 'should' and multiline
regex (/.*/m) statements.

Note: Perhaps, this fix should be merged
despite on CI failure. The failure is natural
for this specific case only, due to multiple
regressions had been accepted while tests
were reporting false positives results.
And in order to fix failing tests later, all
of these regressions should be assdessed by
other patches as well.

Closes-bug: #MODULES-1416

Signed-off-by: Bogdan Dobrelya bdobrelia@mirantis.com
