### PR TITLE
Fix spec tests

### DIFF
--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -602,7 +602,7 @@ describe 'rabbitmq' do
           'release'     => 'testing',
           'repos'       => 'main',
           'include_src' => false,
-          'key'         => '056E8E56'
+          'key'         => 'F7B8CEA6056E8E56'
         ) }
       end
     end
@@ -616,7 +616,7 @@ describe 'rabbitmq' do
           'release'     => 'testing',
           'repos'       => 'main',
           'include_src' => false,
-          'key'         => '056E8E56'
+          'key'         => 'F7B8CEA6056E8E56'
         ) }
 
         it { should contain_apt__pin('rabbitmq').with(


### PR DESCRIPTION
https://github.com/puppetlabs/puppetlabs-rabbitmq/pull/259 updated the
apt key without updating the tests for it. This patch fixes the tests.
