### PR TITLE
Signing key patch 1

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,7 +70,7 @@ class rabbitmq::params {
   $management_port             = '15672'
   $management_ssl              = true
   $package_apt_pin             = ''
-  $package_gpg_key             = 'https://www.rabbitmq.com/rabbitmq-signing-key-public.asc'
+  $package_gpg_key             = 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc'
   $repos_ensure                = true
   $manage_repos                = undef
   $service_ensure              = 'running'

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -6,8 +6,8 @@ class rabbitmq::repo::apt(
   $release      = 'testing',
   $repos        = 'main',
   $include_src  = false,
-  $key          = 'F78372A06FF50C80464FC1B4F7B8CEA6056E8E56',
-  $key_source   = 'http://www.rabbitmq.com/rabbitmq-signing-key-public.asc',
+  $key          = '0A9AF2115F4687BD29803A206B73A36E6026DFCA',
+  $key_source   = 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc',
   $key_content  = undef,
   $architecture = undef,
   ) {


### PR DESCRIPTION
Due change on rabbitmq.com where they have removed old signaturing key and published new key, puppet and apt is not able to verify package. 
This solution work for me.
