### PR TITLE
don't "touch" hiera.yaml in spec_helper_acceptance

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -21,7 +21,6 @@ RSpec.configure do |c|
                          %{"exec { 'setenforce 0': path   => '/bin:/sbin:/usr/bin:/usr/sbin', onlyif => 'which setenforce && getenforce | grep Enforcing', }"})
       end
 
-      on host, "/bin/touch #{default['puppetpath']}/hiera.yaml"
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppet-staging'), { :acceptable_exit_codes => [0,1] }
 


### PR DESCRIPTION
when running the non-Docker Beaker acceptance tests, I get the following error:

```
Failure/Error: on host, "/bin/touch #{default['puppetpath']}/hiera.yaml"
Beaker::Host::CommandFailure:
  Host 'centos-7-x64' exited with 1 running:
   /bin/touch /etc/puppet/hiera.yaml
  Last 10 lines of output were:
```

It seems like with the new images, this may not be necessary anyway (I have a `hiera.yaml` file already), and for some reason, running `bundle exec rake beaker:centos-7-x64` seems to fail because it's trying to write to `/etc/puppet/hiera.yaml` instead of `/etc/puppetlabs/puppet/hiera.yaml`. I'm not sure where it's getting `default['puppetpath']` from, but I think the tests don't need this line anyway?