### PR TITLE
Simplify "all_vhosts" in rabbitmq_queue provider

### DIFF
--- a/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
@@ -24,11 +24,7 @@ Puppet::Type.type(:rabbitmq_queue).provide(:rabbitmqadmin) do
   end
 
   def self.all_vhosts
-    vhosts = []
-    rabbitmqctl('list_vhosts', '-q').split(/\n/).collect do |vhost|
-        vhosts.push(vhost)
-    end
-    vhosts
+    rabbitmqctl('list_vhosts', '-q').split(/\n/)
   end
 
   def self.all_queues(vhost)


### PR DESCRIPTION
This is more idiomatic ruby, avoids creating array only to throw it away, and consistent with a method below.