### PR TITLE
Pin nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development, :test do
   gem 'beaker',                  :require => false
   gem 'beaker-rspec',            :require => false
   gem 'pry',                     :require => false
+  gem 'nokogiri', '1.5.11',      :require => false # pin to make TravisCI happy
 end
 
 if facterversion = ENV['FACTER_GEM_VERSION']


### PR DESCRIPTION
For unknown reasons TravisCI is attempting to install nokogiri 1.6.5 on
Ruby 1.8.7 builds, which are not compatible together. This commit
forcibly pins nokogiri so that TravisCI can run.
