### PR TITLE
Remove deprecated parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,6 @@ class { 'rabbitmq':
 
 Boolean, if enabled sets up the management interface/plugin for RabbitMQ.
 
-####`cluster_disk_nodes`
-
-DEPRECATED AND REPLACED BY CLUSTER_NODES.
-
 ####`cluster_node_type`
 
 Choose between disk and ram nodes.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,6 @@
 class rabbitmq::config {
 
   $admin_enable               = $rabbitmq::admin_enable
-  $cluster_disk_nodes         = $rabbitmq::cluster_disk_nodes
   $cluster_node_type          = $rabbitmq::cluster_node_type
   $cluster_nodes              = $rabbitmq::cluster_nodes
   $config                     = $rabbitmq::config
@@ -44,14 +43,6 @@ class rabbitmq::config {
 
   # Handle env variables.
   $environment_variables = merge($default_env_variables, $rabbitmq::environment_variables)
-
-  # Handle deprecated option.
-  if $cluster_disk_nodes != [] {
-    warning('The $cluster_disk_nodes is deprecated. Use $cluster_nodes instead.')
-    $r_cluster_nodes = $cluster_disk_nodes
-  } else {
-    $r_cluster_nodes = $cluster_nodes
-  }
 
   file { '/etc/rabbitmq':
     ensure => directory,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,6 @@
 # Main rabbitmq class
 class rabbitmq(
   $admin_enable               = $rabbitmq::params::admin_enable,
-  $cluster_disk_nodes         = $rabbitmq::params::cluster_disk_nodes,
   $cluster_node_type          = $rabbitmq::params::cluster_node_type,
   $cluster_nodes              = $rabbitmq::params::cluster_nodes,
   $config                     = $rabbitmq::params::config,
@@ -67,7 +66,6 @@ class rabbitmq(
   validate_bool($repos_ensure)
   validate_re($version, '^\d+\.\d+\.\d+(-\d+)*$') # Allow 3 digits and optional -n postfix.
   # Validate config parameters.
-  validate_array($cluster_disk_nodes)
   validate_re($cluster_node_type, '^(ram|disc|disk)$') # Both disc and disk are valid http://www.rabbitmq.com/clustering.html
   validate_array($cluster_nodes)
   validate_string($config)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,7 +47,6 @@ class rabbitmq::params {
   $service_ensure             = 'running'
   $service_manage             = true
   #config
-  $cluster_disk_nodes         = []
   $cluster_node_type          = 'disc'
   $cluster_nodes              = []
   $config                     = 'rabbitmq/rabbitmq.config.erb'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -14,8 +14,6 @@
 #  [*config*] - contents of config file
 #  [*env_config*] - contents of env-config file
 #  [*config_cluster*] - whether to configure a RabbitMQ cluster
-#  [*config_mirrored_queues*] - DEPRECATED (doesn't do anything)
-#  [*cluster_disk_nodes*] - DEPRECATED (use cluster_nodes instead)
 #  [*cluster_nodes*] - which nodes to cluster with (including the current one)
 #  [*cluster_node_type*] - Type of cluster node (disc/disk or ram)
 #  [*erlang_cookie*] - erlang cookie, must be the same for all nodes in a cluster
@@ -45,7 +43,6 @@ class rabbitmq::server(
   $config_stomp             = $rabbitmq::params::config_stomp,
   $stomp_port               = $rabbitmq::params::stomp_port,
   $config_cluster           = $rabbitmq::params::config_cluster,
-  $cluster_disk_nodes       = $rabbitmq::params::cluster_disk_nodes,
   $cluster_nodes            = $rabbitmq::params::cluster_nodes,
   $cluster_node_type        = $rabbitmq::params::cluster_node_type,
   $node_ip_address          = $rabbitmq::params::node_ip_address,
@@ -53,21 +50,7 @@ class rabbitmq::server(
   $env_config               = $rabbitmq::params::env_config,
   $erlang_cookie            = $rabbitmq::params::erlang_cookie,
   $wipe_db_on_cookie_change = $rabbitmq::params::wipe_db_on_cookie_change,
-  # DEPRECATED
-  $manage_service           = undef,
-  $config_mirrored_queues   = undef,
 ) inherits rabbitmq::params {
-
-  if $manage_service != undef {
-    warning('The $manage_service parameter is deprecated; please use $service_manage instead')
-    $_service_manage = $manage_service
-  } else {
-    $_service_manage = $service_manage
-  }
-
-  if $config_mirrored_queues != undef {
-    warning('The $config_mirrored_queues parameter is deprecated; it does not affect anything')
-  }
 
   anchor {'before::rabbimq::class':
     before => Class['rabbitmq'],
@@ -84,11 +67,10 @@ class rabbitmq::server(
     version                  => $version,
     service_name             => $service_name,
     service_ensure           => $service_ensure,
-    service_manage           => $_service_manage,
+    service_manage           => $service_manage,
     config_stomp             => $config_stomp,
     stomp_port               => $stomp_port,
     config_cluster           => $config_cluster,
-    cluster_disk_nodes       => $cluster_disk_nodes,
     cluster_nodes            => $cluster_nodes,
     cluster_node_type        => $cluster_node_type,
     node_ip_address          => $node_ip_address,

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -6,7 +6,7 @@
     {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_ldap]},
 <% end -%>
 <% if @config_cluster -%>
-    {cluster_nodes, {[<%= @r_cluster_nodes.map { |n| "\'rabbit@#{n}\'" }.join(', ') %>], <%= @cluster_node_type %>}},
+    {cluster_nodes, {[<%= @cluster_nodes.map { |n| "\'rabbit@#{n}\'" }.join(', ') %>], <%= @cluster_node_type %>}},
     {cluster_partition_handling, <%= @cluster_partition_handling %>},
 <% end -%>
 <%- if @tcp_keepalive -%>


### PR DESCRIPTION
All parameters removed in this patch were deprecated prior to
3.0.0. It is time to let them go.
