### PR TITLE
Bug fix for when queue names include spaces

### DIFF
--- a/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:rabbitmq_queue).provide(:rabbitmqadmin) do
     all_vhosts.each do |vhost|
       all_queues(vhost).collect do |line|
         next if line =~ /^federation:/
-        name, durable, auto_delete, arguments = line.split()
+        name, durable, auto_delete, arguments = line.split("\t")
         # Convert output of arguments from the rabbitmqctl command to a json string.
         if !arguments.nil?
           arguments = arguments.gsub(/^\[(.*)\]$/, "").gsub(/\{("(?:.|\\")*?"),/, '{\1:').gsub(/\},\{/, ",")


### PR DESCRIPTION
Queue arguments and properties are now parsed by tabs instead of spaces.
