### PR TITLE
Use 16char keyid for rabbit repo

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -6,7 +6,7 @@ class rabbitmq::repo::apt(
   $release     = 'testing',
   $repos       = 'main',
   $include_src = false,
-  $key         = '056E8E56',
+  $key         = 'F7B8CEA6056E8E56',
   $key_source  = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
   $key_content = undef,
   ) {


### PR DESCRIPTION
The 8char keyids are easier to collide.
