### PR TITLE
Remove comments referencing redmine and anchors

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,9 +169,6 @@ class rabbitmq(
     }
   }
 
-  # Anchor this as per #8040 - this ensures that classes won't float off and
-  # mess everything up.  You can read about this at:
-  # http://docs.puppetlabs.com/puppet/2.7/reference/lang_containment.html#known-issues
   anchor { 'rabbitmq::begin': }
   anchor { 'rabbitmq::end': }
 


### PR DESCRIPTION
Redmine is gone (Long Live Jira) and the anchor pattern is now
well established and doesn't need special pointers.
