### PR TITLE
Switch back to using rabbitmq-plugins from system path (#566)

### DIFF
--- a/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
+++ b/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
@@ -1,10 +1,14 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
 Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins, parent: Puppet::Provider::Rabbitmqctl) do
-  case Facter.value(:osfamily)
-  when 'RedHat'
-    has_command(:rabbitmqplugins, '/usr/lib/rabbitmq/bin/rabbitmq-plugins') { environment HOME: '/tmp' }
+  # Prefer rabbitmq-plugins if it's in $PATH, but fall back to /usr/lib/rabbitmq/bin
+  if Puppet::Util.which('rabbitmq-plugins')
+    has_command(:rabbitmqplugins, 'rabbitmq-plugins') do
+      environment HOME: '/tmp'
+    end
   else
-    has_command(:rabbitmqplugins, 'rabbitmq-plugins') { environment HOME: '/tmp' }
+    has_command(:rabbitmqplugins, '/usr/lib/rabbitmq/bin/rabbitmq-plugins') do
+      environment HOME: '/tmp'
+    end
   end
 
   defaultfor feature: :posix


### PR DESCRIPTION
From #566, it seems as if the command in `/sbin` should be preferred, at least with modern RabbitMQ versions. Not sure if we need to get too smart about it, or how far back we need to support in terms of versions... presumably it would be possible to have it fall back to the second path, but not sure if that's overkill.