### PR TITLE
Add HTTP API provider for rabbitmq

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,6 @@ fixtures:
     "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
     "staging": "git://github.com/voxpupuli/puppet-staging.git"
     "erlang:": "git://github.com/garethr/garethr-erlang.git"
+    "rabbitmq_http_api_client": "https://github.com/ruby-amqp/rabbitmq_http_api_client"
   symlinks:
     "rabbitmq": "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
 # to `1` and then run bundle install.
 gem 'facter', *location_for(ENV['FACTER_GEM_VERSION']) if ENV['FACTER_GEM_VERSION']
 gem 'hiera', *location_for(ENV['HIERA_GEM_VERSION']) if ENV['HIERA_GEM_VERSION']
-
+gem 'rabbitmq_http_api_client', '>= 1.7.0',                 :require => false
 
 # Evaluate Gemfile.local if it exists
 if File.exists? "#{__FILE__}.local"

--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin_http.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin_http.rb
@@ -1,0 +1,112 @@
+require 'puppet'
+
+require "rabbitmq/http/client"
+
+$endpoint = "http://localhost:15672"
+$client = RabbitMQ::HTTP::Client.new($endpoint, :username => "guest", :password => "guest")
+
+Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqhttp, :parent => Puppet::Type.type(:rabbitmq_exchange).provider(:rabbitmqctl)) do
+
+
+  defaultfor :feature => :posix
+
+  def should_vhost
+    if @should_vhost
+      @should_vhost
+    else
+      @should_vhost = resource[:name].split('@')[1]
+    end
+  end
+
+  def self.all_vhosts
+    vhosts = []
+    vhost_list = $client.list_vhosts
+    vhost_list.each do |vhost|
+      vhosts.push(vhost[:name])
+    end
+    vhosts
+  end
+
+  def self.all_exchanges(vhost)
+    exchanges = []
+    exchange_list = $client.list_exchanges(vhost)
+    exchange_list.each do |exchange|
+      next if exchange.name.eql? ''
+      json_args = exchange.arguments.to_json
+      tmp_exchange = "#{exchange.name} #{exchange.type} #{exchange.internal} #{exchange.durable} #{exchange.auto_delete} #{json_args}"
+      exchanges.push(tmp_exchange)
+    end
+    exchanges
+  end
+
+  def self.instances
+    resources = []
+    all_vhosts.each do |vhost|
+        all_exchanges(vhost).each do |line|
+          name, type, internal, durable, auto_delete, arguments = line.split()
+            if type.nil?
+                # if name is empty, it will wrongly get the type's value.
+                # This way type will get the correct value
+                type = name
+                name = ''
+            end
+            # Convert output of arguments from the rabbitmqctl command to a json string.
+            if !arguments.nil?
+              arguments = arguments.gsub(/^\[(.*)\]$/, "").gsub(/\{("(?:.|\\")*?"),/, '{\1:').gsub(/\},\{/, ",")
+              if arguments == ""
+                arguments = '{}'
+              end
+            else
+              arguments = '{}'
+            end
+            exchange = {
+              :type   => type,
+              :ensure => :present,
+              :internal => internal,
+              :durable => durable,
+              :auto_delete => auto_delete,
+              :name   => "%s@%s" % [name, vhost],
+              :arguments => JSON.parse(arguments),
+            }
+            resources << new(exchange) if exchange[:type]
+        end
+    end
+    resources
+  end
+
+  def self.prefetch(resources)
+    packages = instances
+    resources.keys.each do |name|
+      if provider = packages.find{ |pkg| pkg.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def exists?
+    exchange_list = $client.list_exchanges(resource[:name].split('@')[1])
+    exchange_list.each do |line|
+      if line.name.eql? resource[:name].split('@')[0]
+        return true
+      end
+    end
+    false
+  end
+
+  def create
+    name = resource[:name].split('@')[0]
+    arguments = resource[:arguments]
+    if arguments.nil?
+      arguments = {}
+    end
+
+    $client.declare_exchange(should_vhost, name, :durable => resource[:durable], :type => resource[:type])
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    $client.delete_exchange(should_vhost, name, if_unused = false)
+    @property_hash[:ensure] = :absent
+  end
+
+end

--- a/lib/puppet/provider/rabbitmq_policy/rabbitmqhttp.rb
+++ b/lib/puppet/provider/rabbitmq_policy/rabbitmqhttp.rb
@@ -1,0 +1,102 @@
+require 'json'
+require 'puppet/util/package'
+
+require "rabbitmq/http/client"
+
+$endpoint = "http://localhost:15672"
+$client = RabbitMQ::HTTP::Client.new($endpoint, :username => "guest", :password => "guest")
+
+Puppet::Type.type(:rabbitmq_policy).provide(:rabbitmqhttp, :parent => Puppet::Type.type(:rabbitmq_policy).provider(:rabbitmqctl)) do
+
+  defaultfor :feature => :posix
+  # cache policies
+  def self.policies(name, vhost)
+    @policies = {} unless @policies
+    unless @policies[vhost]
+      @policies[vhost] = {}
+      vhost_policies = $client.list_policies(vhost)
+      vhost_policies.each do |line|
+      if line.vhost.eql? vhost
+        @policies[vhost][line.name] = {
+          :applyto    => line["apply-to"],
+          :pattern    => line.pattern,
+          :definition => line.definition,
+          :priority   => line.priority}
+        end
+      end
+    end
+    @policies[vhost][name]
+  end
+
+  def policies(name, vhost)
+    self.class.policies(vhost, name)
+  end
+
+  def should_policy
+    @should_policy ||= resource[:name].rpartition('@').first
+  end
+
+  def should_vhost
+    @should_vhost ||= resource[:name].rpartition('@').last
+  end
+
+  def create
+    set_policy
+  end
+
+  def destroy
+    rabbitmqctl('clear_policy', '-p', should_vhost, should_policy)
+  end
+
+  def exists?
+    policies(should_vhost, should_policy)
+  end
+
+  def pattern
+    policies(should_vhost, should_policy)[:pattern]
+  end
+
+  def pattern=(pattern)
+    set_policy
+  end
+
+  def applyto
+    policies(should_vhost, should_policy)[:applyto]
+  end
+
+  def applyto=(applyto)
+    set_policy
+  end
+
+  def definition
+    policies(should_vhost, should_policy)[:definition]
+  end
+
+  def definition=(definition)
+    set_policy
+  end
+
+  def priority
+    policies(should_vhost, should_policy)[:priority]
+  end
+
+  def priority=(priority)
+    set_policy
+  end
+
+  def set_policy
+    unless @set_policy
+      @set_policy = true
+      resource[:applyto]    ||= applyto
+      resource[:definition] ||= definition
+      resource[:pattern]    ||= pattern
+      resource[:priority]   ||= priority
+
+      attributes = {:definition => resource[:definition], :priority => resource[:priority], :pattern => resource[:pattern]}
+
+      $client.update_policies_of(should_vhost, should_policy, attributes)
+
+    end
+  end
+end
+

--- a/lib/puppet/provider/rabbitmq_user/rabbitmqhttp.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqhttp.rb
@@ -1,0 +1,98 @@
+require 'puppet'
+require 'set'
+require "rabbitmq/http/client"
+
+$endpoint = "http://localhost:15672"
+$client = RabbitMQ::HTTP::Client.new($endpoint, :username => "guest", :password => "guest")
+
+Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqhttp, :parent => Puppet::Type.type(:rabbitmq_user).provider(:rabbitmqctl)) do
+
+  defaultfor :feature => :posix
+
+  def create
+    $client.create_user(resource[:name], :password => resource[:password])
+    if ! resource[:tags].empty?
+      set_user_tags(resource[:tags])
+    end
+  end
+
+  def change_password
+      keep_tags = get_user_tags
+      set_user_tags(keep_tags)
+  end
+
+  def password
+    nil
+  end
+
+  def check_password
+    user = $client.user_info(resource[:name])
+    dec_hash = Base64.decode64(user.password_hash)
+    salt = dec_hash[0..3]
+    sha256 = Digest::SHA256.new
+    new_hash = sha256.digest(salt + resource[:password])
+    new_pass = Base64.encode64(salt + new_hash)[0..-2]
+    if user.password_hash.eql? new_pass
+      true
+    else
+      false
+    end
+  end
+
+  def destroy
+    $client.delete_user(resource[:name])
+  end
+
+  def exists?
+    v_list = $client.list_users
+
+    out = false
+    v_list.each {|line|
+      if (line[:name].match(/^#{Regexp.escape(resource[:name])}$/))
+          out = true
+      end
+      }
+    return out
+  end
+
+  def tags
+    tags = get_user_tags
+    # do not expose the administrator tag for admins
+    if resource[:admin] == :true
+      tags.delete('administrator')
+    end
+    tags.entries.sort
+  end
+
+  def tags=(tags)
+    if ! tags.nil?
+      set_user_tags(tags)
+    end
+  end
+
+  def admin
+    if usertags = get_user_tags
+      (:true if usertags.include?('administrator')) || :false
+    end
+  end
+
+  def admin=(state)
+    usertags = get_user_tags
+    if state == :true
+      usertags.add('administrator')
+    else
+      usertags.delete('administrator')
+    end
+    set_user_tags(usertags)
+  end
+
+  def set_user_tags(usertags)
+    $client.update_user(resource[:name], :password => resource[:password], :tags => usertags.to_a.join(','))
+  end
+
+  private
+  def get_user_tags
+    tags = $client.user_info(resource[:name])
+    return Set.new(tags[:tags].split(","))
+  end
+end

--- a/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqhttp.rb
+++ b/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqhttp.rb
@@ -1,0 +1,109 @@
+require "rabbitmq/http/client"
+
+$endpoint = "http://localhost:15672"
+$client = RabbitMQ::HTTP::Client.new($endpoint, :username => "guest", :password => "guest")
+
+Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqhttp, :parent => Puppet::Type.type(:rabbitmq_user_permissions).provider(:rabbitmqctl)) do
+
+  defaultfor :feature=> :posix
+
+  # cache users permissions
+  def self.users(name, vhost)
+    @users = {} unless @users
+    unless @users[name]
+      @users[name] = {}
+      @users[name][vhost] = {}
+      user_perm = $client.list_permissions
+      user_perm.each do |line|
+        if line.user.eql? name
+          @users[line.user][line.vhost] =
+            {:configure => line.configure, :read => line.read, :write => line.write}
+        end
+      end
+    end
+    @users[name][vhost]
+  end
+
+  def users(name, vhost)
+    self.class.users(name, vhost)
+  end
+
+  def should_user
+    if @should_user
+      @should_user
+    else
+      @should_user = resource[:name].split('@')[0]
+    end
+  end
+
+  def should_vhost
+    if @should_vhost
+      @should_vhost
+    else
+      @should_vhost = resource[:name].split('@')[1]
+    end
+  end
+
+  def create
+    resource[:configure_permission] ||= "''"
+    resource[:read_permission]      ||= "''"
+    resource[:write_permission]     ||= "''"
+    $client.update_permissions_of(should_vhost, should_user, :write => resource[:write_permission], :read => resource[:read_permission], :configure => resource[:configure_permission])
+    #rabbitmqctl('set_permissions', '-p', should_vhost, should_user, resource[:configure_permission], resource[:write_permission], resource[:read_permission])
+  end
+
+  def destroy
+    $client.clear_permissions_of(should_vhost, should_user)
+    #rabbitmqctl('clear_permissions', '-p', should_vhost, should_user)
+  end
+
+  # I am implementing prefetching in exists b/c I need to be sure
+  # that the rabbitmq package is installed before I make this call.
+  def exists?
+    users(should_user, should_vhost)
+  end
+
+  def configure_permission
+    users(should_user, should_vhost)[:configure]
+  end
+
+  def configure_permission=(perm)
+    set_permissions
+  end
+
+  def read_permission
+    users(should_user, should_vhost)[:read]
+  end
+
+  def read_permission=(perm)
+    set_permissions
+  end
+
+  def write_permission
+    users(should_user, should_vhost)[:write]
+  end
+
+  def write_permission=(perm)
+    set_permissions
+  end
+
+  # implement memoization so that we only call set_permissions once
+  def set_permissions
+    unless @permissions_set
+      @permissions_set = true
+      resource[:configure_permission] ||= configure_permission
+      resource[:read_permission]      ||= read_permission
+      resource[:write_permission]     ||= write_permission
+      rabbitmqctl('set_permissions', '-p', should_vhost, should_user,
+        resource[:configure_permission], resource[:write_permission],
+        resource[:read_permission]
+      )
+    end
+  end
+
+  def self.strip_backslashes(string)
+    # See: https://github.com/rabbitmq/rabbitmq-server/blob/v1_7/docs/rabbitmqctl.1.pod#output-escaping
+    string.gsub(/\\\\/, '\\')
+  end
+
+end

--- a/lib/puppet/provider/rabbitmq_vhost/rabbitmqhttp.rb
+++ b/lib/puppet/provider/rabbitmq_vhost/rabbitmqhttp.rb
@@ -1,0 +1,31 @@
+require "rabbitmq/http/client"
+
+$endpoint = "http://localhost:15672"
+$client = RabbitMQ::HTTP::Client.new($endpoint, :username => "guest", :password => "guest")
+
+Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqhttp, :parent => Puppet::Type.type(:rabbitmq_vhost).provider(:rabbitmqctl)) do
+
+  def self.instances
+  end
+
+  def create
+    $client.create_vhost(resource[:name])
+  end
+
+  def destroy
+    $client.delete_vhost(resource[:name])
+  end
+
+  def exists?
+    v_list = $client.list_vhosts
+
+    out = false
+    v_list.each {|line|
+      if (line[:name].match(/^#{Regexp.escape(resource[:name])}$/))
+          out = true
+      end
+      }
+    return out
+  end
+end
+

--- a/lib/puppet/provider/rabbitmqhttp.rb
+++ b/lib/puppet/provider/rabbitmqhttp.rb
@@ -1,0 +1,12 @@
+require "rabbitmq/http/client"
+
+$endpoint = "http://localhost:15672"
+$client = RabbitMQ::HTTP::Client.new($endpoint, :username => "guest", :password => "guest")
+
+class Puppet::Provider::Rabbitmqhttp < Puppet::Provider
+  initvars
+
+  def self.rabbitmq_version
+    $client.overview[:rabbitmq_version]
+  end
+end


### PR DESCRIPTION
This request adds new provider for managing rabbitmq  server.
It uses HTTP API, rabbitmq http gem from https://github.com/ruby-amqp/rabbitmq_http_api_client and significantly speeds up puppet runs. Currently the following features are implemented:
- rabbitmq_user
- rabbitmq_vhost
- rabbitmq_user_permission
- rabbitmq_policy
- rabbitmq_exchange
- HTTP connections are currently supported, however TLS has not yet been implemented

Performance metrics:
- rabbitmqctl provider
```
real 4m58.141s 
user 3m47.098s 
sys 1m23.255s 
```
- rabbitmqhttp provider
```
real 0m58.635s 
user 0m33.745s 
sys 0m5.756s
```