### PR TITLE
Use -m flag on rabbitmq-plugins command for managing rabbitmq_plugin res...

### DIFF
--- a/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
+++ b/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
@@ -21,8 +21,8 @@ Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins) do
   defaultfor :feature => :posix
 
   def self.instances
-    rabbitmqplugins('list', '-E').split(/\n/).map do |line|
-      if line.split(/\s+/)[1] =~ /^(\S+)$/
+    rabbitmqplugins('list', '-E', '-m').split(/\n/).map do |line|
+      if line =~ /^(\S+)$/
         new(:name => $1)
       else
         raise Puppet::Error, "Cannot parse invalid plugins line: #{line}"
@@ -39,8 +39,8 @@ Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins) do
   end
 
   def exists?
-    rabbitmqplugins('list', '-E').split(/\n/).detect do |line|
-      line.split(/\s+/)[1].match(/^#{resource[:name]}$/)
+    rabbitmqplugins('list', '-E', '-m').split(/\n/).detect do |line|
+      line.match(/^#{resource[:name]}$/)
     end
   end
 


### PR DESCRIPTION
...ources

Use the -m flag for calls to the rabbitmq-plugins command, which enables minimal
output mode.  This is much easier and more reliable to parse.

Fixes an issue under RMQ 3.4.0 where rabbitmq_plugin resources were being enabled
on every Puppet run, even though they are already enabled.
