### PR TITLE
Fix error text in `rabbitmq_vhost` provider

### DIFF
--- a/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl, :parent => Puppet::Prov
       if line =~ /^(\S+)$/
         new(:name => $1)
       else
-        raise Puppet::Error, "Cannot parse invalid user line: #{line}"
+        raise Puppet::Error, "Cannot parse invalid vhost line: #{line}"
       end
     end
   end


### PR DESCRIPTION
Just a small thing that threw me when looking through the code.

This provider is definitely calling `rabbitmqctl -q list_vhosts`, so if that output can't be parsed it should complain about invalid vhost lines, rather than invalid user lines.

Looks like a copy-paste error from other similar providers.

This will improve user experience when they encounter this error.