### PR TITLE
Adds clarification that epel is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ all features against earlier versions.
 
 ###Beginning with rabbitmq  
 
-If running CentOS/RHEL, ensure the epel repo is present first.
 
 ```puppet
 include '::rabbitmq'
@@ -444,6 +443,9 @@ The module has been tested on:
 Testing on other platforms has been light and cannot be guaranteed.
 
 ### Module dependencies
+
+If running CentOS/RHEL, and using the yum provider, ensure the epel repo is present.
+
 To have a suitable erlang version installed on RedHat and Debian systems,
 you have to install another puppet module from http://forge.puppetlabs.com/garethr/erlang with:
 


### PR DESCRIPTION
Resolves issue MODULES-1419
On Centos, you will get an error if epel isn't present. Clarifies this in the documentation.
