### PR TITLE
patch README, warn of BUG, that rabbitmq_user is not idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,14 @@ Boolean to determine if we should DESTROY AND DELETE the RabbitMQ database.
 
 query all current users: `$ puppet resource rabbitmq_user`
 
+WARNING: These providers are buggy.  They lack idempotence.  On subsequent puppet runs 
+this resource will complain that the user already exists and you will need to comment out 
+this provider's invocation in your manifests, or other resources which depend on it 
+will fail.  The ruby aware can patch this issue in:  
+
+       lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+
+
 ```
 rabbitmq_user { 'dan':
   admin    => true,


### PR DESCRIPTION
If my ruby skills were stronger, or if I had an hour or two to sort out how to write an effective conditional in ruby, I would offer you a real code patch.  But in the mean time, this documentation patch would have saved me an hour or two a few days ago; and another new user who posted on this issue in IRC this morning another hour.  I suspect we are not the only ones tripped up by this issue.  

FYI: I would have used https://tickets.puppetlabs.com/ to report this issue, but I have never been able to log in there and have my session last long enough to post a ticket.  The broken state of that interface has cost you probably a dozen bug reports from me alone over the past year on puppetlabs modules.  I have reported the issue through the link provided there, but never heard back.  

It seems that Pull Requests are the only way you folks are willing to receive contributions from the community, or at least from this community member.  
