### PR TITLE
Use new structure for Apt::Source

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -29,10 +29,14 @@ class rabbitmq::repo::apt(
     location     => $location,
     release      => $release,
     repos        => $repos,
-    include_src  => $include_src,
-    key          => $key,
-    key_source   => $key_source,
-    key_content  => $key_content,
+    include      => {
+      src => $include_src,
+    },
+    key          => {
+      id      => $key,
+      source  => $key_source,
+      content => $key_content,
+    },
     architecture => $architecture,
   }
 

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1425,8 +1425,12 @@ LimitNOFILE=1234
           'location'    => 'http://www.rabbitmq.com/debian/',
           'release'     => 'testing',
           'repos'       => 'main',
-          'include_src' => false,
-          'key'         => '0A9AF2115F4687BD29803A206B73A36E6026DFCA'
+          'include'     => {
+              'src'     => false
+          },
+          'key'         => {
+              'id'      => '0A9AF2115F4687BD29803A206B73A36E6026DFCA'
+          }
         ) }
       end
     end
@@ -1439,8 +1443,12 @@ LimitNOFILE=1234
           'location'    => 'http://www.rabbitmq.com/debian/',
           'release'     => 'testing',
           'repos'       => 'main',
-          'include_src' => false,
-          'key'         => '0A9AF2115F4687BD29803A206B73A36E6026DFCA'
+          'include'     => {
+              'src'     => false
+          },
+          'key'         => {
+              'id'      => '0A9AF2115F4687BD29803A206B73A36E6026DFCA'
+          }
         ) }
 
         it { should contain_apt__pin('rabbitmq').with(


### PR DESCRIPTION
This puppet module uses the `puppetlabs-apt` module for installing rabbitmq through Apt.
The apt-module renders warnings about deprecation.

```
Warning: Scope(Apt::Source[rabbitmq]): $include_src is deprecated and will be removed in the next major release, please use $include => { 'src' => false } instead
Warning: Scope(Apt::Source[rabbitmq]): $key_source is deprecated and will be removed in the next major release, please use $key => { 'source' => https://www.rabbitmq.com/rabbitmq-release-signing-key.asc } instead.
Warning: Scope(Apt::Key[Add key: 0A9AF2115F4687BD29803A206B73A36E6026DFCA from Apt::Source rabbitmq]): $key_source is deprecated and will be removed in the next major release. Please use $source instead.
```

These deprecations are put in place for the upcomming 2.x release of the apt module, see:
https://github.com/puppetlabs/puppetlabs-apt/commit/396f308e6ad4798461a6471ee8bb8e764d8b03cb
