### PR TITLE
Move examples and params to puppet strings style docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 3. [Setup - The basics of getting started with rabbitmq](#setup)
     * [What rabbitmq affects](#what-rabbitmq-affects)
     * [Setup requirements](#setup-requirements)
-    * [Beginning with rabbitmq](#beginning-with-rabbitmq)
 4. [Usage - Configuration options and additional functionality](#usage)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 5. [Limitations - OS compatibility, etc.](#limitations)
@@ -43,451 +42,13 @@ prior to 2.7.1.
 * rabbitmq configuration file.
 * rabbitmq service.
 
-### Beginning with rabbitmq
-
-
-```puppet
-include '::rabbitmq'
-```
-
 ## Usage
 
 All options and configuration can be done through interacting with the parameters
-on the main rabbitmq class.  These are documented below.
+on the main rabbitmq class.
+These are now documented via [Puppet Strings](https://github.com/puppetlabs/puppet-strings)
 
-## rabbitmq class
-
-To begin with the rabbitmq class controls the installation of rabbitmq.  In here
-you can control many parameters relating to the package and service, such as
-disabling puppet support of the service:
-
-```puppet
-class { '::rabbitmq':
-  service_manage    => false,
-  port              => '5672',
-  delete_guest_user => true,
-}
-```
-
-### Environment Variables
-To use RabbitMQ Environment Variables, use the parameters `environment_variables` e.g.:
-
-```puppet
-class { 'rabbitmq':
-  port                  => '5672',
-  environment_variables => {
-    'NODENAME'    => 'node01',
-    'SERVICENAME' => 'RabbitMQ'
-  }
-}
-```
-
-### Variables Configurable in rabbitmq.config
-To change RabbitMQ Config Variables in rabbitmq.config, use the parameters `config_variables` e.g.:
-
-```puppet
-class { 'rabbitmq':
-  port             => '5672',
-  config_variables => {
-    'hipe_compile' => true,
-    'frame_max'    => 131072,
-    'log_levels'   => "[{connection, info}]"
-  }
-}
-```
-
-To change Erlang Kernel Config Variables in rabbitmq.config, use the parameters
-`config_kernel_variables` e.g.:
-
-```puppet
-class { 'rabbitmq':
-  port                    => '5672',
-  config_kernel_variables => {
-    'inet_dist_listen_min' => 9100,
-    'inet_dist_listen_max' => 9105,
-  }
-}
-```
-
-To change Management Plugin Config Variables in rabbitmq.config, use the parameters
-`config_management_variables` e.g.:
-
-```puppet
-class { 'rabbitmq':
-  config_management_variables => {
-    'rates_mode' => 'basic',
-  }
-}
-```
-
-### Additional Variables Configurable in rabbitmq.config
-To change Additional Config Variables in rabbitmq.config, use the parameter
-`config_additional_variables` e.g.:
-
-```puppet
-class { 'rabbitmq':
-  config_additional_variables => {
-    'autocluster' => '[{consul_service, "rabbit"},{cluster_name, "rabbit"}]',
-    'foo'         => '[{bar, "baz"}]'
-  }
-}
-```
-This will result in the following config appended to the config file:
-```
-% Additional config
-  {autocluster, [{consul_service, "rabbit"},{cluster_name, "rabbit"}]},
-  {foo, [{bar, "baz"}]}
-```
-(This is required for the [autocluster plugin](https://github.com/aweber/rabbitmq-autocluster)
-
-### Clustering
-To use RabbitMQ clustering facilities, use the rabbitmq parameters
-`config_cluster`, `cluster_nodes`, and `cluster_node_type`, e.g.:
-
-```puppet
-class { 'rabbitmq':
-  config_cluster           => true,
-  cluster_nodes            => ['rabbit1', 'rabbit2'],
-  cluster_node_type        => 'ram',
-  erlang_cookie            => 'A_SECRET_COOKIE_STRING',
-  wipe_db_on_cookie_change => true,
-}
-```
-
-## Reference
-
-## Classes
-
-* rabbitmq: Main class for installation and service management.
-* rabbitmq::config: Main class for rabbitmq configuration/management.
-* rabbitmq::install: Handles package installation.
-* rabbitmq::params: Different configuration data for different systems.
-* rabbitmq::service: Handles the rabbitmq service.
-* rabbitmq::repo::apt: Handles apt repo for Debian systems.
-* rabbitmq::repo::rhel: Handles rpm repo for Redhat systems.
-
-### Parameters
-
-#### `admin_enable`
-
-Boolean, if enabled sets up the management interface/plugin for RabbitMQ.
-
-#### `auth_backends`
-
-An array specifying authorization/authentication backend to use. Syntax:
-single quotes should be placed around array entries, ex. ['{foo, baz}', 'baz']
-Defaults to [rabbit_auth_backend_internal], and if using LDAP defaults to
-[rabbit_auth_backend_internal, rabbit_auth_backend_ldap].
-
-#### `cluster_node_type`
-
-Choose between disc and ram nodes.
-
-#### `cluster_nodes`
-
-An array of nodes for clustering.
-
-#### `cluster_partition_handling`
-
-Value to set for `cluster_partition_handling` RabbitMQ configuration variable.
-
-#### `collect_statistics_interval`
-
-Integer, set the collect_statistics_interval in rabbitmq.config
-
-#### `config`
-
-The file to use as the rabbitmq.config template.
-
-#### `config_additional_variables`
-
-String, dditional config variables in rabbitmq.config
-
-#### `config_cluster`
-
-Boolean to enable or disable clustering support.
-
-#### `config_kernel_variables`
-
-Hash of Erlang kernel configuration variables to set (see [Variables Configurable in rabbitmq.config](#variables-configurable-in-rabbitmq.config)).
-
-#### `config_mirrored_queues`
-
-DEPRECATED
-
-Configuring queue mirroring should be done by setting the according policy for
-the queue. You can read more about it
-[here](http://www.rabbitmq.com/ha.html#genesis)
-
-#### `config_path`
-
-The path to write the RabbitMQ configuration file to.
-
-#### `config_management_variables`
-
-Hash of configuration variables for the [Management Plugin](https://www.rabbitmq.com/management.html).
-
-#### `config_stomp`
-
-Boolean to enable or disable stomp.
-
-#### `config_shovel`
-
-Boolean to enable or disable shovel.
-
-#### `config_shovel_statics`
-
-Hash of static shovel configurations
-
-#### `config_variables`
-
-To set config variables in rabbitmq.config
-
-#### `default_user`
-
-Username to set for the `default_user` in rabbitmq.config.
-
-#### `default_pass`
-
-Password to set for the `default_user` in rabbitmq.config.
-
-#### `delete_guest_user`
-
-Boolean to decide if we should delete the default guest user.
-
-#### `env_config`
-
-The template file to use for rabbitmq_env.config.
-
-#### `env_config_path`
-
-The path to write the rabbitmq_env.config file to.
-
-#### `environment_variables`
-
-RabbitMQ Environment Variables in rabbitmq_env.config
-
-#### `erlang_cookie`
-
-The erlang cookie to use for clustering - must be the same between all nodes.
-This value has no default and must be set explicitly if using clustering.
-If you run Pacemaker and you don't want to use RabbitMQ buildin cluster, you can
-set config_cluster to 'False' and set 'erlang_cookie'.
-
-#### `file_limit`
-
-Set rabbitmq file ulimit. Defaults to 16384. Only available on systems with
-`$::osfamily == 'Debian'` or `$::osfamily == 'RedHat'`.
-
-#### `heartbeat`
-
-Set the heartbeat timeout interval, default is unset which uses the builtin server
-defaultsof 60 seconds. Setting this to `0` will disable heartbeats.
-
-#### `key_content`
-
-Uses content method for Debian OS family. Should be a template for apt::source
-class. Undefined by default.
-
-#### `ldap_auth`
-
-Boolean, set to true to enable LDAP auth.
-
-#### `ldap_server`
-
-LDAP server to use for auth.
-
-#### `ldap_user_dn_pattern`
-
-User DN pattern for LDAP auth.
-
-#### `ldap_other_bind`
-
-How to bind to the LDAP server. Defaults to 'anon'.
-
-#### `ldap_config_variables`
-
-Hash of other LDAP config variables.
-
-#### `ldap_use_ssl`
-
-Boolean, set to true to use SSL for the LDAP server.
-
-#### `ldap_port`
-
-Numeric port for LDAP server.
-
-#### `ldap_log`
-
-Boolean, set to true to log LDAP auth.
-
-#### `management_ip_address`
-
-Will fall back to `node_ip_address` if not explicitly set; allows configuring
-a separate bind IP for the management interface.
-
-#### `management_hostname`
-
-The hostname for the RabbitMQ management interface.
-
-#### `management_port`
-
-The port for the RabbitMQ management interface.
-
-#### `management_ssl`
-
-Enable/Disable SSL for the management port.
-Has an effect only if ssl => true.
-Default is true.
-Valid values are true or false.
-
-#### `node_ip_address`
-
-The value of NODE_IP_ADDRESS in rabbitmq_env.config and of the
-rabbitmq_management server if it is enabled. See also `management_ip_address`.
-Use 0.0.0.0 to bind to all interfaces.
-
-#### `package_ensure`
-
-Determines the ensure state of the package.  Set to installed by default, but could
-be changed to latest.
-
-#### `package_gpg_key`
-
-This should generally be left as default. If using a package not signed by the
-RabbitMQ signing key, you can use this parameter to override the expected key.
-
-#### `package_name`
-
-The name of the package to install.
-
-#### `port`
-
-The RabbitMQ port.
-
-#### `repos_ensure`
-
-Ensure that a repo with the official (and newer) RabbitMQ package is configured,
-along with its signing key. Defaults to false (use system packages). This does
-*not* ensure that soft dependencies (like EPEL on RHEL systems) are present.
-
-#### `service_ensure`
-
-The state of the service.
-
-#### `service_manage`
-
-Determines if the service is managed.
-
-#### `service_name`
-
-The name of the service to manage.
-
-#### `ssl`
-
-Configures the service for using SSL.
-
-#### `ssl_only`
-
-Configures the service to only use SSL.  No cleartext TCP listeners will be created.
-Requires that ssl => true and port => undef also
-
-#### `ssl_cacert`
-
-CA cert path to use for SSL.
-
-#### `ssl_cert`
-
-Cert to use for SSL.
-
-#### `ssl_key`
-
-Key to use for SSL.
-
-#### `ssl_cert_password`
-
-Password used when generating CSR.
-
-#### `ssl_depth`
-
-SSL verification depth.
-
-#### `ssl_management_port`
-
-SSL management port.
-
-#### `ssl_stomp_port`
-
-SSL stomp port.
-
-#### `ssl_verify`
-
-rabbitmq.config SSL verify setting.
-
-#### `ssl_fail_if_no_peer_cert`
-
-rabbitmq.config `fail_if_no_peer_cert` setting.
-
-#### `ssl_versions`
-
-Choose which SSL versions to enable. Example: `['tlsv1.2', 'tlsv1.1']`.
-
-Note that it is recommended to disable `sslv3` and `tlsv1` to prevent against POODLE and BEAST attacks. Please see the [RabbitMQ SSL](https://www.rabbitmq.com/ssl.html) documentation for more information.
-
-#### `ssl_ciphers`
-
-Support only a given list of SSL ciphers. Example: `['dhe_rsa,aes_256_cbc,sha','dhe_dss,aes_256_cbc,sha','ecdhe_rsa,aes_256_cbc,sha']`.
-
-Supported ciphers in your install can be listed with:
- rabbitmqctl eval 'ssl:cipher_suites().'
-Functionality can be tested with cipherscan or similar tool: https://github.com/jvehent/cipherscan.git
-
-#### `stomp_port`
-
-The port to use for Stomp.
-
-#### `stomp_ssl_only`
-
-Configures STOMP to only use SSL.  No cleartext STOMP TCP listeners will be created.
-Requires setting ssl_stomp_port also.
-
-#### `stomp_ensure`
-
-Boolean to install the stomp plugin.
-
-#### `tcp_backlog`
-
-Integer, the size of the backlog on TCP connections.
-
-#### `tcp_keepalive`
-
-Boolean to enable TCP connection keepalive for RabbitMQ service.
-
-#### `tcp_recbuf`
-
-Integer, corresponds to recbuf in RabbitMQ `tcp_listen_options`
-
-#### `tcp_sndbuf`
-
-Integer, corresponds to sndbuf in RabbitMQ `tcp_listen_options`
-
-#### `wipe_db_on_cookie_change`
-
-Boolean to determine if we should DESTROY AND DELETE the RabbitMQ database.
-
-#### `rabbitmq_user`
-
-String: OS dependent, default defined in param.pp. The system user the rabbitmq daemon runs as.
-
-#### `rabbitmq_group`
-
-String: OS dependent, default defined in param.pp. The system group the rabbitmq daemon runs as.
-
-#### `rabbitmq_home`
-
-String: OS dependent. default defined in param.pp. The home directory of the rabbitmq deamon.
-
-## Native Types
+For convenience, some examples are duplicated here:
 
 ### rabbitmq\_user
 
@@ -508,7 +69,6 @@ rabbitmq_user { 'dan':
   tags     => ['monitoring', 'tag1'],
 }
 ```
-
 
 ### rabbitmq\_vhost
 
@@ -593,7 +153,6 @@ rabbitmq_binding { 'binding 2':
 
 ```
 
-
 ### rabbitmq\_user\_permissions
 
 ```puppet
@@ -650,27 +209,17 @@ rabbitmq_plugin {'rabbitmq_stomp':
   }
 ```
 
-### rabbitmq\_erlang\_cookie
+## Reference
 
-This is essentially a private type used by the rabbitmq::config class
-to manage the erlang cookie. It replaces the rabbitmq_erlang_cookie fact
-from earlier versions of this module. It manages the content of the cookie
-usually located at "${rabbitmq_home}/.erlang.cookie", which includes
-stopping the rabbitmq service and wiping out the database at
-"${rabbitmq_home}/mnesia" if the user agrees to it. We don't recommend using
-this type directly.
+## Classes
 
-## Limitations
-
-The module has been tested on:
-
-* RedHat Enterprise Linux 6/7
-* Debian 7/8
-* CentOS 6/7
-* Ubuntu 12.04/14.04
-
-Testing on other platforms has been light and cannot be guaranteed.
-Support for EL / CentOS 5 is deprecated.
+* rabbitmq: Main class for installation and service management.
+* rabbitmq::config: Main class for rabbitmq configuration/management.
+* rabbitmq::install: Handles package installation.
+* rabbitmq::params: Different configuration data for different systems.
+* rabbitmq::service: Handles the rabbitmq service.
+* rabbitmq::repo::apt: Handles apt repo for Debian systems.
+* rabbitmq::repo::rhel: Handles rpm repo for Redhat systems.
 
 ### Module dependencies
 

--- a/lib/puppet/type/rabbitmq_binding.rb
+++ b/lib/puppet/type/rabbitmq_binding.rb
@@ -1,5 +1,42 @@
 Puppet::Type.newtype(:rabbitmq_binding) do
-  desc 'Native type for managing rabbitmq bindings'
+  desc <<-DESC
+Native type for managing rabbitmq bindings
+
+@example Create a rabbitmq_binding
+ rabbitmq_binding { 'myexchange@myqueue@myvhost':
+   user             => 'dan',
+   password         => 'bar',
+   destination_type => 'queue',
+   routing_key      => '#',
+   arguments        => {},
+   ensure           => present,
+ }
+
+@example Create bindings with same source / destination / vhost but different routing key using individual parameters
+rabbitmq_binding { 'binding 1':
+  ensure           => present,
+  source           => 'myexchange',
+  destination      => 'myqueue',
+  vhost            => 'myvhost',
+  user             => 'dan',
+  password         => 'bar',
+  destination_type => 'queue',
+  routing_key      => 'key1',
+  arguments        => {},
+}
+
+rabbitmq_binding { 'binding 2':
+  ensure           => present,
+  source           => 'myexchange',
+  destination      => 'myqueue',
+  vhost            => 'myvhost',
+  user             => 'dan',
+  password         => 'bar',
+  destination_type => 'queue',
+  routing_key      => 'key2',
+  arguments        => {},
+}
+DESC
 
   ensurable do
     defaultto(:present)

--- a/lib/puppet/type/rabbitmq_erlang_cookie.rb
+++ b/lib/puppet/type/rabbitmq_erlang_cookie.rb
@@ -1,5 +1,15 @@
 Puppet::Type.newtype(:rabbitmq_erlang_cookie) do
-  desc 'Type to manage the rabbitmq erlang cookie securely'
+  desc <<-DESC
+Type to manage the rabbitmq erlang cookie securely
+
+This is essentially a private type used by the rabbitmq::config class
+to manage the erlang cookie. It replaces the rabbitmq_erlang_cookie fact
+from earlier versions of this module. It manages the content of the cookie
+usually located at "${rabbitmq_home}/.erlang.cookie", which includes
+stopping the rabbitmq service and wiping out the database at
+"${rabbitmq_home}/mnesia" if the user agrees to it. We don't recommend using
+this type directly.
+DESC
 
   newparam(:path, namevar: true)
 

--- a/lib/puppet/type/rabbitmq_exchange.rb
+++ b/lib/puppet/type/rabbitmq_exchange.rb
@@ -1,5 +1,21 @@
 Puppet::Type.newtype(:rabbitmq_exchange) do
-  desc 'Native type for managing rabbitmq exchanges'
+  desc <<-DESC
+Native type for managing rabbitmq exchanges
+
+@example Create a rabbitmq_exchange
+ rabbitmq_exchange { 'myexchange@myvhost':
+   user        => 'dan',
+   password    => 'bar',
+   type        => 'topic',
+   ensure      => present,
+   internal    => false,
+   auto_delete => false,
+   durable     => true,
+   arguments   => {
+     hash-header => 'message-distribution-hash'
+   }
+ }
+DESC
 
   ensurable do
     defaultto(:present)

--- a/lib/puppet/type/rabbitmq_parameter.rb
+++ b/lib/puppet/type/rabbitmq_parameter.rb
@@ -1,5 +1,25 @@
 Puppet::Type.newtype(:rabbitmq_parameter) do
-  desc 'Type for managing rabbitmq parameters'
+  desc <<-DESC
+Type for managing rabbitmq parameters
+
+@example Create some rabbitmq_parameter resources
+   rabbitmq_parameter { 'documentumShovel@/':
+     component_name => '',
+     value          => {
+         'src-uri'    => 'amqp://',
+         'src-queue'  => 'my-queue',
+         'dest-uri'   => 'amqp://remote-server',
+         'dest-queue' => 'another-queue',
+     },
+   }
+   rabbitmq_parameter { 'documentumFed@/':
+     component_name => 'federation-upstream',
+     value          => {
+         'uri'     => 'amqp://myserver',
+         'expires' => '360000',
+     },
+   }
+DESC
 
   ensurable do
     defaultto(:present)

--- a/lib/puppet/type/rabbitmq_plugin.rb
+++ b/lib/puppet/type/rabbitmq_plugin.rb
@@ -1,5 +1,15 @@
 Puppet::Type.newtype(:rabbitmq_plugin) do
-  desc 'manages rabbitmq plugins'
+  desc <<-DESC
+manages rabbitmq plugins
+
+@example query all currently enabled plugins
+ $ puppet resource rabbitmq_plugin
+
+@example Ensure a rabbitmq_plugin resource
+ rabbitmq_plugin {'rabbitmq_stomp':
+   ensure => present,
+ }
+DESC
 
   ensurable do
     defaultto(:present)

--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -1,5 +1,18 @@
 Puppet::Type.newtype(:rabbitmq_policy) do
-  desc 'Type for managing rabbitmq policies'
+  desc <<-DESC
+Type for managing rabbitmq policies
+
+@example Create a rabbitmq_policy
+ rabbitmq_policy { 'ha-all@myvhost':
+   pattern    => '.*',
+   priority   => 0,
+   applyto    => 'all',
+   definition => {
+     'ha-mode'      => 'all',
+     'ha-sync-mode' => 'automatic',
+   },
+ }
+DESC
 
   ensurable do
     defaultto(:present)

--- a/lib/puppet/type/rabbitmq_queue.rb
+++ b/lib/puppet/type/rabbitmq_queue.rb
@@ -1,5 +1,20 @@
 Puppet::Type.newtype(:rabbitmq_queue) do
-  desc 'Native type for managing rabbitmq queue'
+  desc <<-DESC
+Native type for managing rabbitmq queue
+
+@example Create a rabbitmq_queue
+ rabbitmq_queue { 'myqueue@myvhost':
+   ensure      => present,
+   user        => 'dan',
+   password    => 'bar',
+   durable     => true,
+   auto_delete => false,
+   arguments   => {
+     x-message-ttl          => 123,
+     x-dead-letter-exchange => 'other'
+   },
+ }
+DESC
 
   ensurable do
     defaultto(:present)

--- a/lib/puppet/type/rabbitmq_user.rb
+++ b/lib/puppet/type/rabbitmq_user.rb
@@ -1,5 +1,24 @@
 Puppet::Type.newtype(:rabbitmq_user) do
-  desc 'Native type for managing rabbitmq users'
+  desc <<-DESC
+Native type for managing rabbitmq users
+
+@example query all current users
+ $ puppet resource rabbitmq_user
+
+@example Configure a user, dan
+ rabbitmq_user { 'dan':
+   admin    => true,
+   password => 'bar',
+ }
+
+@example Optional parameter tags will set further rabbitmq tags like monitoring, policymaker, etc.
+ To set the administrator tag use admin-flag.
+ rabbitmq_user { 'dan':
+   admin    => true,
+   password => 'bar',
+   tags     => ['monitoring', 'tag1'],
+ }
+DESC
 
   ensurable do
     defaultto(:present)

--- a/lib/puppet/type/rabbitmq_user_permissions.rb
+++ b/lib/puppet/type/rabbitmq_user_permissions.rb
@@ -1,5 +1,14 @@
 Puppet::Type.newtype(:rabbitmq_user_permissions) do
-  desc 'Type for managing rabbitmq user permissions'
+  desc <<-DESC
+Type for managing rabbitmq user permissions
+
+@example Define some rabbitmq_user_permissions
+ rabbitmq_user_permissions { 'dan@myvhost':
+   configure_permission => '.*',
+   read_permission      => '.*',
+   write_permission     => '.*',
+ }
+DESC
 
   ensurable do
     defaultto(:present)

--- a/lib/puppet/type/rabbitmq_vhost.rb
+++ b/lib/puppet/type/rabbitmq_vhost.rb
@@ -1,5 +1,15 @@
 Puppet::Type.newtype(:rabbitmq_vhost) do
-  desc 'manages rabbitmq vhosts'
+  desc <<-DESC
+Native type for managing rabbitmq vhosts
+
+@example query all current vhosts
+ $ puppet resource rabbitmq_vhost`
+
+@example Create a rabbitmq_vhost
+ rabbitmq_vhost { 'myvhost':
+   ensure => present,
+ }
+DESC
 
   ensurable do
     defaultto(:present)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,188 @@
 # rabbitmq
 #
-# @summary Main class for rabbitmq module
+# @summary A module to manage RabbitMQ
 #
-# @example Declaring the class
-#   class { 'rabbitmq': }
+# @example Basic usage
+#  include '::rabbitmq'
 #
+# @example rabbitmq class
+#  class { '::rabbitmq':
+#    service_manage    => false,
+#    port              => '5672',
+#    delete_guest_user => true,
+#  }
+#
+# @example Offline installation from local mirror:
+#
+#  class { '::rabbitmq':
+#    key_content     => template('openstack/rabbit.pub.key'),
+#    package_gpg_key => '/tmp/rabbit.pub.key',
+#  }
+#
+# @example Use external package key source for any (apt/rpm) package provider:
+#  class { '::rabbitmq':
+#    package_gpg_key => 'http://www.some_site.some_domain/some_key.pub.key',
+#  }
+#
+# @example To use RabbitMQ Environment Variables, use the parameters `environment_variables` e.g.:
+#
+#  class { 'rabbitmq':
+#    port                  => '5672',
+#    environment_variables => {
+#      'NODENAME'    => 'node01',
+#      'SERVICENAME' => 'RabbitMQ'
+#    }
+#  }
+#
+# @example Change RabbitMQ Config Variables in rabbitmq.config:
+#
+#  class { 'rabbitmq':
+#    port             => '5672',
+#    config_variables => {
+#      'hipe_compile' => true,
+#      'frame_max'    => 131072,
+#      'log_levels'   => "[{connection, info}]"
+#    }
+#  }
+#
+# @example Change Erlang Kernel Config Variables in rabbitmq.config
+#  class { 'rabbitmq':
+#    port                    => '5672',
+#    config_kernel_variables => {
+#      'inet_dist_listen_min' => 9100,
+#      'inet_dist_listen_max' => 9105,
+#    }
+#  }
+# @example Change Management Plugin Config Variables in rabbitmq.config
+#  class { 'rabbitmq':
+#    config_management_variables => {
+#      'rates_mode' => 'basic',
+#    }
+#  }
+#
+# @example Change Additional Config Variables in rabbitmq.config
+#  class { 'rabbitmq':
+#    config_additional_variables => {
+#      'autocluster' => '[{consul_service, "rabbit"},{cluster_name, "rabbit"}]',
+#      'foo'         => '[{bar, "baz"}]'
+#    }
+#  }
+#  This will result in the following config appended to the config file:
+#  {autocluster, [{consul_service, "rabbit"},{cluster_name, "rabbit"}]},
+#   {foo, [{bar, "baz"}]}
+#  (This is required for the [autocluster plugin](https://github.com/aweber/rabbitmq-autocluster)
+#
+# @example Use RabbitMQ clustering facilities
+#  class { 'rabbitmq':
+#    config_cluster           => true,
+#    cluster_nodes            => ['rabbit1', 'rabbit2'],
+#    cluster_node_type        => 'ram',
+#    erlang_cookie            => 'A_SECRET_COOKIE_STRING',
+#    wipe_db_on_cookie_change => true,
+#  }
+#
+# @param admin_enable If enabled sets up the management interface/plugin for RabbitMQ.
+# @param auth_backends An array specifying authorization/authentication backend to use. Single quotes should be placed around array entries, ex. ['{foo, baz}', 'baz'] Defaults to [rabbit_auth_backend_internal], and if using LDAP defaults to [rabbit_auth_backend_internal, rabbit_auth_backend_ldap].
+# @param cluster_node_type Choose between disc and ram nodes.
+# @param cluster_nodes An array of nodes for clustering.
+# @param cluster_partition_handling Value to set for `cluster_partition_handling` RabbitMQ configuration variable.
+# @param collect_statistics_interval Set the collect_statistics_interval in rabbitmq.config
+# @param config The file to use as the rabbitmq.config template.
+# @param config_additional_variables Additional config variables in rabbitmq.config
+# @param config_cluster Enable or disable clustering support.
+# @param config_kernel_variables Hash of Erlang kernel configuration variables to set (see [Variables Configurable in rabbitmq.config](#variables-configurable-in-rabbitmq.config)).
+# @param config_path The path to write the RabbitMQ configuration file to.
+# @param config_management_variables Hash of configuration variables for the [Management Plugin](https://www.rabbitmq.com/management.html).
+# @param config_stomp Enable or disable stomp.
+# @param config_shovel Enable or disable shovel.
+# @param config_shovel_statics Hash of static shovel configurations
+# @param config_variables To set config variables in rabbitmq.config
+# @param default_user Username to set for the `default_user` in rabbitmq.config.
+# @param default_pass Password to set for the `default_user` in rabbitmq.config.
+# @param delete_guest_user Controls whether default guest user is deleted.
+# @param env_config The template file to use for rabbitmq_env.config.
+# @param env_config_path The path to write the rabbitmq_env.config file to.
+# @param environment_variables RabbitMQ Environment Variables in rabbitmq_env.config
+# @param erlang_cookie The erlang cookie to use for clustering - must be the same between all nodes. This value has no default and must be
+#  set explicitly if using clustering. If you run Pacemaker and you don't want to use RabbitMQ buildin cluster, you can set config_cluster
+#  to 'False' and set 'erlang_cookie'.
+# @param file_limit Set rabbitmq file ulimit. Defaults to 16384. Only available on systems with `$::osfamily == 'Debian'` or
+#  `$::osfamily == 'RedHat'`.
+# @param heartbeat Set the heartbeat timeout interval, default is unset which uses the builtin server defaults of 60 seconds. Setting this
+# @param inetrc_config Template to use for the inetrc config
+# @param inetrc_config_path Path of the file to push the inetrc config to.
+# @param ipv6 Whether to listen on ipv6
+# @param interface Interface to bind to (sets tcp_listeners parameter). By default, bind to all interfaces
+#  to `0` will disable heartbeats.
+# @param key_content Uses content method for Debian OS family. Should be a template for apt::source class. Overrides `package_gpg_key`
+#  behavior, if enabled. Undefined by default.
+# @param ldap_auth Set to true to enable LDAP auth.
+# @param ldap_server LDAP server to use for auth.
+# @param ldap_user_dn_pattern User DN pattern for LDAP auth.
+# @param ldap_other_bind How to bind to the LDAP server. Defaults to 'anon'.
+# @param ldap_config_variables Hash of other LDAP config variables.
+# @param ldap_use_ssl Set to true to use SSL for the LDAP server.
+# @param ldap_port Numeric port for LDAP server.
+# @param ldap_log Set to true to log LDAP auth.
+# @param manage_repos Whether or not to manage package repositories.
+# @param management_hostname The hostname for the RabbitMQ management interface.
+# @param management_port The port for the RabbitMQ management interface.
 # @param management_ip_address Allows you to set the IP for management interface to bind to separately. Set to 127.0.0.1 to bind to
 #  localhost only, or 0.0.0.0 to bind to all interfaces.
+# @param management_ssl Enable/Disable SSL for the management port. Has an effect only if ssl => true.
 # @param node_ip_address Allows you to set the IP for RabbitMQ service to bind to. Set to 127.0.0.1 to bind to localhost only, or 0.0.0.0
 #  to bind to all interfaces.
+# @param package_apt_pin Whether to pin the package to a particular source
+# @param package_ensure Determines the ensure state of the package.  Set to installed by default, but could be changed to latest.
+# @param package_gpg_key RPM package GPG key to import. Uses source method. Should be a URL for Debian/RedHat OS family, or a file name for
+#  RedHat OS family. Set to http://www.rabbitmq.com/rabbitmq-signing-key-public.asc by default. Note, that `key_content`, if specified,
+#  would override this parameter for Debian OS family.
+# @param package_name The name of the package to install.
+# @param package_provider What provider to use to install the package.
+# @param package_source Where should the package be installed from? On Debian- and Arch-based systems using the default package provider,
+#  this parameter is ignored and the package is installed from the rabbitmq repository, if enabled with manage_repo => true, or from the
+#  system repository otherwise. If you want to use dpkg as the package_provider, you must specify a local package_source.
+# @param port The RabbitMQ port.
+# @param repos_ensure Ensure that a repo with the official (and newer) RabbitMQ package is configured, along with its signing key.
+#  Defaults to false (use system packages). This does not ensure that soft dependencies (like EPEL on RHEL systems) are present.
+# @param service_ensure The state of the service.
+# @param service_manage Determines if the service is managed.
+# @param service_name The name of the service to manage.
+# @param ssl Configures the service for using SSL.
+#  port => UNSET
+# @param ssl_cacert CA cert path to use for SSL.
+# @param ssl_cert Cert to use for SSL.
+# @param ssl_cert_password Password used when generating CSR.
+# @param ssl_depth SSL verification depth.
+# @param ssl_erl_dist Whether to use the erlang package's SSL (relies on the ssl_erl_path fact)
+# @param ssl_interface Interface for SSL listener to bind to
+# @param ssl_key Key to use for SSL.
+# @param ssl_only Configures the service to only use SSL.  No cleartext TCP listeners will be created. Requires that ssl => true and
+# @param ssl_management_port SSL management port.
+# @param ssl_port SSL port for RabbitMQ
+# @param ssl_stomp_port SSL stomp port.
+# @param ssl_verify rabbitmq.config SSL verify setting.
+# @param ssl_fail_if_no_peer_cert rabbitmq.config `fail_if_no_peer_cert` setting.
+# @param ssl_versions Choose which SSL versions to enable. Example: `['tlsv1.2', 'tlsv1.1']` Note that it is recommended to disable `sslv3
+#  and `tlsv1` to prevent against POODLE and BEAST attacks. Please see the [RabbitMQ SSL](https://www.rabbitmq.com/ssl.html) documentation
+#  for more information.
+# @param ssl_ciphers Support only a given list of SSL ciphers. Example: `['dhe_rsa,aes_256_cbc,sha','dhe_dss,aes_256_cbc,sha',
+#  'ecdhe_rsa,aes_256_cbc,sha']`. Supported ciphers in your install can be listed with: rabbitmqctl eval 'ssl:cipher_suites().'
+#  Functionality can be tested with cipherscan or similar tool: https://github.com/jvehent/cipherscan.git
+# @param stomp_port The port to use for Stomp.
+# @param stomp_ssl_only Configures STOMP to only use SSL.  No cleartext STOMP TCP listeners will be created. Requires setting
+#  ssl_stomp_port also.
+# @param stomp_ensure Enable to install the stomp plugin.
+# @param tcp_backlog The size of the backlog on TCP connections.
+# @param tcp_keepalive Enable TCP connection keepalive for RabbitMQ service.
+# @param tcp_recbuf Corresponds to recbuf in RabbitMQ `tcp_listen_options`
+# @param tcp_sndbuf Integer, corresponds to sndbuf in RabbitMQ `tcp_listen_options`
+# @param version Sets the version to install. On Debian- and Arch-based operating systems, the version parameter is ignored and the latest
+#  version is installed from the rabbitmq repository, if enabled with manage_repo => true, or from the system repository otherwise.
+# @param wipe_db_on_cookie_change Boolean to determine if we should DESTROY AND DELETE the RabbitMQ database.
+# @param rabbitmq_user OS dependent, default defined in param.pp. The system user the rabbitmq daemon runs as.
+# @param rabbitmq_group OS dependent, default defined in param.pp. The system group the rabbitmq daemon runs as.
+# @param rabbitmq_home OS dependent. default defined in param.pp. The home directory of the rabbitmq deamon.
 class rabbitmq(
   Boolean $admin_enable                          = $rabbitmq::params::admin_enable,
   Enum['ram', 'disk', 'disc'] $cluster_node_type = $rabbitmq::params::cluster_node_type,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
-# Class: rabbitmq::params
+# rabbitmq::params
 #
-#   The RabbitMQ Module configuration settings.
+# @summary OS Specific parameters and other settings
 #
 class rabbitmq::params {
 


### PR DESCRIPTION
This is a first pass at moving docs to puppet-strings, starting with params and examples. Only bad thing is that we might want to move some of the params that aren't os specific back to init.pp at some point, so that it's easier to see default params in the docs.