### PR TITLE
Pin beaker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :development, :test do
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'puppet-lint',             :require => false
   gem 'serverspec',              :require => false
-  gem 'beaker',                  :require => false
+  gem 'beaker', '~>1.0',         :require => false
   gem 'beaker-rspec',            :require => false
   gem 'pry',                     :require => false
 end


### PR DESCRIPTION
Beaker 2.0 dropped support for Ruby 1.8.7 and adds dependencies on gems
that are incompatible with 1.8.7. This patch pins beaker until we drop
support for 1.8.7.
