### PR TITLE
add default_vhost parameter and test

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class rabbitmq(
   $config_shovel_statics      = $rabbitmq::params::config_shovel_statics,
   $default_user               = $rabbitmq::params::default_user,
   $default_pass               = $rabbitmq::params::default_pass,
+  $default_vhost              = $rabbitmq::params::default_vhost,
   $delete_guest_user          = $rabbitmq::params::delete_guest_user,
   $env_config                 = $rabbitmq::params::env_config,
   $env_config_path            = $rabbitmq::params::env_config_path,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -84,6 +84,7 @@ class rabbitmq::params {
   $config_shovel_statics       = {}
   $default_user                = 'guest'
   $default_pass                = 'guest'
+  $default_vhost               = undef
   $delete_guest_user           = false
   $env_config                  = 'rabbitmq/rabbitmq-env.conf.erb'
   $env_config_path             = '/etc/rabbitmq/rabbitmq-env.conf'

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -809,6 +809,15 @@ LimitNOFILE=1234
         end
       end
 
+      describe 'default_vhost set' do
+        let(:params) {{ :default_vhost => '/foo' }}
+        it 'should set default_vhost if a value is specified' do
+          should contain_file('rabbitmq.config').with({
+            'content' => /,\n.*default_vhost, <<"\/foo">>/m,
+          })
+        end
+      end
+
       describe 'interfaces option with no ssl' do
         let(:params) {
           { :interface => '0.0.0.0',

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -63,7 +63,9 @@
 <%- end -%>
 <%- end -%>
     {default_user, <<"<%= @default_user %>">>},
-    {default_pass, <<"<%= @default_pass %>">>}
+    {default_pass, <<"<%= @default_pass %>">>}<% if @default_vhost -%>,
+    {default_vhost, <<"<%= @default_vhost %>">>}
+<%- end -%>
   ]}<% if @config_kernel_variables -%>,
   {kernel, [
     <%= @config_kernel_variables.sort.map{|k,v| "{#{k}, #{v}}"}.join(",\n    ") %>


### PR DESCRIPTION
Ability to set default_vhost in rabbitmq.config.

Part of me thinks this should check in some way require that the specified vhost be defined, though I'm not exactly sure how. Thoughts?
