### PR TITLE
Add support to uninstall rabbitmq plugins.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -223,52 +223,48 @@ class rabbitmq(
     }
   }
 
-  if $admin_enable and $service_manage {
+  $admin_ensure = $admin_enable and $service_manage
+
+  if $admin_ensure {
     include '::rabbitmq::install::rabbitmqadmin'
-
-    rabbitmq_plugin { 'rabbitmq_management':
-      ensure   => present,
-      require  => Class['rabbitmq::install'],
-      notify   => Class['rabbitmq::service'],
-      provider => 'rabbitmqplugins',
-    }
-
     Class['::rabbitmq::service'] -> Class['::rabbitmq::install::rabbitmqadmin']
     Class['::rabbitmq::install::rabbitmqadmin'] -> Rabbitmq_exchange<| |>
   }
 
-  if $stomp_ensure {
-    rabbitmq_plugin { 'rabbitmq_stomp':
-      ensure  => present,
-      require => Class['rabbitmq::install'],
-      notify  => Class['rabbitmq::service'],
-    }
+  rabbitmq_plugin { 'rabbitmq_management':
+    ensure   => bool2str($admin_ensure, 'present', 'absent'),
+    require  => Class['rabbitmq::install'],
+    notify   => Class['rabbitmq::service'],
+    provider => 'rabbitmqplugins',
   }
 
-  if ($ldap_auth) {
-    rabbitmq_plugin { 'rabbitmq_auth_backend_ldap':
-      ensure  => present,
-      require => Class['rabbitmq::install'],
-      notify  => Class['rabbitmq::service'],
-    }
+  rabbitmq_plugin { 'rabbitmq_stomp':
+    ensure  => bool2str($stomp_ensure, 'present', 'absent'),
+    require => Class['rabbitmq::install'],
+    notify  => Class['rabbitmq::service'],
   }
 
-  if ($config_shovel) {
-    rabbitmq_plugin { 'rabbitmq_shovel':
-      ensure   => present,
-      require  => Class['rabbitmq::install'],
-      notify   => Class['rabbitmq::service'],
-      provider => 'rabbitmqplugins',
-    }
+  rabbitmq_plugin { 'rabbitmq_auth_backend_ldap':
+    ensure  => bool2str($ldap_auth, 'present', 'absent'),
+    require => Class['rabbitmq::install'],
+    notify  => Class['rabbitmq::service'],
+  }
 
-    if ($admin_enable) {
-      rabbitmq_plugin { 'rabbitmq_shovel_management':
-        ensure   => present,
-        require  => Class['rabbitmq::install'],
-        notify   => Class['rabbitmq::service'],
-        provider => 'rabbitmqplugins',
-      }
-    }
+  rabbitmq_plugin { 'rabbitmq_shovel':
+    ensure   => bool2str($config_shovel, 'present', 'absent'),
+    ensure   => present,
+    require  => Class['rabbitmq::install'],
+    notify   => Class['rabbitmq::service'],
+    provider => 'rabbitmqplugins',
+  }
+
+  $config_shovel_management = $admin_enable and $config_shovel
+  rabbitmq_plugin { 'rabbitmq_shovel_management':
+    ensure   => bool2str($config_shovel_management, 'present', 'absent'),
+    ensure   => present,
+    require  => Class['rabbitmq::install'],
+    notify   => Class['rabbitmq::service'],
+    provider => 'rabbitmqplugins',
   }
 
   # Anchor this as per #8040 - this ensures that classes won't float off and

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -252,7 +252,6 @@ class rabbitmq(
 
   rabbitmq_plugin { 'rabbitmq_shovel':
     ensure   => bool2str($config_shovel, 'present', 'absent'),
-    ensure   => present,
     require  => Class['rabbitmq::install'],
     notify   => Class['rabbitmq::service'],
     provider => 'rabbitmqplugins',
@@ -261,7 +260,6 @@ class rabbitmq(
   $config_shovel_management = $admin_enable and $config_shovel
   rabbitmq_plugin { 'rabbitmq_shovel_management':
     ensure   => bool2str($config_shovel_management, 'present', 'absent'),
-    ensure   => present,
     require  => Class['rabbitmq::install'],
     notify   => Class['rabbitmq::service'],
     provider => 'rabbitmqplugins',

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">=3.0.0 <5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">=4.10.0 <5.0.0"},
     {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
     {"name":"puppet/staging","version_requirement":">=0.3.1 <2.0.0"}
   ]

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -425,6 +425,7 @@ LimitNOFILE=1234
           it 'we enable the admin interface by default' do
             should contain_class('rabbitmq::install::rabbitmqadmin')
             should contain_rabbitmq_plugin('rabbitmq_management').with(
+              'ensure'  => 'present',
               'require' => 'Class[Rabbitmq::Install]',
               'notify'  => 'Class[Rabbitmq::Service]'
             )
@@ -464,7 +465,11 @@ LimitNOFILE=1234
           let(:params) {{ :admin_enable => true, :service_manage => false }}
           it 'should do nothing' do
             should_not contain_class('rabbitmq::install::rabbitmqadmin')
-            should_not contain_rabbitmq_plugin('rabbitmq_management')
+            should contain_rabbitmq_plugin('rabbitmq_management').with(
+              'ensure'  => 'absent',
+              'require' => 'Class[Rabbitmq::Install]',
+              'notify'  => 'Class[Rabbitmq::Service]'
+            )
           end
         end
       end

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -720,7 +720,11 @@ LimitNOFILE=1234
             }
           end
 
-          it { should_not contain_rabbitmq_plugin('rabbitmq_shovel_management') }
+          it { should contain_rabbitmq_plugin('rabbitmq_shovel_management').with(
+              'ensure'  => 'absent',
+              'require' => 'Class[Rabbitmq::Install]',
+              'notify'  => 'Class[Rabbitmq::Service]'
+            ) }
         end
 
         describe 'with static shovels' do
@@ -772,7 +776,11 @@ LimitNOFILE=1234
             }
           end
 
-          it { should_not contain_rabbitmq_plugin('rabbitmq_shovel_management') }
+          it { should contain_rabbitmq_plugin('rabbitmq_shovel_management').with(
+              'ensure'  => 'absent',
+              'require' => 'Class[Rabbitmq::Install]',
+              'notify'  => 'Class[Rabbitmq::Service]'
+            ) }
         end
 
         describe 'with static shovels' do


### PR DESCRIPTION
This is an update of pull request #388 from 14 Sep 2015.  There have been quite a number of changes to puppetlabs-rabbitmq in the interim, so I rewrote the patch.
