### PR TITLE
Make provider to wait for rabbitmq cluster

### DIFF
--- a/lib/puppet/provider/rabbitmq_common.rb
+++ b/lib/puppet/provider/rabbitmq_common.rb
@@ -1,0 +1,34 @@
+require 'rubygems'
+require 'puppet'
+require 'puppet/util'
+require 'puppet/util/execution'
+
+module RabbitmqCommon
+  # Wait 'count*step' seconds while RabbitMQ is ready (able to list its users&channels)
+  # Make 'count' retries with 'step' delay between retries.
+  # Limit each query time by 'timeout'
+  def wait_for_rabbitmq(count=30, step=6, timeout=10)
+    (0...count).each do |n|
+      begin
+        # Note, that then RabbitMQ cluster is broken or not ready, it might not show its
+        # channels some times and hangs for ever, so we have to specify a timeout as well
+        Timeout::timeout(timeout) do
+          if Puppet::Util::Execution.respond_to? :execute
+            Puppet::Util::Execution.execute 'rabbitmqctl list_users'
+            Puppet::Util::Execution.execute 'rabbitmqctl list_channels'
+          else
+            Puppet::Util.execute 'rabbitmqctl list_users'
+            Puppet::Util.execute 'rabbitmqctl list_channels'
+          end
+        end
+      rescue Puppet::ExecutionFailure, Timeout
+        Puppet.debug "RabbitMQ is not ready, retrying"
+        sleep step
+      else
+        Puppet.debug "RabbitMQ is online after #{n * step} seconds"
+        return true
+      end
+    end
+    raise Puppet::Error, "RabbitMQ is not ready after #{count * step} seconds expired!"
+  end
+end

--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -1,5 +1,6 @@
-require 'puppet'
-Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin) do
+require File.join File.dirname(__FILE__), '../rabbitmq_wait.rb'
+
+Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin, :parent => Puppet::Provider::Rabbitmq_wait) do
 
   if Puppet::PUPPETVERSION.to_f < 3
     commands :rabbitmqctl   => 'rabbitmqctl'
@@ -45,6 +46,7 @@ Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin) do
   end
 
   def self.instances
+    self.wait_for_rabbitmq
     resources = []
     all_vhosts.each do |vhost|
         all_exchanges(vhost).collect do |line|
@@ -67,6 +69,7 @@ Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin) do
   end
 
   def self.prefetch(resources)
+    self.wait_for_rabbitmq
     packages = instances
     resources.keys.each do |name|
       if provider = packages.find{ |pkg| pkg.name == name }
@@ -76,6 +79,7 @@ Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin) do
   end
 
   def exists?
+    wait_for_rabbitmq
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
+++ b/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
@@ -1,4 +1,6 @@
-Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins) do
+require File.join File.dirname(__FILE__), '../rabbitmq_wait.rb'
+
+Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins, :parent => Puppet::Provider::Rabbitmq_wait) do
 
   if Puppet::PUPPETVERSION.to_f < 3
     if Facter.value(:osfamily) == 'RedHat'
@@ -21,6 +23,7 @@ Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins) do
   defaultfor :feature => :posix
 
   def self.instances
+    self.wait_for_rabbitmq
     rabbitmqplugins('list', '-E').split(/\n/).map do |line|
       if line.split(/\s+/)[1] =~ /^(\S+)$/
         new(:name => $1)
@@ -39,6 +42,7 @@ Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins) do
   end
 
   def exists?
+    wait_for_rabbitmq
     rabbitmqplugins('list', '-E').split(/\n/).detect do |line|
       line.split(/\s+/)[1].match(/^#{resource[:name]}$/)
     end

--- a/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
@@ -1,4 +1,6 @@
-Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl) do
+require File.join File.dirname(__FILE__), '../rabbitmq_wait.rb'
+
+Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl, :parent => Puppet::Provider::Rabbitmq_wait) do
 
   if Puppet::PUPPETVERSION.to_f < 3
     commands :rabbitmqctl => 'rabbitmqctl'
@@ -51,7 +53,7 @@ Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl) do
     resource[:configure_permission] ||= "''"
     resource[:read_permission]      ||= "''"
     resource[:write_permission]     ||= "''"
-    rabbitmqctl('set_permissions', '-p', should_vhost, should_user, resource[:configure_permission], resource[:write_permission], resource[:read_permission]) 
+    rabbitmqctl('set_permissions', '-p', should_vhost, should_user, resource[:configure_permission], resource[:write_permission], resource[:read_permission])
   end
 
   def destroy
@@ -61,6 +63,7 @@ Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl) do
   # I am implementing prefetching in exists b/c I need to be sure
   # that the rabbitmq package is installed before I make this call.
   def exists?
+    wait_for_rabbitmq
     users(should_user, should_vhost)
   end
 

--- a/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
@@ -1,4 +1,6 @@
-Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl) do
+require File.join File.dirname(__FILE__), '../rabbitmq_wait.rb'
+
+Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl, :parent => Puppet::Provider::Rabbitmq_wait) do
 
   if Puppet::PUPPETVERSION.to_f < 3
     commands :rabbitmqctl => 'rabbitmqctl'
@@ -9,6 +11,7 @@ Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl) do
   end
 
   def self.instances
+    self.wait_for_rabbitmq
     rabbitmqctl('list_vhosts').split(/\n/)[1..-2].map do |line|
       if line =~ /^(\S+)$/
         new(:name => $1)
@@ -27,6 +30,7 @@ Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl) do
   end
 
   def exists?
+    wait_for_rabbitmq
     out = rabbitmqctl('list_vhosts').split(/\n/)[1..-2].detect do |line|
       line.match(/^#{Regexp.escape(resource[:name])}$/)
     end

--- a/lib/puppet/provider/rabbitmq_wait.rb
+++ b/lib/puppet/provider/rabbitmq_wait.rb
@@ -1,0 +1,10 @@
+require File.join File.dirname(__FILE__), './rabbitmq_common.rb'
+
+# Abstract
+class Puppet::Provider::Rabbitmq_wait < Puppet::Provider
+
+  private
+
+  include RabbitmqCommon
+  extend RabbitmqCommon
+end

--- a/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
@@ -1,5 +1,7 @@
 require 'puppet'
 require 'mocha'
+require 'puppet/util'
+require 'puppet/util/execution'
 RSpec.configure do |config|
   config.mock_with :mocha
 end
@@ -11,9 +13,20 @@ describe provider_class do
        :type => :topic}
     )
     @provider = provider_class.new(@resource)
+    if Puppet::Util::Execution.respond_to? :execute
+      Puppet::Util::Execution.stubs(:execute).returns(0)
+    else
+      Puppet::Util.stubs(:execute).returns(0)
+    end
+  end
+
+  it 'should wait for rabbit on exists?' do
+    @provider.expects(:wait_for_rabbitmq).once
+    @provider.exists?
   end
 
   it 'should return instances' do
+    provider_class.expects(:wait_for_rabbitmq).once
     provider_class.expects(:rabbitmqctl).with('list_vhosts').returns <<-EOT
 Listing vhosts ...
 /

--- a/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
@@ -1,5 +1,7 @@
 require 'puppet'
 require 'mocha'
+require 'puppet/util'
+require 'puppet/util/execution'
 RSpec.configure do |config|
   config.mock_with :mocha
 end
@@ -10,8 +12,14 @@ describe provider_class do
       {:name => 'foo', :password => 'bar'}
     )
     @provider = provider_class.new(@resource)
+    if Puppet::Util::Execution.respond_to? :execute
+      Puppet::Util::Execution.stubs(:execute).returns(0)
+    else
+      Puppet::Util.stubs(:execute).returns(0)
+    end
   end
   it 'should match user names' do
+    @provider.expects(:wait_for_rabbitmq).once
     @provider.expects(:rabbitmqctl).with('list_users').returns <<-EOT
 Listing users ...
 foo
@@ -20,6 +28,7 @@ EOT
     @provider.exists?.should == 'foo'
   end
   it 'should match user names with 2.4.1 syntax' do
+    @provider.expects(:wait_for_rabbitmq).once
     @provider.expects(:rabbitmqctl).with('list_users').returns <<-EOT
 Listing users ...
 foo bar
@@ -28,6 +37,7 @@ EOT
     @provider.exists?.should == 'foo bar'
   end
   it 'should not match if no users on system' do
+    @provider.expects(:wait_for_rabbitmq).once
     @provider.expects(:rabbitmqctl).with('list_users').returns <<-EOT
 Listing users ...
 ...done.
@@ -35,6 +45,7 @@ EOT
     @provider.exists?.should be_nil
   end
   it 'should not match if no matching users on system' do
+    @provider.expects(:wait_for_rabbitmq).once
     @provider.expects(:rabbitmqctl).with('list_users').returns <<-EOT
 Listing users ...
 fooey
@@ -43,6 +54,7 @@ EOT
     @provider.exists?.should be_nil
   end
   it 'should match user names from list' do
+    @provider.expects(:wait_for_rabbitmq).once
     @provider.expects(:rabbitmqctl).with('list_users').returns <<-EOT
 Listing users ...
 one

--- a/spec/unit/puppet/provider/rabbitmq_vhost/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_vhost/rabbitmqctl_spec.rb
@@ -12,6 +12,7 @@ describe provider_class do
     @provider = provider_class.new(@resource)
   end
   it 'should match vhost names' do
+    @provider.expects(:wait_for_rabbitmq).once
     @provider.expects(:rabbitmqctl).with('list_vhosts').returns <<-EOT
 Listing vhosts ...
 foo
@@ -20,6 +21,7 @@ EOT
     @provider.exists?.should == 'foo'
   end
   it 'should not match if no vhosts on system' do
+    @provider.expects(:wait_for_rabbitmq).once
     @provider.expects(:rabbitmqctl).with('list_vhosts').returns <<-EOT
 Listing vhosts ...
 ...done.
@@ -27,6 +29,7 @@ EOT
     @provider.exists?.should be_nil
   end
   it 'should not match if no matching vhosts on system' do
+    @provider.expects(:wait_for_rabbitmq).once
     @provider.expects(:rabbitmqctl).with('list_vhosts').returns <<-EOT
 Listing vhosts ...
 fooey


### PR DESCRIPTION
W/o this fix, then RabbitMQ put in a cluster and managed
by Pacemaker, rabbitmqctl/rabbitmqadmin can fail their
requests due to cluster is not ready yet.

The solution is:
1) introduce rabbitmq_common module with a common functions
for rabbitmq providers, the first one is wait_for_rabbitmq. 
2) Add an abstract provider rabbitmq_wait containing wait_for_rabbitmq
as a class methods for providers to ensure rabbitmqctl or
rabbitmq_admin call will retry instead of fail then cluster is not ready.
3) Derive rabbitmq provider classes from the former one to make
them able to wait for RabbitMQ reasy as well.
4) Update rspecs

Co-authors: Dmitry Ilyin dilyin@mirantis.com
Closes-bug: #MODULES-1452

Signed-off-by: Bogdan Dobrelya bdobrelia@mirantis.com
