### PR TITLE
(MODULES-636) Allow version to be user-defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,12 @@ What provider to use to install the package.
 
 Where should the package be installed from?
 
+On Debian- and Arch-based systems using the default package provider,
+this parameter is ignored and the package is installed from the
+rabbitmq repository, if enabled with manage_repo => true, or from the
+system repository otherwise. If you want to use dpkg as the
+package_provider, you must specify a local package_source.
+
 ####`plugin_dir`
 
 Location of RabbitMQ plugins.
@@ -360,6 +366,11 @@ Boolean to enable TCP connection keepalive for RabbitMQ service.
 ####`version`
 
 Sets the version to install.
+
+On Debian- and Arch-based operating systems, the version parameter is
+ignored and the latest version is installed from the rabbitmq
+repository, if enabled with manage_repo => true, or from the system
+repository otherwise.
 
 ####`wipe_db_on_cookie_change`
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,7 +5,7 @@ class rabbitmq::install {
   $package_ensure   = $rabbitmq::package_ensure
   $package_name     = $rabbitmq::package_name
   $package_provider = $rabbitmq::package_provider
-  $package_source   = $rabbitmq::package_source
+  $package_source   = $rabbitmq::real_package_source
 
   package { 'rabbitmq-server':
     ensure   => $package_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,17 +9,13 @@ class rabbitmq::params {
       $package_ensure   = 'installed'
       $package_name     = 'rabbitmq'
       $service_name     = 'rabbitmq'
-      $package_source   = ''
       $version          = '3.1.3-1'
-      $base_version     = regsubst($version,'^(.*)-\d$','\1')
-      # This must remain at the end as we need $base_version and $version defined first
     }
     'Debian': {
       $package_ensure   = 'installed'
       $package_name     = 'rabbitmq-server'
       $service_name     = 'rabbitmq-server'
       $package_provider = 'apt'
-      $package_source   = ''
       $version          = '3.1.5'
     }
     'RedHat': {
@@ -28,9 +24,6 @@ class rabbitmq::params {
       $service_name     = 'rabbitmq-server'
       $package_provider = 'rpm'
       $version          = '3.1.5-1'
-      $base_version     = regsubst($version,'^(.*)-\d$','\1')
-      # This must remain at the end as we need $base_version and $version defined first.
-      $package_source   = "http://www.rabbitmq.com/releases/rabbitmq-server/v${base_version}/rabbitmq-server-${version}.noarch.rpm"
     }
     'SUSE': {
       $package_ensure   = 'installed'
@@ -38,9 +31,6 @@ class rabbitmq::params {
       $service_name     = 'rabbitmq-server'
       $package_provider = 'zypper'
       $version          = '3.1.5-1'
-      $base_version     = regsubst($version,'^(.*)-\d$','\1')
-      # This must remain at the end as we need $base_version and $version defined first.
-      $package_source   = "http://www.rabbitmq.com/releases/rabbitmq-server/v${base_version}/rabbitmq-server-${version}.noarch.rpm"
     }
     default: {
       fail("The ${module_name} module is not supported on an ${::osfamily} based system.")


### PR DESCRIPTION
Without this patch, the rabbitmq class defines a package source for
RedHat and Suse systems in params.pp, based on the version in
params.pp. This means that the version is not overrideable. This patch
moves the construction of the RPM package source to the rabbitmq class
so that it takes into account the version that a user has defined, if
any. It also adds clarification about the behavior of the
package_source and version parameters for systems that don't use RPM.
