### PR TITLE
Fix regex double escaping of rabbitmqctl list_policies

### DIFF
--- a/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
@@ -18,12 +18,18 @@ Puppet::Type.type(:rabbitmq_policy).provide(:rabbitmqctl, :parent => Puppet::Pro
         # 1 2      3?  4  5                                            6
         # / ha-all all .* {"ha-mode":"all","ha-sync-mode":"automatic"} 0
         if line =~ /^(\S+)\s+(\S+)\s+(all|exchanges|queues)?\s*(\S+)\s+(\S+)\s+(\d+)$/
-          applyto = $3 || 'all'
-          @policies[vhost][$2] = {
+          n          = $2
+          applyto    = $3 || 'all'
+          priority   = $6
+          definition = JSON.parse($5)
+          # be aware that the gsub will reset the captures
+          # from the regexp above
+          pattern    = $4.to_s.gsub(/\\\\/, '\\')
+          @policies[vhost][n] = {
             :applyto    => applyto,
-            :pattern    => $4,
-            :definition => JSON.parse($5),
-            :priority   => $6}
+            :pattern    => pattern,
+            :definition => definition,
+            :priority   => priority}
         else
           raise Puppet::Error, "cannot parse line from list_policies:#{line}"
         end

--- a/spec/acceptance/policy_spec.rb
+++ b/spec/acceptance/policy_spec.rb
@@ -30,15 +30,31 @@ describe 'rabbitmq policy on a vhost:' do
           'ha-sync-mode' => 'automatic',
         },
       }
+
+      rabbitmq_policy { 'eu-federation@myhost':
+        pattern    => '^eu\\.',
+        priority   => 0,
+        applyto    => 'all',
+        definition => {
+          'federation-upstream-set' => 'all',
+        },
+      }
       EOS
 
       apply_manifest(pp, :catch_failures => true)
       apply_manifest(pp, :catch_changes => true)
+
+
+      # Apply twice to ensure no changes the second time.
+      apply_manifest(pp, :catch_failures => true)
+      expect(apply_manifest(pp, :catch_changes => true).exit_code).to be_zero
+
     end
 
     it 'should have the policy' do
       shell('rabbitmqctl list_policies -p myhost') do |r|
         expect(r.stdout).to match(/myhost.*ha-all.*ha-sync-mode/)
+        expect(r.stdout).to match(/myhost.*eu-federation/)
         expect(r.exit_code).to be_zero
       end
     end


### PR DESCRIPTION
This reworks #482, and keeps attribution, but adds the spec test that @DrOwl posted. cc: @eputnam @sspreitzer @devfaz