### PR TITLE
Multiple routing keys for bindings using namevars

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,34 @@ rabbitmq_binding { 'myexchange@myqueue@myvhost':
 }
 ```
 
+```puppet
+rabbitmq_binding { 'binding 1':
+  source           => 'myexchange',
+  destination      => 'myqueue',
+  vhost            => 'myvhost',
+  user             => 'dan',
+  password         => 'bar',
+  destination_type => 'queue',
+  routing_key      => 'key1',
+  arguments        => {},
+  ensure           => present,
+}
+
+rabbitmq_binding { 'binding 2':
+  source           => 'myexchange',
+  destination      => 'myqueue',
+  vhost            => 'myvhost',
+  user             => 'dan',
+  password         => 'bar',
+  destination_type => 'queue',
+  routing_key      => 'key2',
+  arguments        => {},
+  ensure           => present,
+}
+
+```
+
+
 ### rabbitmq\_user\_permissions
 
 ```puppet

--- a/spec/acceptance/queue_spec.rb
+++ b/spec/acceptance/queue_spec.rb
@@ -78,7 +78,7 @@ describe 'rabbitmq binding:' do
   end
   
 
-  context "create multiple bindings when same source / dest / vhost but different routing keys" do
+  context "create multiple bindings when same source / destination / vhost but different routing keys" do
     it 'should run successfully' do
       pp = <<-EOS
       if $::osfamily == 'RedHat' {
@@ -125,7 +125,9 @@ describe 'rabbitmq binding:' do
 
       rabbitmq_binding { 'binding 1':
         source           => 'exchange1',
+        destination      => 'queue1',
         user             => 'dan',
+        vhost            => 'host1',
         password         => 'bar',
         destination_type => 'queue',
         routing_key      => 'test1',
@@ -134,7 +136,9 @@ describe 'rabbitmq binding:' do
 
       rabbitmq_binding { 'binding 2':
         source           => 'exchange1',
+        destination      => 'queue1',
         user             => 'dan',
+        vhost            => 'host1',
         password         => 'bar',
         destination_type => 'queue',
         routing_key      => 'test2',

--- a/spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb
@@ -7,24 +7,111 @@ provider_class = Puppet::Type.type(:rabbitmq_binding).provider(:rabbitmqadmin)
 describe provider_class do
   before :each do
     @resource = Puppet::Type::Rabbitmq_binding.new(
-      {:name => 'source@target@/',
-       :destination_type => :queue,
-       :routing_key => 'blablub',
-       :arguments => {}
+      {
+        :name             => 'source@target@/',
+        :destination_type => :queue,
+        :routing_key      => 'blablub',
+        :arguments        => {}
       }
     )
     @provider = provider_class.new(@resource)
   end
 
-  it 'should return instances' do
-    provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
+  describe "#instances" do
+    it 'should return instances' do
+      provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
 /
 EOT
-    provider_class.expects(:rabbitmqctl).with('list_bindings', '-q', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments').returns <<-EOT
-    queue queue queue []
+      provider_class.expects(:rabbitmqctl).with('list_bindings', '-q', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments').returns <<-EOT
+exchange\tdst_queue\tqueue\t*\t[]
 EOT
-    instances = provider_class.instances
-    instances.size.should == 1
+      instances = provider_class.instances
+      instances.size.should == 1
+      instances.map do |prov|
+        {
+          :source      => prov.get(:source),
+          :destination => prov.get(:destination),
+          :vhost       => prov.get(:vhost),
+          :routing_key => prov.get(:routing_key)
+        }
+      end.should == [
+        {
+          :source      => 'exchange',
+          :destination => 'dst_queue',
+          :vhost       => '/',
+          :routing_key => '*'
+        }
+      ]
+    end
+
+    it 'should return multiple instances' do
+      provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
+/
+EOT
+      provider_class.expects(:rabbitmqctl).with('list_bindings', '-q', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments').returns <<-EOT
+exchange\tdst_queue\tqueue\trouting_one\t[]
+exchange\tdst_queue\tqueue\trouting_two\t[]
+EOT
+      instances = provider_class.instances
+      instances.size.should == 2
+      instances.map do |prov|
+        {
+          :source      => prov.get(:source),
+          :destination => prov.get(:destination),
+          :vhost       => prov.get(:vhost),
+          :routing_key => prov.get(:routing_key)
+        }
+      end.should == [
+        {
+          :source      => 'exchange',
+          :destination => 'dst_queue',
+          :vhost       => '/',
+          :routing_key => 'routing_one'
+        },
+        {
+          :source      => 'exchange',
+          :destination => 'dst_queue',
+          :vhost       => '/',
+          :routing_key => 'routing_two'
+        }
+      ]
+    end
+  end
+
+  describe "Test for prefetch error" do
+    it "exists" do
+      provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
+/
+EOT
+      provider_class.expects(:rabbitmqctl).with('list_bindings', '-q', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments').returns <<-EOT
+exchange\tdst_queue\tqueue\t*\t[]
+EOT
+
+      provider_class.prefetch({})
+    end
+
+    it "matches" do
+      # Test resource to match against
+      @resource = Puppet::Type::Rabbitmq_binding.new(
+        {
+          :name             => 'binding1',
+          :source           => 'exchange1',
+          :destination      => 'destqueue',
+          :destination_type => :queue,
+          :routing_key      => 'blablubd',
+          :arguments        => {}
+        }
+      )
+
+      provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
+/
+EOT
+      provider_class.expects(:rabbitmqctl).with('list_bindings', '-q', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments').returns <<-EOT
+exchange\tdst_queue\tqueue\t*\t[]
+EOT
+
+      provider_class.prefetch({ "binding1" => @resource})
+    end
   end
   
   it 'should call rabbitmqadmin to create' do
@@ -40,12 +127,13 @@ EOT
   context 'specifying credentials' do
     before :each do
       @resource = Puppet::Type::Rabbitmq_binding.new(
-        {:name => 'source@test2@/',
-         :destination_type => :queue,
-         :routing_key => 'blablubd',
-         :arguments => {},
-         :user => 'colin',
-         :password => 'secret'
+        {
+          :name             => 'source@test2@/',
+          :destination_type => :queue,
+          :routing_key      => 'blablubd',
+          :arguments        => {},
+          :user             => 'colin',
+          :password         => 'secret'
         }
       )
       @provider = provider_class.new(@resource)
@@ -56,4 +144,26 @@ EOT
       @provider.create
     end
   end
+
+  context 'new queue_bindings' do
+    before :each do
+      @resource = Puppet::Type::Rabbitmq_binding.new(
+        {
+          :name             => 'binding1',
+          :source           => 'exchange1',
+          :destination      => 'destqueue',
+          :destination_type => :queue,
+          :routing_key      => 'blablubd',
+          :arguments        => {}
+        }
+      )
+      @provider = provider_class.new(@resource)
+    end
+
+    it 'should call rabbitmqadmin to create' do
+      @provider.expects(:rabbitmqadmin).with('declare', 'binding', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'source=exchange1', 'destination=destqueue', 'arguments={}', 'routing_key=blablubd', 'destination_type=queue')
+      @provider.create
+    end
+  end
+
 end

--- a/spec/unit/puppet/type/rabbitmq_binding_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_binding_spec.rb
@@ -15,16 +15,30 @@ describe Puppet::Type.type(:rabbitmq_binding) do
       Puppet::Type.type(:rabbitmq_binding).new({})
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
+  it 'should error when missing source' do
+    expect {
+      Puppet::Type.type(:rabbitmq_binding).new(
+        :name        => 'test binding',
+        :destination => 'foobar'
+      )
+    }.to raise_error(Puppet::Error, /Source and destination must both be defined/)
+  end
+  it 'should error when missing destination' do
+    expect {
+      Puppet::Type.type(:rabbitmq_binding).new(
+        :name   => 'test binding',
+        :source => 'foobar'
+      )
+    }.to raise_error(Puppet::Error, /Source and destination must both be defined/)
+  end
   it 'should accept an binding destination_type' do
     @binding[:destination_type] = :exchange
     @binding[:destination_type].should == :exchange
   end
-
   it 'should accept a user' do
     @binding[:user] = :root
     @binding[:user].should == :root
   end
-
   it 'should accept a password' do
     @binding[:password] = :PaSsw0rD
     @binding[:password].should == :PaSsw0rD

--- a/spec/unit/puppet/type/rabbitmq_binding_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_binding_spec.rb
@@ -15,23 +15,6 @@ describe Puppet::Type.type(:rabbitmq_binding) do
       Puppet::Type.type(:rabbitmq_binding).new({})
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
-  it 'should not allow whitespace in the name' do
-    expect {
-      @binding[:name] = 'b r'
-    }.to raise_error(Puppet::Error, /Valid values match/)
-  end
-  it 'should not allow names without one @' do
-    expect {
-      @binding[:name] = 'b_r'
-    }.to raise_error(Puppet::Error, /Valid values match/)
-  end
-
-  it 'should not allow names without two @' do
-    expect {
-      @binding[:name] = 'b@r'
-    }.to raise_error(Puppet::Error, /Valid values match/)
-  end
-
   it 'should accept an binding destination_type' do
     @binding[:destination_type] = :exchange
     @binding[:destination_type].should == :exchange


### PR DESCRIPTION
Updated: proposing this as an option instead of #375 
This PR lets you specify legacy style resources (`source@destination@vhost`) and / or lets you specify `source`, `destination` (and, optionally, `routing_key` and `vhost`) as separate parameters, with a descriptive or arbitrary name.

There's still probably some room for improvement, but I've finally got this in shape where I think it could be merged.
