### PR TITLE
Installation of the rabbitmqadmin script fails when SSL is enabled. This...

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -1,7 +1,13 @@
 #
 class rabbitmq::install::rabbitmqadmin {
 
-  $management_port = $rabbitmq::management_port
+  if($rabbitmq::ssl) {
+    $management_port = $rabbitmq::ssl_management_port
+  }
+  else {
+    $management_port = $rabbitmq::management_port
+  }
+
   $default_user = $rabbitmq::default_user
   $default_pass = $rabbitmq::default_pass
   $protocol = $rabbitmq::ssl ? { false => 'http', default => 'https' }
@@ -9,7 +15,7 @@ class rabbitmq::install::rabbitmqadmin {
   staging::file { 'rabbitmqadmin':
     target      => '/var/lib/rabbitmq/rabbitmqadmin',
     source      => "${protocol}://${default_user}:${default_pass}@localhost:${management_port}/cli/rabbitmqadmin",
-    curl_option => '--noproxy localhost',
+    curl_option => '-k --noproxy localhost',
     wget_option => '--no-proxy',
     require     => [
       Class['rabbitmq::service'],


### PR DESCRIPTION
... is fixed by using ::ssl_management_port when SSL is enabled.

Conflicts:
    manifests/install/rabbitmqadmin.pp

Cherry-picks #258 
