### PR TITLE
fixes for RabbitMQ 3.4.0

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -13,7 +13,11 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
   defaultfor :feature => :posix
 
   def self.instances
-    rabbitmqctl('list_users').split(/\n/)[1..-2].collect do |line|
+    # RabbitMQ 3.4.0 and up no longer include the "...done." at the end
+    users_split = rabbitmqctl('list_users').split(/\n/)
+    users = users_split[-1] == "...done." ? users_split[1..-2] : users_split[1..-1]
+
+    users.collect do |line|
       if line =~ /^(\S+)(\s+\[.*?\]|)$/
         new(:name => $1)
       else
@@ -37,7 +41,11 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
   end
 
   def exists?
-    rabbitmqctl('list_users').split(/\n/)[1..-2].detect do |line|
+    # RabbitMQ 3.4.0 and up no longer include the "...done." at the end
+    users_split = rabbitmqctl('list_users').split(/\n/)
+    users = users_split[-1] == "...done." ? users_split[1..-2] : users_split[1..-1]
+
+    users.detect do |line|
       line.match(/^#{Regexp.escape(resource[:name])}(\s+(\[.*?\]|\S+)|)$/)
     end
   end
@@ -90,7 +98,11 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl) do
 
   private
   def get_user_tags
-    match = rabbitmqctl('list_users').split(/\n/)[1..-2].collect do |line|
+    # RabbitMQ 3.4.0 and up no longer include the "...done." at the end
+    users_split = rabbitmqctl('list_users').split(/\n/)
+    users = users_split[-1] == "...done." ? users_split[1..-2] : users_split[1..-1]
+
+    match = users.collect do |line|
       line.match(/^#{Regexp.escape(resource[:name])}\s+\[(.*?)\]/)
     end.compact.first
     Set.new(match[1].split(/, /)) if match

--- a/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
@@ -15,7 +15,11 @@ Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl) do
     @users = {} unless @users
     unless @users[name]
       @users[name] = {}
-      rabbitmqctl('list_user_permissions', name).split(/\n/)[1..-2].each do |line|
+      # RabbitMQ 3.4.0 and up no longer include the "...done." at the end
+      user_perms_split = rabbitmqctl('list_user_permissions', name).split(/\n/)
+      user_perms = user_perms_split[-1] == "...done." ? user_perms_split[1..-2] : user_perms_split[1..-1]
+
+      user_perms.each do |line|
         if line =~ /^(\S+)\s+(\S*)\s+(\S*)\s+(\S*)$/
           @users[name][$1] =
             {:configure => $2, :read => $4, :write => $3}

--- a/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
@@ -9,7 +9,11 @@ Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl) do
   end
 
   def self.instances
-    rabbitmqctl('list_vhosts').split(/\n/)[1..-2].map do |line|
+  # RabbitMQ 3.4.0 and up no longer include the "...done." at the end
+  vhosts_split = rabbitmqctl('list_vhosts').split(/\n/)
+  vhosts = vhosts_split[-1] == "...done." ? vhosts_split[1..-2] : vhosts_split[1..-1]
+
+  vhosts.map do |line|
       if line =~ /^(\S+)$/
         new(:name => $1)
       else
@@ -27,7 +31,10 @@ Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl) do
   end
 
   def exists?
-    out = rabbitmqctl('list_vhosts').split(/\n/)[1..-2].detect do |line|
+    vhosts_split = rabbitmqctl('list_vhosts').split(/\n/)
+    vhosts = vhosts_split[-1] == "...done." ? vhosts_split[1..-2] : vhosts_split[1..-1]
+
+    vhosts.detect do |line|
       line.match(/^#{Regexp.escape(resource[:name])}$/)
     end
   end


### PR DESCRIPTION
RabbitMQ 3.4.0 and higher do away with the "...done." at the end of rabbitmqctl's list commands, so this change checks to see if the split command output ends with "...done." and slices the array appropriately.
