### PR TITLE
convert to "expect" spec syntax (auto-converted via transpec)

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -32,12 +32,12 @@ describe 'rabbitmq class:' do
     end
 
     describe package(package_name) do
-      it { should be_installed }      
+      it { is_expected.to be_installed }      
     end
 
     describe service(service_name) do
-      it { should be_enabled }
-      it { should be_running }
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
     end
   end
 
@@ -57,8 +57,8 @@ describe 'rabbitmq class:' do
     end
 
     describe service(service_name) do
-      it { should_not be_enabled }
-      it { should_not be_running }
+      it { is_expected.not_to be_enabled }
+      it { is_expected.not_to be_running }
     end
   end
 
@@ -88,8 +88,8 @@ describe 'rabbitmq class:' do
     end
 
     describe service(service_name) do
-      it { should be_enabled }
-      it { should be_running }
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
     end
   end
 
@@ -108,17 +108,17 @@ describe 'rabbitmq class:' do
     end
 
     describe service(service_name) do
-      it { should be_running }
+      it { is_expected.to be_running }
     end
     describe port(5672) do
-      it { should be_listening.on('0.0.0.0').with('tcp') }
+      it { is_expected.to be_listening.on('0.0.0.0').with('tcp') }
     end
     describe port(15672) do
-      it { should be_listening.on('0.0.0.0').with('tcp') }
+      it { is_expected.to be_listening.on('0.0.0.0').with('tcp') }
     end
     describe port(25672) do
       xit "Is on 55672 instead on older rmq versions" do
-        should be_listening.on('0.0.0.0').with('tcp')
+        is_expected.to be_listening.on('0.0.0.0').with('tcp')
       end
     end
   end
@@ -138,18 +138,18 @@ describe 'rabbitmq class:' do
     end
 
     describe service(service_name) do
-      it { should be_running }
+      it { is_expected.to be_running }
     end
     describe port(5672) do
-      it { should be_listening.on('127.0.0.1').with('tcp') }
+      it { is_expected.to be_listening.on('127.0.0.1').with('tcp') }
     end
     describe port(15672) do
-      it { should be_listening.on('127.0.0.1').with('tcp') }
+      it { is_expected.to be_listening.on('127.0.0.1').with('tcp') }
     end
     # This listens on all interfaces regardless of these settings
     describe port(25672) do
       xit "Is on 55672 instead on older rmq versions" do
-        should be_listening.on('0.0.0.0').with('tcp')
+        is_expected.to be_listening.on('0.0.0.0').with('tcp')
       end
     end
   end
@@ -170,17 +170,17 @@ describe 'rabbitmq class:' do
     end
 
     describe service(service_name) do
-      it { should be_running }
+      it { is_expected.to be_running }
     end
     describe port(5672) do
-      it { should be_listening.on('0.0.0.0').with('tcp') }
+      it { is_expected.to be_listening.on('0.0.0.0').with('tcp') }
     end
     describe port(15672) do
-      it { should be_listening.on('127.0.0.1').with('tcp') }
+      it { is_expected.to be_listening.on('127.0.0.1').with('tcp') }
     end
     describe port(25672) do
       xit "Is on 55672 instead on older rmq versions" do
-        should be_listening.on('0.0.0.0').with('tcp')
+        is_expected.to be_listening.on('0.0.0.0').with('tcp')
       end
     end
   end

--- a/spec/acceptance/clustering_spec.rb
+++ b/spec/acceptance/clustering_spec.rb
@@ -21,7 +21,7 @@ describe 'rabbitmq clustering' do
     end
 
     describe file('/var/lib/rabbitmq/.erlang.cookie') do
-      it { should_not contain 'TESTCOOKIE' }
+      it { is_expected.not_to contain 'TESTCOOKIE' }
     end
 
   end
@@ -45,16 +45,16 @@ describe 'rabbitmq clustering' do
     end
 
     describe file('/etc/rabbitmq/rabbitmq.config') do
-      it { should be_file }
-      it { should contain 'cluster_nodes' }
-      it { should contain 'rabbit@rabbit1' }
-      it { should contain 'rabbit@rabbit2' }
-      it { should contain 'ram' }
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'cluster_nodes' }
+      it { is_expected.to contain 'rabbit@rabbit1' }
+      it { is_expected.to contain 'rabbit@rabbit2' }
+      it { is_expected.to contain 'ram' }
     end
 
     describe file('/var/lib/rabbitmq/.erlang.cookie') do
-      it { should be_file }
-      it { should contain 'TESTCOOKIE' }
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'TESTCOOKIE' }
     end
   end
 end

--- a/spec/acceptance/delete_guest_user_spec.rb
+++ b/spec/acceptance/delete_guest_user_spec.rb
@@ -19,8 +19,8 @@ describe 'rabbitmq with delete_guest_user' do
     end
 
     describe file('/tmp/rabbitmqctl_users') do
-      it { should be_file }
-      it { should_not contain 'guest' }
+      it { is_expected.to be_file }
+      it { is_expected.not_to contain 'guest' }
     end
   end
 end

--- a/spec/acceptance/rabbitmqadmin_spec.rb
+++ b/spec/acceptance/rabbitmqadmin_spec.rb
@@ -18,7 +18,7 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
     end
 
     describe file('/var/lib/rabbitmq/rabbitmqadmin') do
-      it { should be_file }
+      it { is_expected.to be_file }
     end
   end
 
@@ -40,7 +40,7 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
     end
 
     describe file('/var/lib/rabbitmq/rabbitmqadmin') do
-      it { should_not be_file }
+      it { is_expected.not_to be_file }
     end
   end
 
@@ -78,7 +78,7 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
     end
 
     describe file('/var/lib/rabbitmq/rabbitmqadmin') do
-      it { should be_file }
+      it { is_expected.to be_file }
     end
   end
 

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -32,12 +32,12 @@ describe 'rabbitmq server:' do
     end
 
     describe package(package_name) do
-      it { should be_installed }      
+      it { is_expected.to be_installed }      
     end
 
     describe service(service_name) do
-      it { should be_enabled }
-      it { should be_running }
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
     end
   end
 
@@ -57,8 +57,8 @@ describe 'rabbitmq server:' do
     end
 
     describe service(service_name) do
-      it { should_not be_enabled }
-      it { should_not be_running }
+      it { is_expected.not_to be_enabled }
+      it { is_expected.not_to be_running }
     end
   end
 
@@ -89,8 +89,8 @@ describe 'rabbitmq server:' do
     end
 
     describe service(service_name) do
-      it { should be_enabled }
-      it { should be_running }
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
     end
   end
 end

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -13,11 +13,11 @@ describe 'rabbitmq' do
   context 'on Debian' do
     with_debian_facts
     it 'should not include rabbitmq::repo::apt' do
-      should_not  contain_class('rabbitmq::repo::apt')
+      is_expected.not_to  contain_class('rabbitmq::repo::apt')
     end
 
     it 'does ensure rabbitmq apt::source is absent when repos_ensure is false' do
-      should_not contain_apt__source('rabbitmq')
+      is_expected.not_to contain_apt__source('rabbitmq')
     end
   end
 
@@ -26,12 +26,12 @@ describe 'rabbitmq' do
     with_debian_facts
 
     it 'includes rabbitmq::repo::apt' do
-      should contain_class('rabbitmq::repo::apt')
+      is_expected.to contain_class('rabbitmq::repo::apt')
     end
 
     describe 'apt::source default values' do
       it 'should add a repo with default values' do
-        should contain_apt__source('rabbitmq').with( {
+        is_expected.to contain_apt__source('rabbitmq').with( {
           :ensure   => 'present',
           :location => 'http://www.rabbitmq.com/debian/',
           :release  => 'testing',
@@ -42,27 +42,27 @@ describe 'rabbitmq' do
 
     context 'with file_limit => unlimited' do
       let(:params) {{ :file_limit => 'unlimited' }}
-      it { should contain_file('/etc/default/rabbitmq-server').with_content(/ulimit -n unlimited/) }
+      it { is_expected.to contain_file('/etc/default/rabbitmq-server').with_content(/ulimit -n unlimited/) }
     end
 
     context 'with file_limit => infinity' do
       let(:params) {{ :file_limit => 'infinity' }}
-      it { should contain_file('/etc/default/rabbitmq-server').with_content(/ulimit -n infinity/) }
+      it { is_expected.to contain_file('/etc/default/rabbitmq-server').with_content(/ulimit -n infinity/) }
     end
 
     context 'with file_limit => \'-1\'' do
       let(:params) {{ :file_limit => '-1' }}
-      it { should contain_file('/etc/default/rabbitmq-server').with_content(/ulimit -n -1/) }
+      it { is_expected.to contain_file('/etc/default/rabbitmq-server').with_content(/ulimit -n -1/) }
     end
 
     context 'with file_limit => \'1234\'' do
       let(:params) {{ :file_limit => '1234' }}
-      it { should contain_file('/etc/default/rabbitmq-server').with_content(/ulimit -n 1234/) }
+      it { is_expected.to contain_file('/etc/default/rabbitmq-server').with_content(/ulimit -n 1234/) }
     end
 
     context 'with file_limit => 1234' do
       let(:params) {{ :file_limit => 1234 }}
-      it { should contain_file('/etc/default/rabbitmq-server').with_content(/ulimit -n 1234/) }
+      it { is_expected.to contain_file('/etc/default/rabbitmq-server').with_content(/ulimit -n 1234/) }
     end
 
     context 'with file_limit => \'-42\'' do
@@ -83,12 +83,12 @@ describe 'rabbitmq' do
   context 'on Redhat' do
     with_redhat_facts
     it 'should not include rabbitmq::repo::rhel' do
-      should_not contain_class('rabbitmq::repo::rhel')
+      is_expected.not_to contain_class('rabbitmq::repo::rhel')
     end
 
     context 'with file_limit => \'unlimited\'' do
       let(:params) {{ :file_limit => 'unlimited' }}
-      it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
+      it { is_expected.to contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
         'owner'   => '0',
         'group'   => '0',
         'mode'    => '0644',
@@ -101,7 +101,7 @@ rabbitmq hard nofile unlimited
 
     context 'with file_limit => \'infinity\'' do
       let(:params) {{ :file_limit => 'infinity' }}
-      it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
+      it { is_expected.to contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
         'owner'   => '0',
         'group'   => '0',
         'mode'    => '0644',
@@ -114,7 +114,7 @@ rabbitmq hard nofile infinity
 
     context 'with file_limit => \'-1\'' do
       let(:params) {{ :file_limit => '-1' }}
-      it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
+      it { is_expected.to contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
         'owner'   => '0',
         'group'   => '0',
         'mode'    => '0644',
@@ -127,7 +127,7 @@ rabbitmq hard nofile -1
 
     context 'with file_limit => \'1234\'' do
       let(:params) {{ :file_limit => '1234' }}
-      it { should contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
+      it { is_expected.to contain_file('/etc/security/limits.d/rabbitmq-server.conf').with(
         'owner'   => '0',
         'group'   => '0',
         'mode'    => '0644',
@@ -157,10 +157,10 @@ rabbitmq hard nofile 1234
     let(:params) {{ :repos_ensure => false }}
     with_redhat_facts
     it 'does not contain class rabbitmq::repo::rhel when repos_ensure is false' do
-      should_not contain_class('rabbitmq::repo::rhel')
+      is_expected.not_to contain_class('rabbitmq::repo::rhel')
     end
     it 'should not contain "rabbitmq" repo' do
-      should_not contain_yumrepo('rabbitmq')
+      is_expected.not_to contain_yumrepo('rabbitmq')
     end
   end
 
@@ -168,13 +168,13 @@ rabbitmq hard nofile 1234
     let(:params) {{ :repos_ensure => true }}
     with_redhat_facts
     it 'should contain class rabbitmq::repo::rhel' do
-      should contain_class('rabbitmq::repo::rhel')
+      is_expected.to contain_class('rabbitmq::repo::rhel')
     end
     it 'should contain "rabbitmq" repo' do
-      should contain_yumrepo('rabbitmq')
+      is_expected.to contain_yumrepo('rabbitmq')
     end
     it 'the repo should be present, and contain the expected values' do
-      should contain_yumrepo('rabbitmq').with( {
+      is_expected.to contain_yumrepo('rabbitmq').with( {
         :ensure   => 'present',
         :baseurl  => 'https://packagecloud.io/rabbitmq/rabbitmq-server/el/$releasever/$basearch',
         :gpgkey   => 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc',
@@ -185,7 +185,7 @@ rabbitmq hard nofile 1234
   context 'on RedHat 7.0 or higher' do
     with_redhat_facts
 
-    it { should contain_file('/etc/systemd/system/rabbitmq-server.service.d').with(
+    it { is_expected.to contain_file('/etc/systemd/system/rabbitmq-server.service.d').with(
       'ensure'                  => 'directory',
       'owner'                   => '0',
       'group'                   => '0',
@@ -193,14 +193,14 @@ rabbitmq hard nofile 1234
       'selinux_ignore_defaults' => true
     ) }
 
-    it { should contain_exec('rabbitmq-systemd-reload').with(
+    it { is_expected.to contain_exec('rabbitmq-systemd-reload').with(
       'command'     => '/usr/bin/systemctl daemon-reload',
       'notify'      => 'Class[Rabbitmq::Service]',
       'refreshonly' => true
     ) }
     context 'with file_limit => \'unlimited\'' do
       let(:params) {{ :file_limit => 'unlimited' }}
-      it { should contain_file('/etc/systemd/system/rabbitmq-server.service.d/limits.conf').with(
+      it { is_expected.to contain_file('/etc/systemd/system/rabbitmq-server.service.d/limits.conf').with(
         'owner'   => '0',
         'group'   => '0',
         'mode'    => '0644',
@@ -213,7 +213,7 @@ LimitNOFILE=unlimited
 
     context 'with file_limit => \'infinity\'' do
       let(:params) {{ :file_limit => 'infinity' }}
-      it { should contain_file('/etc/systemd/system/rabbitmq-server.service.d/limits.conf').with(
+      it { is_expected.to contain_file('/etc/systemd/system/rabbitmq-server.service.d/limits.conf').with(
         'owner'   => '0',
         'group'   => '0',
         'mode'    => '0644',
@@ -226,7 +226,7 @@ LimitNOFILE=infinity
 
     context 'with file_limit => \'-1\'' do
       let(:params) {{ :file_limit => '-1' }}
-      it { should contain_file('/etc/systemd/system/rabbitmq-server.service.d/limits.conf').with(
+      it { is_expected.to contain_file('/etc/systemd/system/rabbitmq-server.service.d/limits.conf').with(
         'owner'   => '0',
         'group'   => '0',
         'mode'    => '0644',
@@ -239,7 +239,7 @@ LimitNOFILE=-1
 
     context 'with file_limit => \'1234\'' do
       let(:params) {{ :file_limit => '1234' }}
-      it { should contain_file('/etc/systemd/system/rabbitmq-server.service.d/limits.conf').with(
+      it { is_expected.to contain_file('/etc/systemd/system/rabbitmq-server.service.d/limits.conf').with(
         'owner'   => '0',
         'group'   => '0',
         'mode'    => '0644',
@@ -273,37 +273,37 @@ LimitNOFILE=1234
     context "on #{distro}" do
       with_distro_facts distro
 
-      it { should contain_class('rabbitmq::install') }
-      it { should contain_class('rabbitmq::config') }
-      it { should contain_class('rabbitmq::service') }
+      it { is_expected.to contain_class('rabbitmq::install') }
+      it { is_expected.to contain_class('rabbitmq::config') }
+      it { is_expected.to contain_class('rabbitmq::service') }
 
      context 'with admin_enable set to true' do
         let(:params) {{ :admin_enable => true, :management_ip_address => '1.1.1.1' }}
         context 'with service_manage set to true' do
           it 'we enable the admin interface by default' do
-            should contain_class('rabbitmq::install::rabbitmqadmin')
-            should contain_rabbitmq_plugin('rabbitmq_management').with(
+            is_expected.to contain_class('rabbitmq::install::rabbitmqadmin')
+            is_expected.to contain_rabbitmq_plugin('rabbitmq_management').with(
               'require' => 'Class[Rabbitmq::Install]',
               'notify'  => 'Class[Rabbitmq::Service]'
             )
-            should contain_staging__file('rabbitmqadmin').with_source("http://1.1.1.1:15672/cli/rabbitmqadmin")
+            is_expected.to contain_staging__file('rabbitmqadmin').with_source("http://1.1.1.1:15672/cli/rabbitmqadmin")
           end
         end
         context 'with $management_ip_address undef and service_manage set to true' do
           let(:params) {{ :admin_enable => true, :management_ip_address => :undef }}
           it 'we enable the admin interface by default' do
-            should contain_class('rabbitmq::install::rabbitmqadmin')
-            should contain_rabbitmq_plugin('rabbitmq_management').with(
+            is_expected.to contain_class('rabbitmq::install::rabbitmqadmin')
+            is_expected.to contain_rabbitmq_plugin('rabbitmq_management').with(
               'require' => 'Class[Rabbitmq::Install]',
               'notify'  => 'Class[Rabbitmq::Service]'
             )
-            should contain_staging__file('rabbitmqadmin').with_source("http://127.0.0.1:15672/cli/rabbitmqadmin")
+            is_expected.to contain_staging__file('rabbitmqadmin').with_source("http://127.0.0.1:15672/cli/rabbitmqadmin")
           end
         end
         context 'with service_manage set to true, node_ip_address = undef, and default user/pass specified' do
           let(:params) {{ :admin_enable => true, :default_user => 'foobar', :default_pass => 'hunter2', :node_ip_address => :undef }}
           it 'we use the correct URL to rabbitmqadmin' do
-            should contain_staging__file('rabbitmqadmin').with(
+            is_expected.to contain_staging__file('rabbitmqadmin').with(
               :source      => 'http://127.0.0.1:15672/cli/rabbitmqadmin',
               :curl_option => '-u "foobar:hunter2" -k  --retry 30 --retry-delay 6',
             )
@@ -312,7 +312,7 @@ LimitNOFILE=1234
         context 'with service_manage set to true and default user/pass specified' do
           let(:params) {{ :admin_enable => true, :default_user => 'foobar', :default_pass => 'hunter2', :management_ip_address => '1.1.1.1' }}
           it 'we use the correct URL to rabbitmqadmin' do
-            should contain_staging__file('rabbitmqadmin').with(
+            is_expected.to contain_staging__file('rabbitmqadmin').with(
               :source      => 'http://1.1.1.1:15672/cli/rabbitmqadmin',
               :curl_option => '-u "foobar:hunter2" -k --noproxy 1.1.1.1 --retry 30 --retry-delay 6',
             )
@@ -322,7 +322,7 @@ LimitNOFILE=1234
           # note that the 2.x management port is 55672 not 15672
           let(:params) {{ :admin_enable => true, :management_port => 55672, :management_ip_address => '1.1.1.1' }}
           it 'we use the correct URL to rabbitmqadmin' do
-            should contain_staging__file('rabbitmqadmin').with(
+            is_expected.to contain_staging__file('rabbitmqadmin').with(
               :source      => 'http://1.1.1.1:55672/cli/rabbitmqadmin',
               :curl_option => '-u "guest:guest" -k --noproxy 1.1.1.1 --retry 30 --retry-delay 6',
             )
@@ -332,7 +332,7 @@ LimitNOFILE=1234
           # note that the 2.x management port is 55672 not 15672
           let(:params) {{ :admin_enable => true, :management_port => 55672, :management_ip_address => '::1' }}
           it 'we use the correct URL to rabbitmqadmin' do
-            should contain_staging__file('rabbitmqadmin').with(
+            is_expected.to contain_staging__file('rabbitmqadmin').with(
               :source      => 'http://[::1]:55672/cli/rabbitmqadmin',
               :curl_option => '-u "guest:guest" -k --noproxy ::1 -g -6 --retry 30 --retry-delay 6',
             )
@@ -341,21 +341,21 @@ LimitNOFILE=1234
         context 'with service_manage set to false' do
           let(:params) {{ :admin_enable => true, :service_manage => false }}
           it 'should do nothing' do
-            should_not contain_class('rabbitmq::install::rabbitmqadmin')
-            should_not contain_rabbitmq_plugin('rabbitmq_management')
+            is_expected.not_to contain_class('rabbitmq::install::rabbitmqadmin')
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_management')
           end
         end
       end
 
       describe 'manages configuration directory correctly' do
-        it { should contain_file('/etc/rabbitmq').with(
+        it { is_expected.to contain_file('/etc/rabbitmq').with(
           'ensure' => 'directory',
           'mode'   => '0755'
         )}
       end
 
       describe 'manages configuration file correctly' do
-        it { should contain_file('rabbitmq.config').with(
+        it { is_expected.to contain_file('rabbitmq.config').with(
           'owner' => '0',
           'group' => 'rabbitmq',
           'mode'  => '0640'
@@ -379,7 +379,7 @@ LimitNOFILE=1234
             :wipe_db_on_cookie_change => true
           }}
           it 'contains the rabbitmq_erlang_cookie' do
-            should contain_rabbitmq_erlang_cookie('/var/lib/rabbitmq/.erlang.cookie')
+            is_expected.to contain_rabbitmq_erlang_cookie('/var/lib/rabbitmq/.erlang.cookie')
           end
         end
 
@@ -389,7 +389,7 @@ LimitNOFILE=1234
             :erlang_cookie            => 'TESTCOOKIE',
           }}
           it 'contains the rabbitmq_erlang_cookie' do
-            should contain_rabbitmq_erlang_cookie('/var/lib/rabbitmq/.erlang.cookie')
+            is_expected.to contain_rabbitmq_erlang_cookie('/var/lib/rabbitmq/.erlang.cookie')
           end
         end
 
@@ -398,7 +398,7 @@ LimitNOFILE=1234
             :config_cluster           => false,
           }}
           it 'contains the rabbitmq_erlang_cookie' do
-            should_not contain_rabbitmq_erlang_cookie('/var/lib/rabbitmq/.erlang.cookie')
+            is_expected.not_to contain_rabbitmq_erlang_cookie('/var/lib/rabbitmq/.erlang.cookie')
           end
         end
 
@@ -411,7 +411,7 @@ LimitNOFILE=1234
             :wipe_db_on_cookie_change => true
           }}
           it 'for cluster_nodes' do
-            should contain_file('rabbitmq.config').with({
+            is_expected.to contain_file('rabbitmq.config').with({
               'content' => /cluster_nodes.*\['rabbit@hare-1', 'rabbit@hare-2'\], ram/,
             })
           end
@@ -423,7 +423,7 @@ LimitNOFILE=1234
 
         context 'with default params' do
           it 'should set environment variables' do
-            should contain_file('rabbitmq-env.config') \
+            is_expected.to contain_file('rabbitmq-env.config') \
               .with_content(%r{ERL_INETRC=/etc/rabbitmq/inetrc})
           end
         end
@@ -440,7 +440,7 @@ LimitNOFILE=1234
             'SERVER_START_ARGS'  => 'debug'
           }}}
           it 'should set environment variables' do
-            should contain_file('rabbitmq-env.config') \
+            is_expected.to contain_file('rabbitmq-env.config') \
               .with_content(/NODE_IP_ADDRESS=1.1.1.1/) \
               .with_content(/NODE_PORT=5656/) \
               .with_content(/NODENAME=HOSTNAME/) \
@@ -455,13 +455,13 @@ LimitNOFILE=1234
 
       context 'delete_guest_user' do
         describe 'should do nothing by default' do
-          it { should_not contain_rabbitmq_user('guest') }
+          it { is_expected.not_to contain_rabbitmq_user('guest') }
         end
 
         describe 'delete user when delete_guest_user set' do
           let(:params) {{ :delete_guest_user => true }}
           it 'removes the user' do
-            should contain_rabbitmq_user('guest').with(
+            is_expected.to contain_rabbitmq_user('guest').with(
               'ensure'   => 'absent',
               'provider' => 'rabbitmqctl'
             )
@@ -473,21 +473,21 @@ LimitNOFILE=1234
         describe 'node_ip_address when set' do
           let(:params) {{ :node_ip_address => '172.0.0.1' }}
           it 'should set NODE_IP_ADDRESS to specified value' do
-            should contain_file('rabbitmq-env.config').
+            is_expected.to contain_file('rabbitmq-env.config').
               with_content(%r{NODE_IP_ADDRESS=172\.0\.0\.1})
           end
         end
 
         describe 'stomp by default' do
           it 'should not specify stomp parameters in rabbitmq.config' do
-            should contain_file('rabbitmq.config').without({
+            is_expected.to contain_file('rabbitmq.config').without({
               'content' => /stomp/,})
           end
         end
         describe 'stomp when set' do
           let(:params) {{ :config_stomp => true, :stomp_port => 5679 }}
           it 'should specify stomp port in rabbitmq.config' do
-            should contain_file('rabbitmq.config').with({
+            is_expected.to contain_file('rabbitmq.config').with({
               'content' => /rabbitmq_stomp.*tcp_listeners, \[5679\]/m,
             })
           end
@@ -495,7 +495,7 @@ LimitNOFILE=1234
         describe 'stomp when set ssl port w/o ssl enabled' do
           let(:params) {{ :config_stomp => true, :stomp_port => 5679, :ssl => false, :ssl_stomp_port => 5680 }}
           it 'should not configure ssl_listeners in rabbitmq.config' do
-            should contain_file('rabbitmq.config').without({
+            is_expected.to contain_file('rabbitmq.config').without({
               'content' => /rabbitmq_stomp.*ssl_listeners, \[5680\]/m,
             })
           end
@@ -503,7 +503,7 @@ LimitNOFILE=1234
         describe 'stomp when set with ssl' do
           let(:params) {{ :config_stomp => true, :stomp_port => 5679, :ssl => true, :ssl_stomp_port => 5680 }}
           it 'should specify stomp port and ssl stomp port in rabbitmq.config' do
-            should contain_file('rabbitmq.config').with({
+            is_expected.to contain_file('rabbitmq.config').with({
               'content' => /rabbitmq_stomp.*tcp_listeners, \[5679\].*ssl_listeners, \[5680\]/m,
             })
           end
@@ -524,7 +524,7 @@ LimitNOFILE=1234
           }
         end
 
-        it { should contain_rabbitmq_plugin('rabbitmq_auth_backend_ldap') }
+        it { is_expected.to contain_rabbitmq_plugin('rabbitmq_auth_backend_ldap') }
 
         it 'should contain ldap parameters' do
           verify_contents(catalogue, 'rabbitmq.config',
@@ -550,7 +550,7 @@ LimitNOFILE=1234
           }
         end
 
-        it { should contain_rabbitmq_plugin('rabbitmq_auth_backend_ldap') }
+        it { is_expected.to contain_rabbitmq_plugin('rabbitmq_auth_backend_ldap') }
 
         it 'should contain ldap parameters' do
           verify_contents(catalogue, 'rabbitmq.config',
@@ -590,9 +590,9 @@ LimitNOFILE=1234
           }
         end
 
-        it { should contain_rabbitmq_plugin('rabbitmq_shovel') }
+        it { is_expected.to contain_rabbitmq_plugin('rabbitmq_shovel') }
 
-        it { should contain_rabbitmq_plugin('rabbitmq_shovel_management') }
+        it { is_expected.to contain_rabbitmq_plugin('rabbitmq_shovel_management') }
 
         describe 'with admin_enable false' do
           let :params do
@@ -602,7 +602,7 @@ LimitNOFILE=1234
             }
           end
 
-          it { should_not contain_rabbitmq_plugin('rabbitmq_shovel_management') }
+          it { is_expected.not_to contain_rabbitmq_plugin('rabbitmq_shovel_management') }
         end
 
         describe 'with static shovels' do
@@ -642,9 +642,9 @@ LimitNOFILE=1234
           }
         end
 
-        it { should contain_rabbitmq_plugin('rabbitmq_shovel') }
+        it { is_expected.to contain_rabbitmq_plugin('rabbitmq_shovel') }
 
-        it { should contain_rabbitmq_plugin('rabbitmq_shovel_management') }
+        it { is_expected.to contain_rabbitmq_plugin('rabbitmq_shovel_management') }
 
         describe 'with admin_enable false' do
           let :params do
@@ -654,7 +654,7 @@ LimitNOFILE=1234
             }
           end
 
-          it { should_not contain_rabbitmq_plugin('rabbitmq_shovel_management') }
+          it { is_expected.not_to contain_rabbitmq_plugin('rabbitmq_shovel_management') }
         end
 
         describe 'with static shovels' do
@@ -690,7 +690,7 @@ LimitNOFILE=1234
       describe 'default_user and default_pass set' do
         let(:params) {{ :default_user => 'foo', :default_pass => 'bar' }}
         it 'should set default_user and default_pass to specified values' do
-          should contain_file('rabbitmq.config').with({
+          is_expected.to contain_file('rabbitmq.config').with({
             'content' => /default_user, <<"foo">>.*default_pass, <<"bar">>/m,
           })
         end
@@ -702,7 +702,7 @@ LimitNOFILE=1234
         } }
 
         it 'should set ssl options to specified values' do
-          should contain_file('rabbitmq.config').with_content(%r{tcp_listeners, \[\{"0.0.0.0", 5672\}\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{tcp_listeners, \[\{"0.0.0.0", 5672\}\]})
         end
       end
 
@@ -718,27 +718,27 @@ LimitNOFILE=1234
         } }
 
         it 'should set ssl options to specified values' do
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{ssl_listeners, \[3141\]}
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{ssl_options, \[}
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{cacertfile,"/path/to/cacert"}
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{certfile,"/path/to/cert"}
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{keyfile,"/path/to/key"}
           )
         end
         it 'should set non ssl port for management port' do
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{port, 13142}
           )
-          should contain_file('rabbitmqadmin.conf').with_content(
+          is_expected.to contain_file('rabbitmqadmin.conf').with_content(
             %r{port\s=\s13142}
           )
         end
@@ -756,44 +756,44 @@ LimitNOFILE=1234
         } }
 
         it 'should set ssl options to specified values' do
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{ssl_listeners, \[3141\]}
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{ssl_opts, }
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{ssl_options, \[}
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{cacertfile,"/path/to/cacert"}
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{certfile,"/path/to/cert"}
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{keyfile,"/path/to/key"}
           )
         end
         it 'should set ssl managment port to specified values' do
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{port, 13141}
           )
         end
         it 'should set ssl options in the rabbitmqadmin.conf' do
-          should contain_file('rabbitmqadmin.conf').with_content(
+          is_expected.to contain_file('rabbitmqadmin.conf').with_content(
             %r{ssl_ca_cert_file\s=\s/path/to/cacert}
           )
-          should contain_file('rabbitmqadmin.conf').with_content(
+          is_expected.to contain_file('rabbitmqadmin.conf').with_content(
             %r{ssl_cert_file\s=\s/path/to/cert}
           )
-          should contain_file('rabbitmqadmin.conf').with_content(
+          is_expected.to contain_file('rabbitmqadmin.conf').with_content(
             %r{ssl_key_file\s=\s/path/to/key}
           )
-          should contain_file('rabbitmqadmin.conf').with_content(
+          is_expected.to contain_file('rabbitmqadmin.conf').with_content(
             %r{hostname\s=\s}
           )
-          should contain_file('rabbitmqadmin.conf').with_content(
+          is_expected.to contain_file('rabbitmqadmin.conf').with_content(
             %r{port\s=\s13141}
           )
         end
@@ -809,19 +809,19 @@ LimitNOFILE=1234
         } }
 
         it 'should set ssl options to specified values' do
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{ssl_listeners, \[3141\]}
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{ssl_options, \[}
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{cacertfile,"/path/to/cacert"}
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{certfile,"/path/to/cert"}
           )
-          should contain_file('rabbitmq.config').with_content(
+          is_expected.to contain_file('rabbitmq.config').with_content(
             %r{keyfile,"/path/to/key"}
           )
         end
@@ -839,10 +839,10 @@ LimitNOFILE=1234
         } }
 
         it 'should set ssl options to specified values' do
-          should contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[\{"0.0.0.0", 3141\}\]})
-          should contain_file('rabbitmq.config').with_content(%r{cacertfile,"/path/to/cacert"})
-          should contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
-          should contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[\{"0.0.0.0", 3141\}\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{cacertfile,"/path/to/cacert"})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
         end
       end
 
@@ -859,15 +859,15 @@ LimitNOFILE=1234
         } }
 
         it 'should set ssl options to specified values' do
-          should contain_file('rabbitmq.config').with_content(%r{tcp_listeners, \[\]})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[3141\]})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_options, \[})
-          should contain_file('rabbitmq.config').with_content(%r{cacertfile,"/path/to/cacert"})
-          should contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
-          should contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{tcp_listeners, \[\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[3141\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl_options, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{cacertfile,"/path/to/cacert"})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
         end
         it 'should not set TCP listener environment defaults' do
-          should contain_file('rabbitmq-env.config') \
+          is_expected.to contain_file('rabbitmq-env.config') \
             .without_content(%r{NODE_PORT=}) \
             .without_content(%r{NODE_IP_ADDRESS=})
         end
@@ -885,11 +885,11 @@ LimitNOFILE=1234
         } }
 
         it 'should set ssl options to specified values' do
-          should contain_file('rabbitmq.config').with_content(%r{tcp_listeners, \[\]})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[\{"0.0.0.0", 3141\}\]})
-          should contain_file('rabbitmq.config').with_content(%r{cacertfile,"/path/to/cacert"})
-          should contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
-          should contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{tcp_listeners, \[\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[\{"0.0.0.0", 3141\}\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{cacertfile,"/path/to/cacert"})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
         end
       end
 
@@ -904,13 +904,13 @@ LimitNOFILE=1234
         } }
 
         it 'should set ssl options to specified values' do
-          should contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[3141\]})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_options, \[})
-          should contain_file('rabbitmq.config').with_content(%r{cacertfile,"/path/to/cacert"})
-          should contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
-          should contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
-          should contain_file('rabbitmq.config').with_content(%r{ssl, \[\{versions, \['tlsv1.1', 'tlsv1.2'\]\}\]})
-          should contain_file('rabbitmq.config').with_content(%r{versions, \['tlsv1.1', 'tlsv1.2'\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl_listeners, \[3141\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl_options, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{cacertfile,"/path/to/cacert"})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{certfile,"/path/to/cert"})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{keyfile,"/path/to/key})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl, \[\{versions, \['tlsv1.1', 'tlsv1.2'\]\}\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{versions, \['tlsv1.1', 'tlsv1.2'\]})
         end
       end
 
@@ -940,7 +940,7 @@ LimitNOFILE=1234
         } }
 
         it 'should set ssl ciphers to specified values' do
-          should contain_file('rabbitmq.config').with_content(%r{ciphers,\[[[:space:]]+{dhe_rsa,aes_256_cbc,sha},[[:space:]]+{ecdhe_rsa,aes_256_cbc,sha}[[:space:]]+\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ciphers,\[[[:space:]]+{dhe_rsa,aes_256_cbc,sha},[[:space:]]+{ecdhe_rsa,aes_256_cbc,sha}[[:space:]]+\]})
         end
       end
 
@@ -956,15 +956,15 @@ LimitNOFILE=1234
         } }
 
         it 'should set admin ssl opts to specified values' do
-          should contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
-          should contain_file('rabbitmq.config').with_content(%r{listener, \[})
-          should contain_file('rabbitmq.config').with_content(%r{port, 5926\}})
-          should contain_file('rabbitmq.config').with_content(%r{ssl, true\}})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[})
-          should contain_file('rabbitmq.config').with_content(%r{cacertfile, "/path/to/cacert"\},})
-          should contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
-          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}})
-          should contain_file('rabbitmq.config').with_content(%r{,\{versions, \['tlsv1.1', 'tlsv1.2'\]\}})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{listener, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{port, 5926\}})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl, true\}})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{cacertfile, "/path/to/cacert"\},})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{,\{versions, \['tlsv1.1', 'tlsv1.2'\]\}})
         end
       end
 
@@ -979,14 +979,14 @@ LimitNOFILE=1234
         } }
 
         it 'should set rabbitmq_management ssl options to specified values' do
-          should contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
-          should contain_file('rabbitmq.config').with_content(%r{listener, \[})
-          should contain_file('rabbitmq.config').with_content(%r{port, 3141\}})
-          should contain_file('rabbitmq.config').with_content(%r{ssl, true\}})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[})
-          should contain_file('rabbitmq.config').with_content(%r{cacertfile, "/path/to/cacert"\},})
-          should contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
-          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{listener, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{port, 3141\}})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl, true\}})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{cacertfile, "/path/to/cacert"\},})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}})
         end
       end
 
@@ -998,9 +998,9 @@ LimitNOFILE=1234
         } }
 
         it 'should set rabbitmq_management  options to specified values' do
-          should contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
-          should contain_file('rabbitmq.config').with_content(%r{listener, \[})
-          should contain_file('rabbitmq.config').with_content(%r{port, 3141\}})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{listener, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{port, 3141\}})
         end
       end
 
@@ -1015,14 +1015,14 @@ LimitNOFILE=1234
         } }
 
         it 'should set rabbitmq_management ssl options to specified values' do
-          should contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
-          should contain_file('rabbitmq.config').with_content(%r{listener, \[})
-          should contain_file('rabbitmq.config').with_content(%r{port, 3141\},})
-          should contain_file('rabbitmq.config').with_content(%r{ssl, true\},})
-          should contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[})
-          should contain_file('rabbitmq.config').with_content(%r{cacertfile, "/path/to/cacert"\},})
-          should contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
-          should contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{listener, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{port, 3141\},})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl, true\},})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ssl_opts, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{cacertfile, "/path/to/cacert"\},})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{certfile, "/path/to/cert"\},})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{keyfile, "/path/to/key"\}})
         end
       end
 
@@ -1034,7 +1034,7 @@ LimitNOFILE=1234
         } }
 
         it 'should set rabbitmq_management  options to specified values' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .with_content(/\{rabbitmq_management, \[/) \
             .with_content(/\{listener, \[/) \
             .with_content(/\{port, 3141\}/)
@@ -1045,12 +1045,12 @@ LimitNOFILE=1234
         let(:params) { { :ipv6 => true } }
 
         it 'should enable resolver inet6 in inetrc' do
-          should contain_file('rabbitmq-inetrc').with_content(%r{{inet6, true}.})
+          is_expected.to contain_file('rabbitmq-inetrc').with_content(%r{{inet6, true}.})
         end
 
         context 'without other erl args' do
           it 'should enable inet6 distribution' do
-            should contain_file('rabbitmq-env.config') \
+            is_expected.to contain_file('rabbitmq-env.config') \
               .with_content(%r{^RABBITMQ_SERVER_ERL_ARGS="-proto_dist inet6_tcp"$}) \
               .with_content(%r{^RABBITMQ_CTL_ERL_ARGS="-proto_dist inet6_tcp"$})
           end
@@ -1064,7 +1064,7 @@ LimitNOFILE=1234
           }
 
           it 'should enable inet6 distribution and quote properly' do
-            should contain_file('rabbitmq-env.config') \
+            is_expected.to contain_file('rabbitmq-env.config') \
               .with_content(%r{^RABBITMQ_SERVER_ERL_ARGS="some quoted args -proto_dist inet6_tcp"$}) \
               .with_content(%r{^RABBITMQ_CTL_ERL_ARGS="other quoted args -proto_dist inet6_tcp"$})
           end
@@ -1078,7 +1078,7 @@ LimitNOFILE=1234
           }
 
           it 'should enable inet6 distribution and quote properly' do
-            should contain_file('rabbitmq-env.config') \
+            is_expected.to contain_file('rabbitmq-env.config') \
               .with_content(%r{^RABBITMQ_SERVER_ERL_ARGS="foo -proto_dist inet6_tcp"$}) \
               .with_content(%r{^RABBITMQ_CTL_ERL_ARGS="bar -proto_dist inet6_tcp"$})
           end
@@ -1095,7 +1095,7 @@ LimitNOFILE=1234
             'auth_mechanisms'               => "['PLAIN', 'AMQPLAIN']",
         }}}
         it 'should set environment variables' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .with_content(/\{hipe_compile, true\}/) \
             .with_content(/\{vm_memory_high_watermark, 0.4\}/) \
             .with_content(/\{frame_max, 131072\}/) \
@@ -1110,7 +1110,7 @@ LimitNOFILE=1234
             'inet_dist_listen_max'      => 9105,
         }}}
         it 'should set config variables' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .with_content(/\{inet_dist_listen_min, 9100\}/) \
             .with_content(/\{inet_dist_listen_max, 9105\}/)
         end
@@ -1121,7 +1121,7 @@ LimitNOFILE=1234
             'rates_mode'      => 'none',
         }}}
         it 'should set config variables' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .with_content(/\{rates_mode, none\}/)
         end
       end
@@ -1129,21 +1129,21 @@ LimitNOFILE=1234
       describe 'tcp_keepalive enabled' do
         let(:params) {{ :tcp_keepalive => true }}
         it 'should set tcp_listen_options keepalive true' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .with_content(/\{keepalive,     true\}/)
         end
       end
 
       describe 'tcp_keepalive disabled (default)' do
         it 'should not set tcp_listen_options' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .without_content(/\{keepalive,     true\}/)
         end
       end
 
       describe 'tcp_backlog with default value' do
         it 'should set tcp_listen_options backlog to 128' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .with_content(/\{backlog,       128\}/)
         end
       end
@@ -1154,14 +1154,14 @@ LimitNOFILE=1234
         end
 
         it 'should set tcp_listen_options backlog to 256' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .with_content(/\{backlog,       256\}/)
         end
       end
 
       describe 'tcp_sndbuf with default value' do
         it 'should not set tcp_listen_options sndbuf' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .without_content(/sndbuf/)
         end
       end
@@ -1172,14 +1172,14 @@ LimitNOFILE=1234
         end
 
         it 'should set tcp_listen_options sndbuf to 128' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .with_content(/\{sndbuf,       128\}/)
         end
       end
 
       describe 'tcp_recbuf with default value' do
         it 'should not set tcp_listen_options recbuf' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .without_content(/recbuf/)
         end
       end
@@ -1190,7 +1190,7 @@ LimitNOFILE=1234
         end
 
         it 'should set tcp_listen_options recbuf to 128' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .with_content(/\{recbuf,       128\}/)
         end
       end
@@ -1198,20 +1198,20 @@ LimitNOFILE=1234
       describe 'rabbitmq-heartbeat options' do
         let(:params) {{ :heartbeat => 60 }}
         it 'should set heartbeat paramter in config file' do
-          should contain_file('rabbitmq.config') \
+          is_expected.to contain_file('rabbitmq.config') \
             .with_content(/\{heartbeat, 60\}/)
         end
       end
 
       context 'delete_guest_user' do
         describe 'should do nothing by default' do
-          it { should_not contain_rabbitmq_user('guest') }
+          it { is_expected.not_to contain_rabbitmq_user('guest') }
         end
 
         describe 'delete user when delete_guest_user set' do
           let(:params) {{ :delete_guest_user => true }}
           it 'removes the user' do
-            should contain_rabbitmq_user('guest').with(
+            is_expected.to contain_rabbitmq_user('guest').with(
               'ensure'   => 'absent',
               'provider' => 'rabbitmqctl'
             )
@@ -1223,7 +1223,7 @@ LimitNOFILE=1234
       ## rabbitmq::service
       ##
       describe 'service with default params' do
-        it { should contain_service('rabbitmq-server').with(
+        it { is_expected.to contain_service('rabbitmq-server').with(
           'ensure'     => 'running',
           'enable'     => 'true',
           'hasstatus'  => 'true',
@@ -1236,7 +1236,7 @@ LimitNOFILE=1234
           { :service_ensure => 'stopped' }
         end
 
-        it { should contain_service('rabbitmq-server').with(
+        it { is_expected.to contain_service('rabbitmq-server').with(
           'ensure'    => 'stopped',
           'enable'    => false
         ) }
@@ -1247,7 +1247,7 @@ LimitNOFILE=1234
           { :service_manage => false }
         end
 
-        it { should_not contain_service('rabbitmq-server') }
+        it { is_expected.not_to contain_service('rabbitmq-server') }
       end
 
     end
@@ -1260,7 +1260,7 @@ LimitNOFILE=1234
     with_redhat_facts
     let(:params) {{ :repos_ensure  => true }}
     it 'installs the rabbitmq package' do
-      should contain_package('rabbitmq-server').with(
+      is_expected.to contain_package('rabbitmq-server').with(
         'ensure'   => 'installed',
         'name'     => 'rabbitmq-server',
       )
@@ -1271,7 +1271,7 @@ LimitNOFILE=1234
     with_redhat_facts
     let(:params) {{ :repos_ensure  => false}}
     it 'installs the rabbitmq package [from EPEL] when $repos_ensure is false' do
-      should contain_package('rabbitmq-server').with(
+      is_expected.to contain_package('rabbitmq-server').with(
         'ensure'   => 'installed',
         'name'     => 'rabbitmq-server',
       )
@@ -1281,7 +1281,7 @@ LimitNOFILE=1234
   context "on Debian" do
     with_debian_facts
     it 'installs the rabbitmq package' do
-      should contain_package('rabbitmq-server').with(
+      is_expected.to contain_package('rabbitmq-server').with(
         'ensure'   => 'installed',
         'name'     => 'rabbitmq-server',
       )
@@ -1291,7 +1291,7 @@ LimitNOFILE=1234
   context "on Archlinux" do
     with_archlinux_facts
     it 'installs the rabbitmq package' do
-      should contain_package('rabbitmq-server').with(
+      is_expected.to contain_package('rabbitmq-server').with(
         'ensure'   => 'installed',
       )
     end
@@ -1300,7 +1300,7 @@ LimitNOFILE=1234
   context "on OpenBSD" do
     with_openbsd_facts
     it 'installs the rabbitmq package' do
-      should contain_package('rabbitmq-server').with(
+      is_expected.to contain_package('rabbitmq-server').with(
         'ensure'   => 'installed',
         'name'     => 'rabbitmq',
       )
@@ -1314,7 +1314,7 @@ LimitNOFILE=1234
       let(:params) {{:repos_ensure  => true, :package_apt_pin => '' }}
       describe 'it sets up an apt::source' do
 
-        it { should contain_apt__source('rabbitmq').with(
+        it { is_expected.to contain_apt__source('rabbitmq').with(
           'location'    => 'http://www.rabbitmq.com/debian/',
           'release'     => 'testing',
           'repos'       => 'main',
@@ -1327,14 +1327,14 @@ LimitNOFILE=1234
       let(:params) {{:repos_ensure  => true, :package_apt_pin => '700' }}
       describe 'it sets up an apt::source and pin' do
 
-        it { should contain_apt__source('rabbitmq').with(
+        it { is_expected.to contain_apt__source('rabbitmq').with(
           'location'    => 'http://www.rabbitmq.com/debian/',
           'release'     => 'testing',
           'repos'       => 'main',
           'key'         => '{"id"=>"0A9AF2115F4687BD29803A206B73A36E6026DFCA", "source"=>"https://www.rabbitmq.com/rabbitmq-release-signing-key.asc", "content"=>:undef}'
         ) }
 
-        it { should contain_apt__pin('rabbitmq').with(
+        it { is_expected.to contain_apt__pin('rabbitmq').with(
           'packages' => '*',
           'priority' => '700',
           'origin'   => 'www.rabbitmq.com'

--- a/spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb
@@ -26,22 +26,22 @@ EOT
 exchange\tdst_queue\tqueue\t*\t[]
 EOT
       instances = provider_class.instances
-      instances.size.should == 1
-      instances.map do |prov|
+      expect(instances.size).to eq(1)
+      expect(instances.map do |prov|
         {
           :source      => prov.get(:source),
           :destination => prov.get(:destination),
           :vhost       => prov.get(:vhost),
           :routing_key => prov.get(:routing_key)
         }
-      end.should == [
+      end).to eq([
         {
           :source      => 'exchange',
           :destination => 'dst_queue',
           :vhost       => '/',
           :routing_key => '*'
         }
-      ]
+      ])
     end
 
     it 'should return multiple instances' do
@@ -53,15 +53,15 @@ exchange\tdst_queue\tqueue\trouting_one\t[]
 exchange\tdst_queue\tqueue\trouting_two\t[]
 EOT
       instances = provider_class.instances
-      instances.size.should == 2
-      instances.map do |prov|
+      expect(instances.size).to eq(2)
+      expect(instances.map do |prov|
         {
           :source      => prov.get(:source),
           :destination => prov.get(:destination),
           :vhost       => prov.get(:vhost),
           :routing_key => prov.get(:routing_key)
         }
-      end.should == [
+      end).to eq([
         {
           :source      => 'exchange',
           :destination => 'dst_queue',
@@ -74,7 +74,7 @@ EOT
           :vhost       => '/',
           :routing_key => 'routing_two'
         }
-      ]
+      ])
     end
   end
 

--- a/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
@@ -36,7 +36,7 @@ amq.topic       topic   false   true    false   []
 test.headers    x-consistent-hash       false   true    false   [{"hash-header","message-distribution-hash"}]
 EOT
     instances = provider_class.instances
-    instances.size.should == 9
+    expect(instances.size).to eq(9)
   end
 
   it 'should call rabbitmqadmin to create as guest' do

--- a/spec/unit/puppet/provider/rabbitmq_parameter/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_parameter/rabbitmqctl_spec.rb
@@ -40,8 +40,8 @@ describe Puppet::Type.type(:rabbitmq_parameter).provider(:rabbitmqctl) do
       :provider => described_class.name
     )
     provider = described_class.new(resource)
-    provider.should_parameter.should == 'documentumShovel'
-    provider.should_vhost.should == '/'
+    expect(provider.should_parameter).to eq('documentumShovel')
+    expect(provider.should_vhost).to eq('/')
   end
 
   it 'should fail with invalid output from list' do
@@ -53,7 +53,7 @@ describe Puppet::Type.type(:rabbitmq_parameter).provider(:rabbitmqctl) do
     provider.class.expects(:rabbitmqctl).with('list_parameters', '-q', '-p', '/').returns <<-EOT
 shovel  documentumShovel  {"src-uri":"amqp://","src-queue":"my-queue","dest-uri":"amqp://remote-server","dest-queue":"another-queue"}
 EOT
-    provider.exists?.should == {
+    expect(provider.exists?).to eq({
       :component_name => 'shovel',
       :value => {
         'src-uri'    => 'amqp://',
@@ -61,12 +61,12 @@ EOT
         'dest-uri'   => 'amqp://remote-server',
         'dest-queue' => 'another-queue',
       }
-    }
+    })
   end
 
   it 'should not match an empty list' do
     provider.class.expects(:rabbitmqctl).with('list_parameters', '-q', '-p', '/').returns ''
-    provider.exists?.should == nil
+    expect(provider.exists?).to eq(nil)
   end
 
   it 'should destroy parameter' do

--- a/spec/unit/puppet/provider/rabbitmq_plugin/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_plugin/rabbitmqctl_spec.rb
@@ -13,7 +13,7 @@ describe provider_class do
   end
   it 'should match plugins' do
     @provider.expects(:rabbitmqplugins).with('list', '-E', '-m').returns("foo\n")
-    @provider.exists?.should == 'foo'
+    expect(@provider.exists?).to eq('foo')
   end
   it 'should call rabbitmqplugins to enable' do
     @provider.expects(:rabbitmqplugins).with('enable', 'foo')

--- a/spec/unit/puppet/provider/rabbitmq_policy/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_policy/rabbitmqctl_spec.rb
@@ -34,8 +34,8 @@ describe Puppet::Type.type(:rabbitmq_policy).provider(:rabbitmqctl) do
       :provider => described_class.name
     )
     provider = described_class.new(resource)
-    provider.should_policy.should == 'ha@home'
-    provider.should_vhost.should == '/'
+    expect(provider.should_policy).to eq('ha@home')
+    expect(provider.should_vhost).to eq('/')
   end
 
   it 'should fail with invalid output from list' do
@@ -48,14 +48,14 @@ describe Puppet::Type.type(:rabbitmq_policy).provider(:rabbitmqctl) do
 / ha-all all .* {"ha-mode":"all","ha-sync-mode":"automatic"} 0
 / test exchanges .* {"ha-mode":"all"} 0
 EOT
-    provider.exists?.should == {
+    expect(provider.exists?).to eq({
       :applyto    => 'all',
       :pattern    => '.*',
       :priority   => '0',
       :definition => {
         'ha-mode'      => 'all',
         'ha-sync-mode' => 'automatic'}
-      }
+      })
   end
 
   it 'should match policies from list (<3.2.0)' do
@@ -63,19 +63,19 @@ EOT
 / ha-all .* {"ha-mode":"all","ha-sync-mode":"automatic"} 0
 / test .* {"ha-mode":"all"} 0
 EOT
-    provider.exists?.should == {
+    expect(provider.exists?).to eq({
       :applyto    => 'all',
       :pattern    => '.*',
       :priority   => '0',
       :definition => {
         'ha-mode'      => 'all',
         'ha-sync-mode' => 'automatic'}
-      }
+      })
   end
 
   it 'should not match an empty list' do
     provider.class.expects(:rabbitmqctl).with('list_policies', '-q', '-p', '/').returns ''
-    provider.exists?.should == nil
+    expect(provider.exists?).to eq(nil)
   end
 
   it 'should destroy policy' do

--- a/spec/unit/puppet/provider/rabbitmq_queue/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_queue/rabbitmqadmin_spec.rb
@@ -25,7 +25,7 @@ test  true  false []
 test2 true  false [{"x-message-ttl",342423},{"x-expires",53253232},{"x-max-length",2332},{"x-max-length-bytes",32563324242},{"x-dead-letter-exchange","amq.direct"},{"x-dead-letter-routing-key","test.routing"}]
 EOT
     instances = provider_class.instances
-    instances.size.should == 2
+    expect(instances.size).to eq(2)
   end
 
   it 'should call rabbitmqadmin to create' do

--- a/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
@@ -15,24 +15,24 @@ describe provider_class do
     @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo
 EOT
-    @provider.exists?.should == 'foo'
+    expect(@provider.exists?).to eq('foo')
   end
   it 'should match user names with 2.4.1 syntax' do
     @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo bar
 EOT
-    @provider.exists?.should == 'foo bar'
+    expect(@provider.exists?).to eq('foo bar')
   end
   it 'should not match if no users on system' do
     @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 EOT
-    @provider.exists?.should be_nil
+    expect(@provider.exists?).to be_nil
   end
   it 'should not match if no matching users on system' do
     @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 fooey
 EOT
-    @provider.exists?.should be_nil
+    expect(@provider.exists?).to be_nil
   end
   it 'should match user names from list' do
     @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
@@ -41,7 +41,7 @@ two three
 foo
 bar
 EOT
-    @provider.exists?.should == 'foo'
+    expect(@provider.exists?).to eq('foo')
   end
   it 'should create user and set password' do
     @resource[:password] = 'bar'
@@ -69,12 +69,12 @@ EOT
     @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo [administrator]
 EOT
-    @provider.admin.should == :true
+    expect(@provider.admin).to eq(:true)
     @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 one [administrator]
 foo []
 EOT
-    @provider.admin.should == :false
+    expect(@provider.admin).to eq(:false)
   end
   it 'should fail if admin value is invalid' do
     @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
@@ -200,7 +200,7 @@ EOT
     @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo [administrator]
 EOT
-    @provider.tags.should == []
+    expect(@provider.tags).to eq([])
   end
 
   it 'should return the administrator tag for non-admins' do
@@ -210,6 +210,6 @@ EOT
     @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo [administrator]
 EOT
-    @provider.tags.should == ["administrator"]
+    expect(@provider.tags).to eq(["administrator"])
   end
 end

--- a/spec/unit/puppet/provider/rabbitmq_user_permissions/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user_permissions/rabbitmqctl_spec.rb
@@ -18,13 +18,13 @@ describe 'Puppet::Type.type(:rabbitmq_user_permissions).provider(:rabbitmqctl)' 
     @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
 bar 1 2 3
 EOT
-    @provider.exists?.should == {:configure=>"1", :write=>"2", :read=>"3"}
+    expect(@provider.exists?).to eq({:configure=>"1", :write=>"2", :read=>"3"})
   end
   it 'should match user permissions with empty columns' do
     @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
 bar			3
 EOT
-    @provider.exists?.should == {:configure=>"", :write=>"", :read=>"3"}
+    expect(@provider.exists?).to eq({:configure=>"", :write=>"", :read=>"3"})
   end
   it 'should not match user permissions with more than 3 columns' do
     @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
@@ -35,7 +35,7 @@ EOT
   it 'should not match an empty list' do
     @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
 EOT
-    @provider.exists?.should == nil
+    expect(@provider.exists?).to eq(nil)
   end
   it 'should create default permissions' do
     @provider.instance_variable_set(:@should_vhost, "bar")
@@ -54,7 +54,7 @@ EOT
       @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
 bar 1 2 3
 EOT
-      @provider.send(k).should == v
+      expect(@provider.send(k)).to eq(v)
     end
   end
   {:configure_permission => '1', :write_permission => '2', :read_permission => '3'}.each do |k,v|
@@ -63,7 +63,7 @@ EOT
 bar 1 2 3
 EOT
       @provider.exists?
-      @provider.send(k).should == v
+      expect(@provider.send(k)).to eq(v)
     end
   end
   {:configure_permission => ['foo', '2', '3'],

--- a/spec/unit/puppet/provider/rabbitmq_vhost/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_vhost/rabbitmqctl_spec.rb
@@ -17,14 +17,14 @@ Listing vhosts ...
 foo
 ...done.
 EOT
-    @provider.exists?.should == 'foo'
+    expect(@provider.exists?).to eq('foo')
   end
   it 'should not match if no vhosts on system' do
     @provider.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
 Listing vhosts ...
 ...done.
 EOT
-    @provider.exists?.should be_nil
+    expect(@provider.exists?).to be_nil
   end
   it 'should not match if no matching vhosts on system' do
     @provider.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
@@ -32,7 +32,7 @@ Listing vhosts ...
 fooey
 ...done.
 EOT
-    @provider.exists?.should be_nil
+    expect(@provider.exists?).to be_nil
   end
   it 'should call rabbitmqctl to create' do
     @provider.expects(:rabbitmqctl).with('add_vhost', 'foo')

--- a/spec/unit/puppet/type/rabbitmq_binding_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_binding_spec.rb
@@ -8,7 +8,7 @@ describe Puppet::Type.type(:rabbitmq_binding) do
   end
   it 'should accept an queue name' do
     @binding[:name] = 'dan@dude@pl'
-    @binding[:name].should == 'dan@dude@pl'
+    expect(@binding[:name]).to eq('dan@dude@pl')
   end
   it 'should require a name' do
     expect {
@@ -33,14 +33,14 @@ describe Puppet::Type.type(:rabbitmq_binding) do
   end
   it 'should accept an binding destination_type' do
     @binding[:destination_type] = :exchange
-    @binding[:destination_type].should == :exchange
+    expect(@binding[:destination_type]).to eq(:exchange)
   end
   it 'should accept a user' do
     @binding[:user] = :root
-    @binding[:user].should == :root
+    expect(@binding[:user]).to eq(:root)
   end
   it 'should accept a password' do
     @binding[:password] = :PaSsw0rD
-    @binding[:password].should == :PaSsw0rD
+    expect(@binding[:password]).to eq(:PaSsw0rD)
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_exchange_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_exchange_spec.rb
@@ -11,7 +11,7 @@ describe Puppet::Type.type(:rabbitmq_exchange) do
   end
   it 'should accept an exchange name' do
     @exchange[:name] = 'dan@pl'
-    @exchange[:name].should == 'dan@pl'
+    expect(@exchange[:name]).to eq('dan@pl')
   end
   it 'should require a name' do
     expect {
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:rabbitmq_exchange) do
 
   it 'should accept an exchange type' do
     @exchange[:type] = :direct
-    @exchange[:type].should == :direct
+    expect(@exchange[:type]).to eq(:direct)
   end
   it 'should require a type' do
     expect {
@@ -46,11 +46,11 @@ describe Puppet::Type.type(:rabbitmq_exchange) do
 
   it 'should accept a user' do
     @exchange[:user] = :root
-    @exchange[:user].should == :root
+    expect(@exchange[:user]).to eq(:root)
   end
 
   it 'should accept a password' do
     @exchange[:password] = :PaSsw0rD
-    @exchange[:password].should == :PaSsw0rD
+    expect(@exchange[:password]).to eq(:PaSsw0rD)
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
 
   it 'should accept a valid name' do
     @parameter[:name] = 'documentumShovel@/'
-    @parameter[:name].should == 'documentumShovel@/'
+    expect(@parameter[:name]).to eq('documentumShovel@/')
   end
 
   it 'should require a name' do
@@ -32,7 +32,7 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
 
   it 'should accept a string' do
     @parameter[:component_name] = 'mystring'
-    @parameter[:component_name].should == 'mystring'
+    expect(@parameter[:component_name]).to eq('mystring')
   end
 
   it 'should not be empty' do
@@ -44,7 +44,7 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
   it 'should accept a valid hash for value' do
     value =  {'message-ttl' => '1800000'}
     @parameter[:value] = value
-    @parameter[:value].should == value
+    expect(@parameter[:value]).to eq(value)
   end
 
   it 'should not accept invalid hash for definition' do
@@ -64,16 +64,16 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
   it 'should accept string as myparameter' do
     value = {'myparameter' => 'mystring'}
     @parameter[:value] = value
-    @parameter[:value]['myparameter'].should be_a(String)
-    @parameter[:value]['myparameter'].should == 'mystring'
+    expect(@parameter[:value]['myparameter']).to be_a(String)
+    expect(@parameter[:value]['myparameter']).to eq('mystring')
   end
 
 
   it 'should convert to integer when string only contains numbers' do
     value = {'myparameter' => '1800000'}
     @parameter[:value] = value
-    @parameter[:value]['myparameter'].should be_a(Fixnum)
-    @parameter[:value]['myparameter'].should == 1800000
+    expect(@parameter[:value]['myparameter']).to be_a(Fixnum)
+    expect(@parameter[:value]['myparameter']).to eq(1800000)
   end
 
 end

--- a/spec/unit/puppet/type/rabbitmq_plugin_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_plugin_spec.rb
@@ -5,7 +5,7 @@ describe Puppet::Type.type(:rabbitmq_plugin) do
   end
   it 'should accept a plugin name' do
     @plugin[:name] = 'plugin-name'
-    @plugin[:name].should == 'plugin-name'
+    expect(@plugin[:name]).to eq('plugin-name')
   end
   it 'should require a name' do
     expect {
@@ -13,7 +13,7 @@ describe Puppet::Type.type(:rabbitmq_plugin) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
   it 'should default to a umask of 0022' do
-    @plugin[:umask].should == 0022
+    expect(@plugin[:umask]).to eq(0022)
   end
   it 'should not allow a non-octal value to be specified' do
     expect {

--- a/spec/unit/puppet/type/rabbitmq_policy_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_policy_spec.rb
@@ -12,7 +12,7 @@ describe Puppet::Type.type(:rabbitmq_policy) do
 
   it 'should accept a valid name' do
     @policy[:name] = 'ha-all@/'
-    @policy[:name].should == 'ha-all@/'
+    expect(@policy[:name]).to eq('ha-all@/')
   end
 
   it 'should require a name' do
@@ -29,12 +29,12 @@ describe Puppet::Type.type(:rabbitmq_policy) do
 
   it 'should accept a valid regex for pattern' do
     @policy[:pattern] = '.*?'
-    @policy[:pattern].should == '.*?'
+    expect(@policy[:pattern]).to eq('.*?')
   end
 
   it 'should accept an empty string for pattern' do
     @policy[:pattern] = ''
-    @policy[:pattern].should == ''
+    expect(@policy[:pattern]).to eq('')
   end
 
   it 'should not accept invalid regex for pattern' do
@@ -46,7 +46,7 @@ describe Puppet::Type.type(:rabbitmq_policy) do
   it 'should accept valid value for applyto' do
     [:all, :exchanges, :queues].each do |v|
       @policy[:applyto] = v
-      @policy[:applyto].should == v
+      expect(@policy[:applyto]).to eq(v)
     end
   end
 
@@ -59,7 +59,7 @@ describe Puppet::Type.type(:rabbitmq_policy) do
   it 'should accept a valid hash for definition' do
     definition = {'ha-mode' => 'all', 'ha-sync-mode' => 'automatic'}
     @policy[:definition] = definition
-    @policy[:definition].should == definition
+    expect(@policy[:definition]).to eq(definition)
   end
 
   it 'should not accept invalid hash for definition' do
@@ -75,7 +75,7 @@ describe Puppet::Type.type(:rabbitmq_policy) do
   it 'should accept valid value for priority' do
     [0, 10, '0', '10'].each do |v|
       @policy[:priority] = v
-      @policy[:priority].should == v
+      expect(@policy[:priority]).to eq(v)
     end
   end
 
@@ -90,8 +90,8 @@ describe Puppet::Type.type(:rabbitmq_policy) do
   it 'should accept and convert ha-params for ha-mode exactly' do
     definition = {'ha-mode' => 'exactly', 'ha-params' => '2'}
     @policy[:definition] = definition
-    @policy[:definition]['ha-params'].should be_a(Fixnum)
-    @policy[:definition]['ha-params'].should == 2
+    expect(@policy[:definition]['ha-params']).to be_a(Fixnum)
+    expect(@policy[:definition]['ha-params']).to eq(2)
   end
 
   it 'should not accept non-numeric ha-params for ha-mode exactly' do
@@ -104,8 +104,8 @@ describe Puppet::Type.type(:rabbitmq_policy) do
   it 'should accept and convert the expires value' do
     definition = {'expires' => '1800000'}
     @policy[:definition] = definition
-    @policy[:definition]['expires'].should be_a(Fixnum)
-    @policy[:definition]['expires'].should == 1800000
+    expect(@policy[:definition]['expires']).to be_a(Fixnum)
+    expect(@policy[:definition]['expires']).to eq(1800000)
   end
 
   it 'should not accept non-numeric expires value' do
@@ -118,8 +118,8 @@ describe Puppet::Type.type(:rabbitmq_policy) do
   it 'should accept and convert the message-ttl value' do
     definition = {'message-ttl' => '1800000'}
     @policy[:definition] = definition
-    @policy[:definition]['message-ttl'].should be_a(Fixnum)
-    @policy[:definition]['message-ttl'].should == 1800000
+    expect(@policy[:definition]['message-ttl']).to be_a(Fixnum)
+    expect(@policy[:definition]['message-ttl']).to eq(1800000)
   end
 
   it 'should not accept non-numeric message-ttl value' do
@@ -132,8 +132,8 @@ describe Puppet::Type.type(:rabbitmq_policy) do
   it 'should accept and convert the max-length value' do
     definition = {'max-length' => '1800000'}
     @policy[:definition] = definition
-    @policy[:definition]['max-length'].should be_a(Fixnum)
-    @policy[:definition]['max-length'].should == 1800000
+    expect(@policy[:definition]['max-length']).to be_a(Fixnum)
+    expect(@policy[:definition]['max-length']).to eq(1800000)
   end
 
   it 'should not accept non-numeric max-length value' do
@@ -146,8 +146,8 @@ describe Puppet::Type.type(:rabbitmq_policy) do
   it 'should accept and convert the shards-per-node value' do
     definition = {'shards-per-node' => '1800000'}
     @policy[:definition] = definition
-    @policy[:definition]['shards-per-node'].should be_a(Fixnum)
-    @policy[:definition]['shards-per-node'].should == 1800000
+    expect(@policy[:definition]['shards-per-node']).to be_a(Fixnum)
+    expect(@policy[:definition]['shards-per-node']).to eq(1800000)
   end
 
   it 'should not accept non-numeric shards-per-node value' do
@@ -160,8 +160,8 @@ describe Puppet::Type.type(:rabbitmq_policy) do
   it 'should accept and convert the ha-sync-batch-size value' do
     definition = {'ha-sync-batch-size' => '1800000'}
     @policy[:definition] = definition
-    @policy[:definition]['ha-sync-batch-size'].should be_a(Fixnum)
-    @policy[:definition]['ha-sync-batch-size'].should == 1800000
+    expect(@policy[:definition]['ha-sync-batch-size']).to be_a(Fixnum)
+    expect(@policy[:definition]['ha-sync-batch-size']).to eq(1800000)
   end
   
   it 'should not accept non-numeric ha-sync-batch-size value' do
@@ -174,10 +174,10 @@ describe Puppet::Type.type(:rabbitmq_policy) do
   it 'should accept list value in ha-params when ha-mode = nodes' do
     definition = {'ha-mode' => 'nodes', 'ha-params' => ['rabbit@rabbit-01', 'rabbit@rabbit-02']}
     @policy[:definition] = definition
-    @policy[:definition]['ha-mode'].should == 'nodes'
-    @policy[:definition]['ha-params'].should be_a(Array)
-    @policy[:definition]['ha-params'][0].should == 'rabbit@rabbit-01'
-    @policy[:definition]['ha-params'][1].should == 'rabbit@rabbit-02'
+    expect(@policy[:definition]['ha-mode']).to eq('nodes')
+    expect(@policy[:definition]['ha-params']).to be_a(Array)
+    expect(@policy[:definition]['ha-params'][0]).to eq('rabbit@rabbit-01')
+    expect(@policy[:definition]['ha-params'][1]).to eq('rabbit@rabbit-02')
   end
 
   it 'should not accept non-list value in ha-params when ha-mode = nodes' do

--- a/spec/unit/puppet/type/rabbitmq_queue_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_queue_spec.rb
@@ -12,7 +12,7 @@ describe Puppet::Type.type(:rabbitmq_queue) do
   end
   it 'should accept an queue name' do
     @queue[:name] = 'dan@pl'
-    @queue[:name].should == 'dan@pl'
+    expect(@queue[:name]).to eq('dan@pl')
   end
   it 'should require a name' do
     expect {
@@ -32,27 +32,27 @@ describe Puppet::Type.type(:rabbitmq_queue) do
 
   it 'should accept an arguments with numbers value' do
     @queue[:arguments] = {'x-message-ttl' => 30}
-    @queue[:arguments].to_json.should == "{\"x-message-ttl\":30}"
-    @queue[:arguments]['x-message-ttl'].should == 30
+    expect(@queue[:arguments].to_json).to eq("{\"x-message-ttl\":30}")
+    expect(@queue[:arguments]['x-message-ttl']).to eq(30)
   end
 
   it 'should accept an arguments with string value' do
     @queue[:arguments] = {'x-dead-letter-exchange' => 'catchallexchange'}
-    @queue[:arguments].to_json.should == "{\"x-dead-letter-exchange\":\"catchallexchange\"}"
+    expect(@queue[:arguments].to_json).to eq("{\"x-dead-letter-exchange\":\"catchallexchange\"}")
   end
 
   it 'should accept an queue durable' do
     @queue[:durable] = :true
-    @queue[:durable].should == :true
+    expect(@queue[:durable]).to eq(:true)
   end
 
   it 'should accept a user' do
     @queue[:user] = :root
-    @queue[:user].should == :root
+    expect(@queue[:user]).to eq(:root)
   end
 
   it 'should accept a password' do
     @queue[:password] = :PaSsw0rD
-    @queue[:password].should == :PaSsw0rD
+    expect(@queue[:password]).to eq(:PaSsw0rD)
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_user_permissions_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_user_permissions_spec.rb
@@ -5,7 +5,7 @@ describe Puppet::Type.type(:rabbitmq_user_permissions) do
   end
   it 'should accept a valid hostname name' do
     @perms[:name] = 'dan@bar'
-    @perms[:name].should == 'dan@bar'
+    expect(@perms[:name]).to eq('dan@bar')
   end
   it 'should require a name' do
     expect {
@@ -19,15 +19,15 @@ describe Puppet::Type.type(:rabbitmq_user_permissions) do
   end
   [:configure_permission, :read_permission, :write_permission].each do |param|
     it 'should not default to anything' do
-       @perms[param].should == nil
+       expect(@perms[param]).to eq(nil)
     end
     it "should accept a valid regex for #{param}" do
       @perms[param] = '.*?'
-      @perms[param].should == '.*?'  
+      expect(@perms[param]).to eq('.*?')  
     end
     it "should accept an empty string for #{param}" do
       @perms[param] = ''
-      @perms[param].should == ''  
+      expect(@perms[param]).to eq('')  
     end
     it "should not accept invalid regex for #{param}" do
       expect {
@@ -47,8 +47,8 @@ describe Puppet::Type.type(:rabbitmq_user_permissions) do
         [vhost, perm].each { |resource| conf.add_resource resource }
       end
       rel = perm.autorequire[0]
-      rel.source.ref.should == vhost.ref
-      rel.target.ref.should == perm.ref
+      expect(rel.source.ref).to eq(vhost.ref)
+      expect(rel.target.ref).to eq(perm.ref)
     end
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_user_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_user_spec.rb
@@ -5,12 +5,12 @@ describe Puppet::Type.type(:rabbitmq_user) do
   end
   it 'should accept a user name' do
     @user[:name] = 'dan'
-    @user[:name].should == 'dan'
-    @user[:admin].should == :false
+    expect(@user[:name]).to eq('dan')
+    expect(@user[:admin]).to eq(:false)
   end
   it 'should accept a password' do
     @user[:password] = 'foo'
-    @user[:password].should == 'foo'
+    expect(@user[:password]).to eq('foo')
   end
   it 'should require a password' do
     expect {
@@ -30,7 +30,7 @@ describe Puppet::Type.type(:rabbitmq_user) do
   [true, false, 'true', 'false'].each do |val|
     it "admin property should accept #{val}" do
       @user[:admin] = val
-      @user[:admin].should == val.to_s.to_sym
+      expect(@user[:admin]).to eq(val.to_s.to_sym)
     end
   end
   it 'should not accept non-boolean values for admin' do

--- a/spec/unit/puppet/type/rabbitmq_vhost_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_vhost_spec.rb
@@ -5,7 +5,7 @@ describe Puppet::Type.type(:rabbitmq_vhost) do
   end
   it 'should accept a vhost name' do
     @vhost[:name] = 'dan'
-    @vhost[:name].should == 'dan'
+    expect(@vhost[:name]).to eq('dan')
   end
   it 'should require a name' do
     expect {


### PR DESCRIPTION
I used transpec to convert spec tests to expect syntax. This should be merged soon or it will get out of date, and it will of course cause some hassles for existing PRs in terms of rebasing.