### PR TITLE
Enable configuring SSL for Erlang distribution

### DIFF
--- a/lib/facter/erl_ssl_path.rb
+++ b/lib/facter/erl_ssl_path.rb
@@ -1,0 +1,16 @@
+# Fact to get the ssl path for the erlang distribution in the current
+# system as described in the RabbitMQ docs [1].
+#
+# [1] https://www.rabbitmq.com/clustering-ssl.html
+Facter.add('erl_ssl_path') do
+  setcode do
+    data = false
+    if Facter::Util::Resolution.which('erl')
+      Facter::Util::Resolution.with_env('HOME' => '/root') do
+        data = Facter::Core::Execution.execute("erl -eval 'io:format(\"~p\", [code:lib_dir(ssl, ebin)]),halt().' -noshell")
+      end
+    end
+    # erl returns the string with quotes, strip them off
+    data.gsub!(/\A"|"\Z/, '')
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,6 +90,7 @@ class rabbitmq(
   Boolean $ipv6                                  = $rabbitmq::params::ipv6,
   String $inetrc_config                          = $rabbitmq::params::inetrc_config,
   Stdlib::Absolutepath $inetrc_config_path       = $rabbitmq::params::inetrc_config_path,
+  Boolean $ssl_erl_dist                          = $rabbitmq::params::ssl_erl_dist,
 ) inherits rabbitmq::params {
 
   # Validate install parameters.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -114,4 +114,5 @@ class rabbitmq::params {
   $ipv6                        = false
   $inetrc_config               = 'rabbitmq/inetrc.erb'
   $inetrc_config_path          = '/etc/rabbitmq/inetrc'
+  $ssl_erl_dist                = false
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1017,6 +1017,49 @@ LimitNOFILE=#{value}
               with_content(%r{^RABBITMQ_CTL_ERL_ARGS="bar -proto_dist inet6_tcp"$})
           end
         end
+
+        context 'with SSL and without other erl args' do
+          let(:params) {
+            { :ipv6         => true,
+              :ssl_erl_dist => true }
+          }
+          it 'enables inet6 distribution' do
+            is_expected.to contain_file('rabbitmq-env.config') \
+              .with_content(%r{^RABBITMQ_SERVER_ERL_ARGS=" -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin -proto_dist inet6_tls"$}) \
+              .with_content(%r{^RABBITMQ_CTL_ERL_ARGS=" -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin -proto_dist inet6_tls"$})
+          end
+        end
+
+        context 'with SSL and other quoted erl args' do
+          let(:params) {
+            { :ipv6         => true,
+              :ssl_erl_dist => true,
+              :environment_variables => { 'RABBITMQ_SERVER_ERL_ARGS' => '"some quoted args"',
+                                          'RABBITMQ_CTL_ERL_ARGS'    => '"other quoted args"'} }
+          }
+
+          it 'enables inet6 distribution and quote properly' do
+            is_expected.to contain_file('rabbitmq-env.config') \
+              .with_content(%r{^RABBITMQ_SERVER_ERL_ARGS="some quoted args -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin  -proto_dist inet6_tls"$}) \
+              .with_content(%r{^RABBITMQ_CTL_ERL_ARGS="other quoted args -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin  -proto_dist inet6_tls"$})
+          end
+        end
+
+        context 'with SSL and with other unquoted erl args' do
+          let(:params) {
+            { :ipv6         => true,
+              :ssl_erl_dist => true,
+              :environment_variables => { 'RABBITMQ_SERVER_ERL_ARGS' => 'foo',
+                                          'RABBITMQ_CTL_ERL_ARGS'    => 'bar'} }
+          }
+
+          it 'enables inet6 distribution and quote properly' do
+            is_expected.to contain_file('rabbitmq-env.config') \
+              .with_content(%r{^RABBITMQ_SERVER_ERL_ARGS="foo -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin  -proto_dist inet6_tls"$}) \
+              .with_content(%r{^RABBITMQ_CTL_ERL_ARGS="bar -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin  -proto_dist inet6_tls"$})
+          end
+
+        end
       end
 
       describe 'config_variables options' do

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -4,3 +4,4 @@ include RspecPuppetFacts
 add_custom_fact :puppetversion, Puppet.version      # Facter, but excluded from rspec-puppet-facts
 add_custom_fact :staging_http_get, ''               # puppet-staging
 add_custom_fact :rabbitmq_version, '3.6.1'          # puppet-rabbitmq
+add_custom_fact :erl_ssl_path, '/usr/lib64/erlang/lib/ssl-7.3.3.1/ebin'          # puppet-rabbitmq


### PR DESCRIPTION
As mentioned in the RabbitMQ documentation [1], this sets up the
necessary parameters through environment variables to use the relevant
-proto_dist value, and enable the ssl path (through the -pa option) if
necessary.

[1] https://www.rabbitmq.com/clustering-ssl.html