### PR TITLE
Add options for IPv6 and inetrc

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,9 @@ class rabbitmq(
   Optional[Array] $auth_backends                 = $rabbitmq::params::auth_backends,
   $key_content                                   = undef,
   Optional[Integer] $collect_statistics_interval = $rabbitmq::params::collect_statistics_interval,
+  Boolean $ipv6                                  = $rabbitmq::params::ipv6,
+  String $inetrc_config                          = $rabbitmq::params::inetrc_config,
+  Stdlib::Absolutepath $inetrc_config_path       = $rabbitmq::params::inetrc_config_path,
 ) inherits rabbitmq::params {
 
   # Validate install parameters.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -135,4 +135,7 @@ class rabbitmq::params {
   $auth_backends               = undef
   $file_limit                  = '16384'
   $collect_statistics_interval = undef
+  $ipv6                        = false
+  $inetrc_config               = 'rabbitmq/inetrc.erb'
+  $inetrc_config_path          = '/etc/rabbitmq/inetrc'
 }

--- a/templates/inetrc.erb
+++ b/templates/inetrc.erb
@@ -1,0 +1,5 @@
+% This file managed by Puppet
+% Template Path: <%= @module_name %>/templates/inetrc
+<%- if @ipv6 -%>
+{inet6, true}.
+<%- end -%>


### PR DESCRIPTION
This adds a new parameter, ipv6, which if set to true will configure
the erlang runtime to use IPv6 for distribution and name resolution.

It also adds two other parameters, inetrc_config and
inetrc_config_path, which support ipv6 enablement.

The environment variable ERL_INETRC is set to the value of
inetrc_config_path, by default /etc/rabbitmq/inetrc.  If ipv6 is
disabled (default), this file is empty and has no effect.  If ipv6 is
enabled, it sets the option 'inet6' to 'true', which prefers IPv6 name
resolution[1].

Users may pass their own inetrc_config to supply an alternate
template.

In addition, if ipv6 is set to true, the flag '-proto_dist inet6_tcp'
is appended to the environment variables RABBITMQ_SERVER_ERL_ARGS and
RABBITMQ_CTL_ERL_ARGS.  This enables IPv6 as the distribution protocol.

[1] https://github.com/erlang/otp/commit/5d7dcfc2e0de7e93b29d01f07a2f970720d62f9d