### PR TITLE
create .rabbitmqadmin.conf for rabbitmq_exchange provider

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -87,6 +87,15 @@ class rabbitmq::config {
     notify  => Class['rabbitmq::service'],
   }
 
+  file { 'rabbitmqadmin.conf':
+    ensure  => file,
+    path    => '/tmp/.rabbitmqadmin.conf',
+    content => template('rabbitmq/rabbitmqadmin.conf.erb'),
+    owner   => '0',
+    group   => '0',
+    mode    => '0644',
+  }
+
 
   if $config_cluster {
 

--- a/templates/rabbitmqadmin.conf.erb
+++ b/templates/rabbitmqadmin.conf.erb
@@ -1,0 +1,8 @@
+[default]
+<% if @ssl -%>
+ssl = True
+port = <%= @ssl_management_port %>
+<% else -%>
+ssl = False
+port = <%= @management_port %>
+<% end -%>


### PR DESCRIPTION
Commit 7f5a21f introduced configuring of SSL for the rabbitmq web management UI. This broken any providers which used `rabbitmqadmin` as they had no way of knowing what port to connect to (by default it connects to port 15672) or if it needed SSL. This pull request creates `/tmp/.rabbitmqadmin.conf` as the provider sets `$HOME` to be `/tmp` as `rabbitmqadmin` checks for its `.rabbitmqadmin.conf` in `$HOME/.rabbitmqadmin.conf`.
