### PR TITLE
Fix lint errors in ldap_user_dn_example parameter

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,9 +77,7 @@ class rabbitmq::params {
   $stomp_ensure               = false
   $ldap_auth                  = false
   $ldap_server                = 'ldap'
-  # lint:ignore:variable_scope
-  $ldap_user_dn_pattern       = "cn=${username},ou=People,dc=example,dc=com"
-  # lint:endignore
+  $ldap_user_dn_pattern       = 'cn=username,ou=People,dc=example,dc=com'
   $ldap_use_ssl               = false
   $ldap_port                  = '389'
   $ldap_log                   = false


### PR DESCRIPTION
There is no $username variable anywhere in the rabbitmq module.
${username} is not a valid cn. While most likely no one was using
dc=example,dc=com anyway, this patch at least changes the example value
to one that lints.
