### PR TITLE
Switch to 'let(:foo)' syntax (resolves rubocop warnings)

### DIFF
--- a/spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb
@@ -5,15 +5,15 @@ RSpec.configure do |config|
 end
 provider_class = Puppet::Type.type(:rabbitmq_binding).provider(:rabbitmqadmin)
 describe provider_class do
-  before do
-    @resource = Puppet::Type::Rabbitmq_binding.new(
+  let(:resource) do
+    Puppet::Type::Rabbitmq_binding.new(
       name: 'source@target@/',
       destination_type: :queue,
       routing_key: 'blablub',
       arguments: {}
     )
-    @provider = provider_class.new(@resource)
   end
+  let(:provider) { provider_class.new(resource) }
 
   describe '#instances' do
     it 'returns instances' do
@@ -77,6 +77,17 @@ EOT
   end
 
   describe 'Test for prefetch error' do
+    let(:resource) do
+      Puppet::Type::Rabbitmq_binding.new(
+        name: 'binding1',
+        source: 'exchange1',
+        destination: 'destqueue',
+        destination_type: :queue,
+        routing_key: 'blablubd',
+        arguments: {}
+      )
+    end
+
     it 'exists' do
       provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
 /
@@ -90,15 +101,6 @@ EOT
 
     it 'matches' do
       # Test resource to match against
-      @resource = Puppet::Type::Rabbitmq_binding.new(
-        name: 'binding1',
-        source: 'exchange1',
-        destination: 'destqueue',
-        destination_type: :queue,
-        routing_key: 'blablubd',
-        arguments: {}
-      )
-
       provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
 /
 EOT
@@ -106,23 +108,23 @@ EOT
 exchange\tdst_queue\tqueue\t*\t[]
 EOT
 
-      provider_class.prefetch('binding1' => @resource)
+      provider_class.prefetch('binding1' => resource)
     end
   end
 
   it 'calls rabbitmqadmin to create' do
-    @provider.expects(:rabbitmqadmin).with('declare', 'binding', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'source=source', 'destination=target', 'arguments={}', 'routing_key=blablub', 'destination_type=queue')
-    @provider.create
+    provider.expects(:rabbitmqadmin).with('declare', 'binding', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'source=source', 'destination=target', 'arguments={}', 'routing_key=blablub', 'destination_type=queue')
+    provider.create
   end
 
   it 'calls rabbitmqadmin to destroy' do
-    @provider.expects(:rabbitmqadmin).with('delete', 'binding', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'source=source', 'destination_type=queue', 'destination=target', 'properties_key=blablub')
-    @provider.destroy
+    provider.expects(:rabbitmqadmin).with('delete', 'binding', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'source=source', 'destination_type=queue', 'destination=target', 'properties_key=blablub')
+    provider.destroy
   end
 
   context 'specifying credentials' do
-    before do
-      @resource = Puppet::Type::Rabbitmq_binding.new(
+    let(:resource) do
+      Puppet::Type::Rabbitmq_binding.new(
         name: 'source@test2@/',
         destination_type: :queue,
         routing_key: 'blablubd',
@@ -130,18 +132,18 @@ EOT
         user: 'colin',
         password: 'secret'
       )
-      @provider = provider_class.new(@resource)
     end
+    let(:provider) { provider_class.new(resource) }
 
     it 'calls rabbitmqadmin to create' do
-      @provider.expects(:rabbitmqadmin).with('declare', 'binding', '--vhost=/', '--user=colin', '--password=secret', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'source=source', 'destination=test2', 'arguments={}', 'routing_key=blablubd', 'destination_type=queue')
-      @provider.create
+      provider.expects(:rabbitmqadmin).with('declare', 'binding', '--vhost=/', '--user=colin', '--password=secret', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'source=source', 'destination=test2', 'arguments={}', 'routing_key=blablubd', 'destination_type=queue')
+      provider.create
     end
   end
 
   context 'new queue_bindings' do
-    before do
-      @resource = Puppet::Type::Rabbitmq_binding.new(
+    let(:resource) do
+      Puppet::Type::Rabbitmq_binding.new(
         name: 'binding1',
         source: 'exchange1',
         destination: 'destqueue',
@@ -149,12 +151,12 @@ EOT
         routing_key: 'blablubd',
         arguments: {}
       )
-      @provider = provider_class.new(@resource)
     end
+    let(:provider) { provider_class.new(resource) }
 
     it 'calls rabbitmqadmin to create' do
-      @provider.expects(:rabbitmqadmin).with('declare', 'binding', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'source=exchange1', 'destination=destqueue', 'arguments={}', 'routing_key=blablubd', 'destination_type=queue')
-      @provider.create
+      provider.expects(:rabbitmqadmin).with('declare', 'binding', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'source=exchange1', 'destination=destqueue', 'arguments={}', 'routing_key=blablubd', 'destination_type=queue')
+      provider.create
     end
   end
 end

--- a/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
@@ -5,8 +5,8 @@ RSpec.configure do |config|
 end
 provider_class = Puppet::Type.type(:rabbitmq_exchange).provider(:rabbitmqadmin)
 describe provider_class do
-  before do
-    @resource = Puppet::Type::Rabbitmq_exchange.new(
+  let(:resource) do
+    Puppet::Type::Rabbitmq_exchange.new(
       name: 'test.headers@/',
       type: :headers,
       internal: :false,
@@ -16,8 +16,8 @@ describe provider_class do
         'hash-headers' => 'message-distribution-hash'
       }
     )
-    @provider = provider_class.new(@resource)
   end
+  let(:provider) { provider_class.new(resource) }
 
   it 'returns instances' do
     provider_class.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
@@ -39,18 +39,18 @@ EOT
   end
 
   it 'calls rabbitmqadmin to create as guest' do
-    @provider.expects(:rabbitmqadmin).with('declare', 'exchange', '--vhost=/', '--user=guest', '--password=guest', 'name=test.headers', 'type=headers', 'internal=false', 'durable=true', 'auto_delete=false', 'arguments={"hash-headers":"message-distribution-hash"}', '-c', '/etc/rabbitmq/rabbitmqadmin.conf')
-    @provider.create
+    provider.expects(:rabbitmqadmin).with('declare', 'exchange', '--vhost=/', '--user=guest', '--password=guest', 'name=test.headers', 'type=headers', 'internal=false', 'durable=true', 'auto_delete=false', 'arguments={"hash-headers":"message-distribution-hash"}', '-c', '/etc/rabbitmq/rabbitmqadmin.conf')
+    provider.create
   end
 
   it 'calls rabbitmqadmin to destroy' do
-    @provider.expects(:rabbitmqadmin).with('delete', 'exchange', '--vhost=/', '--user=guest', '--password=guest', 'name=test.headers', '-c', '/etc/rabbitmq/rabbitmqadmin.conf')
-    @provider.destroy
+    provider.expects(:rabbitmqadmin).with('delete', 'exchange', '--vhost=/', '--user=guest', '--password=guest', 'name=test.headers', '-c', '/etc/rabbitmq/rabbitmqadmin.conf')
+    provider.destroy
   end
 
   context 'specifying credentials' do
-    before do
-      @resource = Puppet::Type::Rabbitmq_exchange.new(
+    let(:resource) do
+      Puppet::Type::Rabbitmq_exchange.new(
         name: 'test.headers@/',
         type: :headers,
         internal: 'false',
@@ -62,12 +62,12 @@ EOT
           'hash-header' => 'message-distribution-hash'
         }
       )
-      @provider = provider_class.new(@resource)
     end
+    let(:provider) { provider_class.new(resource) }
 
     it 'calls rabbitmqadmin to create with credentials' do
-      @provider.expects(:rabbitmqadmin).with('declare', 'exchange', '--vhost=/', '--user=colin', '--password=secret', 'name=test.headers', 'type=headers', 'internal=false', 'durable=true', 'auto_delete=false', 'arguments={"hash-header":"message-distribution-hash"}', '-c', '/etc/rabbitmq/rabbitmqadmin.conf')
-      @provider.create
+      provider.expects(:rabbitmqadmin).with('declare', 'exchange', '--vhost=/', '--user=colin', '--password=secret', 'name=test.headers', 'type=headers', 'internal=false', 'durable=true', 'auto_delete=false', 'arguments={"hash-header":"message-distribution-hash"}', '-c', '/etc/rabbitmq/rabbitmqadmin.conf')
+      provider.create
     end
   end
 end

--- a/spec/unit/puppet/provider/rabbitmq_plugin/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_plugin/rabbitmqctl_spec.rb
@@ -5,22 +5,23 @@ RSpec.configure do |config|
 end
 provider_class = Puppet::Type.type(:rabbitmq_plugin).provider(:rabbitmqplugins)
 describe provider_class do
-  before do
-    @resource = Puppet::Type::Rabbitmq_plugin.new(
+  let(:resource) do
+    Puppet::Type::Rabbitmq_plugin.new(
       name: 'foo'
     )
-    @provider = provider_class.new(@resource)
   end
+  let(:provider) { provider_class.new(resource) }
+
   it 'matches plugins' do
-    @provider.expects(:rabbitmqplugins).with('list', '-E', '-m').returns("foo\n")
-    expect(@provider.exists?).to eq('foo')
+    provider.expects(:rabbitmqplugins).with('list', '-E', '-m').returns("foo\n")
+    expect(provider.exists?).to eq('foo')
   end
   it 'calls rabbitmqplugins to enable' do
-    @provider.expects(:rabbitmqplugins).with('enable', 'foo')
-    @provider.create
+    provider.expects(:rabbitmqplugins).with('enable', 'foo')
+    provider.create
   end
   it 'calls rabbitmqplugins to disable' do
-    @provider.expects(:rabbitmqplugins).with('disable', 'foo')
-    @provider.destroy
+    provider.expects(:rabbitmqplugins).with('disable', 'foo')
+    provider.destroy
   end
 end

--- a/spec/unit/puppet/provider/rabbitmq_queue/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_queue/rabbitmqadmin_spec.rb
@@ -5,15 +5,15 @@ RSpec.configure do |config|
 end
 provider_class = Puppet::Type.type(:rabbitmq_queue).provider(:rabbitmqadmin)
 describe provider_class do
-  before do
-    @resource = Puppet::Type::Rabbitmq_queue.new(
+  let(:resource) do
+    Puppet::Type::Rabbitmq_queue.new(
       name: 'test@/',
       durable: :true,
       auto_delete: :false,
       arguments: {}
     )
-    @provider = provider_class.new(@resource)
   end
+  let(:provider) { provider_class.new(resource) }
 
   it 'returns instances' do
     provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
@@ -28,18 +28,18 @@ EOT
   end
 
   it 'calls rabbitmqadmin to create' do
-    @provider.expects(:rabbitmqadmin).with('declare', 'queue', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'name=test', 'durable=true', 'auto_delete=false', 'arguments={}')
-    @provider.create
+    provider.expects(:rabbitmqadmin).with('declare', 'queue', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'name=test', 'durable=true', 'auto_delete=false', 'arguments={}')
+    provider.create
   end
 
   it 'calls rabbitmqadmin to destroy' do
-    @provider.expects(:rabbitmqadmin).with('delete', 'queue', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'name=test')
-    @provider.destroy
+    provider.expects(:rabbitmqadmin).with('delete', 'queue', '--vhost=/', '--user=guest', '--password=guest', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'name=test')
+    provider.destroy
   end
 
   context 'specifying credentials' do
-    before do
-      @resource = Puppet::Type::Rabbitmq_queue.new(
+    let(:resource) do
+      Puppet::Type::Rabbitmq_queue.new(
         name: 'test@/',
         durable: 'true',
         auto_delete: 'false',
@@ -47,12 +47,12 @@ EOT
         user: 'colin',
         password: 'secret'
       )
-      @provider = provider_class.new(@resource)
     end
+    let(:provider) { provider_class.new(resource) }
 
     it 'calls rabbitmqadmin to create' do
-      @provider.expects(:rabbitmqadmin).with('declare', 'queue', '--vhost=/', '--user=colin', '--password=secret', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'name=test', 'durable=true', 'auto_delete=false', 'arguments={}')
-      @provider.create
+      provider.expects(:rabbitmqadmin).with('declare', 'queue', '--vhost=/', '--user=colin', '--password=secret', '-c', '/etc/rabbitmq/rabbitmqadmin.conf', 'name=test', 'durable=true', 'auto_delete=false', 'arguments={}')
+      provider.create
     end
   end
 end

--- a/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
@@ -5,211 +5,212 @@ RSpec.configure do |config|
 end
 provider_class = Puppet::Type.type(:rabbitmq_user).provider(:rabbitmqctl)
 describe provider_class do
-  before do
-    @resource = Puppet::Type::Rabbitmq_user.new(
+  let(:resource) do
+    Puppet::Type::Rabbitmq_user.new(
       name: 'foo', password: 'bar'
     )
-    @provider = provider_class.new(@resource)
   end
+  let(:provider) { provider_class.new(resource) }
+
   it 'matches user names' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo
 EOT
-    expect(@provider.exists?).to eq('foo')
+    expect(provider.exists?).to eq('foo')
   end
   it 'matches user names with 2.4.1 syntax' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo bar
 EOT
-    expect(@provider.exists?).to eq('foo bar')
+    expect(provider.exists?).to eq('foo bar')
   end
   it 'does not match if no users on system' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 EOT
-    expect(@provider.exists?).to be_nil
+    expect(provider.exists?).to be_nil
   end
   it 'does not match if no matching users on system' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 fooey
 EOT
-    expect(@provider.exists?).to be_nil
+    expect(provider.exists?).to be_nil
   end
   it 'matches user names from list' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 one
 two three
 foo
 bar
 EOT
-    expect(@provider.exists?).to eq('foo')
+    expect(provider.exists?).to eq('foo')
   end
   it 'creates user and set password' do
-    @resource[:password] = 'bar'
-    @provider.expects(:rabbitmqctl).with('add_user', 'foo', 'bar')
-    @provider.create
+    resource[:password] = 'bar'
+    provider.expects(:rabbitmqctl).with('add_user', 'foo', 'bar')
+    provider.create
   end
   it 'creates user, set password and set to admin' do
-    @resource[:password] = 'bar'
-    @resource[:admin] = 'true'
-    @provider.expects(:rabbitmqctl).with('add_user', 'foo', 'bar')
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    resource[:password] = 'bar'
+    resource[:admin] = 'true'
+    provider.expects(:rabbitmqctl).with('add_user', 'foo', 'bar')
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo   []
 icinga  [monitoring]
 kitchen []
 kitchen2        [abc, def, ghi]
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['administrator'])
-    @provider.create
+    provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['administrator'])
+    provider.create
   end
   it 'calls rabbitmqctl to delete' do
-    @provider.expects(:rabbitmqctl).with('delete_user', 'foo')
-    @provider.destroy
+    provider.expects(:rabbitmqctl).with('delete_user', 'foo')
+    provider.destroy
   end
   it 'is able to retrieve admin value' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo [administrator]
 EOT
-    expect(@provider.admin).to eq(:true)
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    expect(provider.admin).to eq(:true)
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 one [administrator]
 foo []
 EOT
-    expect(@provider.admin).to eq(:false)
+    expect(provider.admin).to eq(:false)
   end
   it 'fails if admin value is invalid' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo fail
 EOT
-    expect { @provider.admin }.to raise_error(Puppet::Error, %r{Could not match line})
+    expect { provider.admin }.to raise_error(Puppet::Error, %r{Could not match line})
   end
   it 'is able to set admin value' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo   []
 icinga  [monitoring]
 kitchen []
 kitchen2        [abc, def, ghi]
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['administrator'])
-    @provider.admin = :true
+    provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['administrator'])
+    provider.admin = :true
   end
   it 'does not interfere with existing tags on the user when setting admin value' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo   [bar, baz]
 icinga  [monitoring]
 kitchen []
 kitchen2        [abc, def, ghi]
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', %w[bar baz administrator].sort)
-    @provider.admin = :true
+    provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', %w[bar baz administrator].sort)
+    provider.admin = :true
   end
   it 'is able to unset admin value' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo     [administrator]
 guest   [administrator]
 icinga  []
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', [])
-    @provider.admin = :false
+    provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', [])
+    provider.admin = :false
   end
   it 'does not interfere with existing tags on the user when unsetting admin value' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo   [administrator, bar, baz]
 icinga  [monitoring]
 kitchen []
 kitchen2        [abc, def, ghi]
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', %w[bar baz].sort)
-    @provider.admin = :false
+    provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', %w[bar baz].sort)
+    provider.admin = :false
   end
 
   it 'clears all tags on existing user' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 one [administrator]
 foo [tag1,tag2]
 icinga  [monitoring]
 kitchen []
 kitchen2        [abc, def, ghi]
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', [])
-    @provider.tags = []
+    provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', [])
+    provider.tags = []
   end
 
   it 'sets multiple tags' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 one [administrator]
 foo []
 icinga  [monitoring]
 kitchen []
 kitchen2        [abc, def, ghi]
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', %w[tag1 tag2])
-    @provider.tags = %w[tag1 tag2]
+    provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', %w[tag1 tag2])
+    provider.tags = %w[tag1 tag2]
   end
 
   it 'clears tags while keep admin tag' do
-    @resource[:admin] = true
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    resource[:admin] = true
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 one [administrator]
 foo [administrator, tag1, tag2]
 icinga  [monitoring]
 kitchen []
 kitchen2        [abc, def, ghi]
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['administrator'])
-    @provider.tags = []
+    provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['administrator'])
+    provider.tags = []
   end
 
   it 'changes tags while keep admin tag' do
-    @resource[:admin] = true
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    resource[:admin] = true
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 one [administrator]
 foo [administrator, tag1, tag2]
 icinga  [monitoring]
 kitchen []
 kitchen2        [abc, def, ghi]
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', %w[administrator tag1 tag3 tag7])
-    @provider.tags = %w[tag1 tag7 tag3]
+    provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', %w[administrator tag1 tag3 tag7])
+    provider.tags = %w[tag1 tag7 tag3]
   end
 
   it 'creates user with tags and without admin' do
-    @resource[:tags] = %w[tag1 tag2]
-    @provider.expects(:rabbitmqctl).with('add_user', 'foo', 'bar')
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', %w[tag1 tag2])
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    resource[:tags] = %w[tag1 tag2]
+    provider.expects(:rabbitmqctl).with('add_user', 'foo', 'bar')
+    provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', %w[tag1 tag2])
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo []
 EOT
-    @provider.create
+    provider.create
   end
 
   it 'creates user with tags and with admin' do
-    @resource[:tags] = %w[tag1 tag2]
-    @resource[:admin] = true
-    @provider.expects(:rabbitmqctl).with('add_user', 'foo', 'bar')
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').twice.returns <<-EOT
+    resource[:tags] = %w[tag1 tag2]
+    resource[:admin] = true
+    provider.expects(:rabbitmqctl).with('add_user', 'foo', 'bar')
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').twice.returns <<-EOT
 foo []
 EOT
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['administrator'])
-    @provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', %w[administrator tag1 tag2])
-    @provider.create
+    provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', ['administrator'])
+    provider.expects(:rabbitmqctl).with('set_user_tags', 'foo', %w[administrator tag1 tag2])
+    provider.create
   end
 
   it 'does not return the administrator tag in tags for admins' do
-    @resource[:tags] = []
-    @resource[:admin] = true
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    resource[:tags] = []
+    resource[:admin] = true
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo [administrator]
 EOT
-    expect(@provider.tags).to eq([])
+    expect(provider.tags).to eq([])
   end
 
   it 'returns the administrator tag for non-admins' do
     # this should not happen though.
-    @resource[:tags] = []
-    @resource[:admin] = :false
-    @provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
+    resource[:tags] = []
+    resource[:admin] = :false
+    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 foo [administrator]
 EOT
-    expect(@provider.tags).to eq(['administrator'])
+    expect(provider.tags).to eq(['administrator'])
   end
 end

--- a/spec/unit/puppet/provider/rabbitmq_user_permissions/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user_permissions/rabbitmqctl_spec.rb
@@ -4,88 +4,89 @@ RSpec.configure do |config|
   config.mock_with :mocha
 end
 describe 'Puppet::Type.type(:rabbitmq_user_permissions).provider(:rabbitmqctl)' do
-  before do
-    @provider_class = Puppet::Type.type(:rabbitmq_user_permissions).provider(:rabbitmqctl)
-    @resource = Puppet::Type::Rabbitmq_user_permissions.new(
+  let(:resource) do
+    Puppet::Type::Rabbitmq_user_permissions.new(
       name: 'foo@bar'
     )
-    @provider = @provider_class.new(@resource)
   end
+  let(:provider_class) { Puppet::Type.type(:rabbitmq_user_permissions).provider(:rabbitmqctl) }
+  let(:provider) { provider_class.new(resource) }
+
   after do
-    @provider_class.instance_variable_set(:@users, nil)
+    provider_class.instance_variable_set(:@users, nil)
   end
   it 'matches user permissions from list' do
-    @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+    provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
 bar 1 2 3
 EOT
-    expect(@provider.exists?).to eq(configure: '1', write: '2', read: '3')
+    expect(provider.exists?).to eq(configure: '1', write: '2', read: '3')
   end
   it 'matches user permissions with empty columns' do
-    @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+    provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
 bar			3
 EOT
-    expect(@provider.exists?).to eq(configure: '', write: '', read: '3')
+    expect(provider.exists?).to eq(configure: '', write: '', read: '3')
   end
   it 'does not match user permissions with more than 3 columns' do
-    @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+    provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
 bar 1 2 3 4
 EOT
-    expect { @provider.exists? }.to raise_error(Puppet::Error, %r{cannot parse line from list_user_permissions})
+    expect { provider.exists? }.to raise_error(Puppet::Error, %r{cannot parse line from list_user_permissions})
   end
   it 'does not match an empty list' do
-    @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+    provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
 EOT
-    expect(@provider.exists?).to eq(nil)
+    expect(provider.exists?).to eq(nil)
   end
   it 'creates default permissions' do
-    @provider.instance_variable_set(:@should_vhost, 'bar')
-    @provider.instance_variable_set(:@should_user, 'foo')
-    @provider.expects(:rabbitmqctl).with('set_permissions', '-p', 'bar', 'foo', "''", "''", "''")
-    @provider.create
+    provider.instance_variable_set(:@should_vhost, 'bar')
+    provider.instance_variable_set(:@should_user, 'foo')
+    provider.expects(:rabbitmqctl).with('set_permissions', '-p', 'bar', 'foo', "''", "''", "''")
+    provider.create
   end
   it 'destroys permissions' do
-    @provider.instance_variable_set(:@should_vhost, 'bar')
-    @provider.instance_variable_set(:@should_user, 'foo')
-    @provider.expects(:rabbitmqctl).with('clear_permissions', '-p', 'bar', 'foo')
-    @provider.destroy
+    provider.instance_variable_set(:@should_vhost, 'bar')
+    provider.instance_variable_set(:@should_user, 'foo')
+    provider.expects(:rabbitmqctl).with('clear_permissions', '-p', 'bar', 'foo')
+    provider.destroy
   end
   { configure_permission: '1', write_permission: '2', read_permission: '3' }.each do |k, v|
     it "should be able to retrieve #{k}" do
-      @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+      provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
 bar 1 2 3
 EOT
-      expect(@provider.send(k)).to eq(v)
+      expect(provider.send(k)).to eq(v)
     end
   end
   { configure_permission: '1', write_permission: '2', read_permission: '3' }.each do |k, v|
     it "should be able to retrieve #{k} after exists has been called" do
-      @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+      provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
 bar 1 2 3
 EOT
-      @provider.exists?
-      expect(@provider.send(k)).to eq(v)
+      provider.exists?
+      expect(provider.send(k)).to eq(v)
     end
   end
   { configure_permission: %w[foo 2 3],
     read_permission: %w[1 2 foo],
     write_permission: %w[1 foo 3] }.each do |perm, columns|
     it "should be able to sync #{perm}" do
-      @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+      provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
 bar 1 2 3
 EOT
-      @provider.resource[perm] = 'foo'
-      @provider.expects(:rabbitmqctl).with('set_permissions', '-p', 'bar', 'foo', *columns)
-      @provider.send("#{perm}=".to_sym, 'foo')
+      provider.resource[perm] = 'foo'
+      provider.expects(:rabbitmqctl).with('set_permissions', '-p', 'bar', 'foo', *columns)
+      provider.send("#{perm}=".to_sym, 'foo')
     end
   end
   it 'onlies call set_permissions once' do
-    @provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+    provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
 bar 1 2 3
 EOT
-    @provider.resource[:configure_permission] = 'foo'
-    @provider.resource[:read_permission] = 'foo'
-    @provider.expects(:rabbitmqctl).with('set_permissions', '-p', 'bar', 'foo', 'foo', '2', 'foo').once
-    @provider.configure_permission = 'foo'
-    @provider.read_permission = 'foo'
+    provider.resource[:configure_permission] = 'foo'
+    provider.resource[:read_permission] = 'foo'
+    provider.expects(:rabbitmqctl).with('set_permissions', '-p', 'bar', 'foo', 'foo', '2', 'foo').once
+    provider.configure_permission = 'foo'
+    provider.read_permission = 'foo'
   end
 end

--- a/spec/unit/puppet/provider/rabbitmq_vhost/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_vhost/rabbitmqctl_spec.rb
@@ -5,41 +5,42 @@ RSpec.configure do |config|
 end
 provider_class = Puppet::Type.type(:rabbitmq_vhost).provider(:rabbitmqctl)
 describe provider_class do
-  before do
-    @resource = Puppet::Type::Rabbitmq_vhost.new(
+  let(:resource) do
+    Puppet::Type::Rabbitmq_vhost.new(
       name: 'foo'
     )
-    @provider = provider_class.new(@resource)
   end
+  let(:provider) { provider_class.new(resource) }
+
   it 'matches vhost names' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
 Listing vhosts ...
 foo
 ...done.
 EOT
-    expect(@provider.exists?).to eq('foo')
+    expect(provider.exists?).to eq('foo')
   end
   it 'does not match if no vhosts on system' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
 Listing vhosts ...
 ...done.
 EOT
-    expect(@provider.exists?).to be_nil
+    expect(provider.exists?).to be_nil
   end
   it 'does not match if no matching vhosts on system' do
-    @provider.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
+    provider.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
 Listing vhosts ...
 fooey
 ...done.
 EOT
-    expect(@provider.exists?).to be_nil
+    expect(provider.exists?).to be_nil
   end
   it 'calls rabbitmqctl to create' do
-    @provider.expects(:rabbitmqctl).with('add_vhost', 'foo')
-    @provider.create
+    provider.expects(:rabbitmqctl).with('add_vhost', 'foo')
+    provider.create
   end
   it 'calls rabbitmqctl to create' do
-    @provider.expects(:rabbitmqctl).with('delete_vhost', 'foo')
-    @provider.destroy
+    provider.expects(:rabbitmqctl).with('delete_vhost', 'foo')
+    provider.destroy
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_binding_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_binding_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_binding) do
-  before do
-    @binding = Puppet::Type.type(:rabbitmq_binding).new(
+  let(:binding) do
+    Puppet::Type.type(:rabbitmq_binding).new(
       name: 'foo@blub@bar',
       destination_type: :queue
     )
   end
+
   it 'accepts an queue name' do
-    @binding[:name] = 'dan@dude@pl'
-    expect(@binding[:name]).to eq('dan@dude@pl')
+    binding[:name] = 'dan@dude@pl'
+    expect(binding[:name]).to eq('dan@dude@pl')
   end
   it 'requires a name' do
     expect do
@@ -32,15 +33,15 @@ describe Puppet::Type.type(:rabbitmq_binding) do
     end.to raise_error(Puppet::Error, %r{Source and destination must both be defined})
   end
   it 'accepts an binding destination_type' do
-    @binding[:destination_type] = :exchange
-    expect(@binding[:destination_type]).to eq(:exchange)
+    binding[:destination_type] = :exchange
+    expect(binding[:destination_type]).to eq(:exchange)
   end
   it 'accepts a user' do
-    @binding[:user] = :root
-    expect(@binding[:user]).to eq(:root)
+    binding[:user] = :root
+    expect(binding[:user]).to eq(:root)
   end
   it 'accepts a password' do
-    @binding[:password] = :PaSsw0rD
-    expect(@binding[:password]).to eq(:PaSsw0rD)
+    binding[:password] = :PaSsw0rD
+    expect(binding[:password]).to eq(:PaSsw0rD)
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_exchange_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_exchange_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_exchange) do
-  before do
-    @exchange = Puppet::Type.type(:rabbitmq_exchange).new(
+  let(:exchange) do
+    Puppet::Type.type(:rabbitmq_exchange).new(
       name: 'foo@bar',
       type: :topic,
       internal: false,
@@ -9,9 +9,10 @@ describe Puppet::Type.type(:rabbitmq_exchange) do
       durable: true
     )
   end
+
   it 'accepts an exchange name' do
-    @exchange[:name] = 'dan@pl'
-    expect(@exchange[:name]).to eq('dan@pl')
+    exchange[:name] = 'dan@pl'
+    expect(exchange[:name]).to eq('dan@pl')
   end
   it 'requires a name' do
     expect do
@@ -20,18 +21,18 @@ describe Puppet::Type.type(:rabbitmq_exchange) do
   end
   it 'does not allow whitespace in the name' do
     expect do
-      @exchange[:name] = 'b r'
+      exchange[:name] = 'b r'
     end.to raise_error(Puppet::Error, %r{Valid values match})
   end
   it 'does not allow names without @' do
     expect do
-      @exchange[:name] = 'b_r'
+      exchange[:name] = 'b_r'
     end.to raise_error(Puppet::Error, %r{Valid values match})
   end
 
   it 'accepts an exchange type' do
-    @exchange[:type] = :direct
-    expect(@exchange[:type]).to eq(:direct)
+    exchange[:type] = :direct
+    expect(exchange[:type]).to eq(:direct)
   end
   it 'requires a type' do
     expect do
@@ -45,12 +46,12 @@ describe Puppet::Type.type(:rabbitmq_exchange) do
   end
 
   it 'accepts a user' do
-    @exchange[:user] = :root
-    expect(@exchange[:user]).to eq(:root)
+    exchange[:user] = :root
+    expect(exchange[:user]).to eq(:root)
   end
 
   it 'accepts a password' do
-    @exchange[:password] = :PaSsw0rD
-    expect(@exchange[:password]).to eq(:PaSsw0rD)
+    exchange[:password] = :PaSsw0rD
+    expect(exchange[:password]).to eq(:PaSsw0rD)
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_parameter) do
-  before do
-    @parameter = Puppet::Type.type(:rabbitmq_parameter).new(
+  let(:parameter) do
+    Puppet::Type.type(:rabbitmq_parameter).new(
       name: 'documentumShovel@/',
       component_name: 'shovel',
       value: {
@@ -14,8 +14,8 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
   end
 
   it 'accepts a valid name' do
-    @parameter[:name] = 'documentumShovel@/'
-    expect(@parameter[:name]).to eq('documentumShovel@/')
+    parameter[:name] = 'documentumShovel@/'
+    expect(parameter[:name]).to eq('documentumShovel@/')
   end
 
   it 'requires a name' do
@@ -26,52 +26,52 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
 
   it 'fails when name does not have a @' do
     expect do
-      @parameter[:name] = 'documentumShovel'
+      parameter[:name] = 'documentumShovel'
     end.to raise_error(Puppet::Error, %r{Valid values match})
   end
 
   it 'accepts a string' do
-    @parameter[:component_name] = 'mystring'
-    expect(@parameter[:component_name]).to eq('mystring')
+    parameter[:component_name] = 'mystring'
+    expect(parameter[:component_name]).to eq('mystring')
   end
 
   it 'is not empty' do
     expect do
-      @parameter[:component_name] = ''
+      parameter[:component_name] = ''
     end.to raise_error(Puppet::Error, %r{component_name must be defined})
   end
 
   it 'accepts a valid hash for value' do
     value = { 'message-ttl' => '1800000' }
-    @parameter[:value] = value
-    expect(@parameter[:value]).to eq(value)
+    parameter[:value] = value
+    expect(parameter[:value]).to eq(value)
   end
 
   it 'does not accept invalid hash for definition' do
     expect do
-      @parameter[:value] = ''
+      parameter[:value] = ''
     end.to raise_error(Puppet::Error, %r{Invalid value})
 
     expect do
-      @parameter[:value] = 'guest'
+      parameter[:value] = 'guest'
     end.to raise_error(Puppet::Error, %r{Invalid value})
 
     expect do
-      @parameter[:value] = { 'message-ttl' => %w[999 100] }
+      parameter[:value] = { 'message-ttl' => %w[999 100] }
     end.to raise_error(Puppet::Error, %r{Invalid value})
   end
 
   it 'accepts string as myparameter' do
     value = { 'myparameter' => 'mystring' }
-    @parameter[:value] = value
-    expect(@parameter[:value]['myparameter']).to be_a(String)
-    expect(@parameter[:value]['myparameter']).to eq('mystring')
+    parameter[:value] = value
+    expect(parameter[:value]['myparameter']).to be_a(String)
+    expect(parameter[:value]['myparameter']).to eq('mystring')
   end
 
   it 'converts to integer when string only contains numbers' do
     value = { 'myparameter' => '1800000' }
-    @parameter[:value] = value
-    expect(@parameter[:value]['myparameter']).to be_a(Integer)
-    expect(@parameter[:value]['myparameter']).to eq(1_800_000)
+    parameter[:value] = value
+    expect(parameter[:value]['myparameter']).to be_a(Integer)
+    expect(parameter[:value]['myparameter']).to eq(1_800_000)
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_plugin_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_plugin_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_plugin) do
-  before do
-    @plugin = Puppet::Type.type(:rabbitmq_plugin).new(name: 'foo')
+  let(:plugin) do
+    Puppet::Type.type(:rabbitmq_plugin).new(name: 'foo')
   end
+
   it 'accepts a plugin name' do
-    @plugin[:name] = 'plugin-name'
-    expect(@plugin[:name]).to eq('plugin-name')
+    plugin[:name] = 'plugin-name'
+    expect(plugin[:name]).to eq('plugin-name')
   end
   it 'requires a name' do
     expect do
@@ -13,11 +14,11 @@ describe Puppet::Type.type(:rabbitmq_plugin) do
     end.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
   it 'defaults to a umask of 0022' do
-    expect(@plugin[:umask]).to eq(0o022)
+    expect(plugin[:umask]).to eq(0o022)
   end
   it 'does not allow a non-octal value to be specified' do
     expect do
-      @plugin[:umask] = '198'
+      plugin[:umask] = '198'
     end.to raise_error(Puppet::Error, %r{The umask specification is invalid: "198"})
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_policy_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_policy_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_policy) do
-  before do
-    @policy = Puppet::Type.type(:rabbitmq_policy).new(
+  let(:policy) do
+    Puppet::Type.type(:rabbitmq_policy).new(
       name: 'ha-all@/',
       pattern: '.*',
       definition: {
@@ -11,8 +11,8 @@ describe Puppet::Type.type(:rabbitmq_policy) do
   end
 
   it 'accepts a valid name' do
-    @policy[:name] = 'ha-all@/'
-    expect(@policy[:name]).to eq('ha-all@/')
+    policy[:name] = 'ha-all@/'
+    expect(policy[:name]).to eq('ha-all@/')
   end
 
   it 'requires a name' do
@@ -23,167 +23,167 @@ describe Puppet::Type.type(:rabbitmq_policy) do
 
   it 'fails when name does not have a @' do
     expect do
-      @policy[:name] = 'ha-all'
+      policy[:name] = 'ha-all'
     end.to raise_error(Puppet::Error, %r{Valid values match})
   end
 
   it 'accepts a valid regex for pattern' do
-    @policy[:pattern] = '.*?'
-    expect(@policy[:pattern]).to eq('.*?')
+    policy[:pattern] = '.*?'
+    expect(policy[:pattern]).to eq('.*?')
   end
 
   it 'accepts an empty string for pattern' do
-    @policy[:pattern] = ''
-    expect(@policy[:pattern]).to eq('')
+    policy[:pattern] = ''
+    expect(policy[:pattern]).to eq('')
   end
 
   it 'does not accept invalid regex for pattern' do
     expect do
-      @policy[:pattern] = '*'
+      policy[:pattern] = '*'
     end.to raise_error(Puppet::Error, %r{Invalid regexp})
   end
 
   it 'accepts valid value for applyto' do
     [:all, :exchanges, :queues].each do |v|
-      @policy[:applyto] = v
-      expect(@policy[:applyto]).to eq(v)
+      policy[:applyto] = v
+      expect(policy[:applyto]).to eq(v)
     end
   end
 
   it 'does not accept invalid value for applyto' do
     expect do
-      @policy[:applyto] = 'me'
+      policy[:applyto] = 'me'
     end.to raise_error(Puppet::Error, %r{Invalid value})
   end
 
   it 'accepts a valid hash for definition' do
     definition = { 'ha-mode' => 'all', 'ha-sync-mode' => 'automatic' }
-    @policy[:definition] = definition
-    expect(@policy[:definition]).to eq(definition)
+    policy[:definition] = definition
+    expect(policy[:definition]).to eq(definition)
   end
 
   it 'does not accept invalid hash for definition' do
     expect do
-      @policy[:definition] = 'ha-mode'
+      policy[:definition] = 'ha-mode'
     end.to raise_error(Puppet::Error, %r{Invalid definition})
 
     expect do
-      @policy[:definition] = { 'ha-mode' => %w[a b] }
+      policy[:definition] = { 'ha-mode' => %w[a b] }
     end.to raise_error(Puppet::Error, %r{Invalid definition})
   end
 
   it 'accepts valid value for priority' do
     [0, 10, '0', '10'].each do |v|
-      @policy[:priority] = v
-      expect(@policy[:priority]).to eq(v)
+      policy[:priority] = v
+      expect(policy[:priority]).to eq(v)
     end
   end
 
   it 'does not accept invalid value for priority' do
     ['-1', -1, '1.0', 1.0, 'abc', ''].each do |v|
       expect do
-        @policy[:priority] = v
+        policy[:priority] = v
       end.to raise_error(Puppet::Error, %r{Invalid value})
     end
   end
 
   it 'accepts and convert ha-params for ha-mode exactly' do
     definition = { 'ha-mode' => 'exactly', 'ha-params' => '2' }
-    @policy[:definition] = definition
-    expect(@policy[:definition]['ha-params']).to be_a(Integer)
-    expect(@policy[:definition]['ha-params']).to eq(2)
+    policy[:definition] = definition
+    expect(policy[:definition]['ha-params']).to be_a(Integer)
+    expect(policy[:definition]['ha-params']).to eq(2)
   end
 
   it 'does not accept non-numeric ha-params for ha-mode exactly' do
     definition = { 'ha-mode' => 'exactly', 'ha-params' => 'nonnumeric' }
     expect do
-      @policy[:definition] = definition
+      policy[:definition] = definition
     end.to raise_error(Puppet::Error, %r{Invalid ha-params.*nonnumeric.*exactly})
   end
 
   it 'accepts and convert the expires value' do
     definition = { 'expires' => '1800000' }
-    @policy[:definition] = definition
-    expect(@policy[:definition]['expires']).to be_a(Integer)
-    expect(@policy[:definition]['expires']).to eq(1_800_000)
+    policy[:definition] = definition
+    expect(policy[:definition]['expires']).to be_a(Integer)
+    expect(policy[:definition]['expires']).to eq(1_800_000)
   end
 
   it 'does not accept non-numeric expires value' do
     definition = { 'expires' => 'future' }
     expect do
-      @policy[:definition] = definition
+      policy[:definition] = definition
     end.to raise_error(Puppet::Error, %r{Invalid expires value.*future})
   end
 
   it 'accepts and convert the message-ttl value' do
     definition = { 'message-ttl' => '1800000' }
-    @policy[:definition] = definition
-    expect(@policy[:definition]['message-ttl']).to be_a(Integer)
-    expect(@policy[:definition]['message-ttl']).to eq(1_800_000)
+    policy[:definition] = definition
+    expect(policy[:definition]['message-ttl']).to be_a(Integer)
+    expect(policy[:definition]['message-ttl']).to eq(1_800_000)
   end
 
   it 'does not accept non-numeric message-ttl value' do
     definition = { 'message-ttl' => 'future' }
     expect do
-      @policy[:definition] = definition
+      policy[:definition] = definition
     end.to raise_error(Puppet::Error, %r{Invalid message-ttl value.*future})
   end
 
   it 'accepts and convert the max-length value' do
     definition = { 'max-length' => '1800000' }
-    @policy[:definition] = definition
-    expect(@policy[:definition]['max-length']).to be_a(Integer)
-    expect(@policy[:definition]['max-length']).to eq(1_800_000)
+    policy[:definition] = definition
+    expect(policy[:definition]['max-length']).to be_a(Integer)
+    expect(policy[:definition]['max-length']).to eq(1_800_000)
   end
 
   it 'does not accept non-numeric max-length value' do
     definition = { 'max-length' => 'future' }
     expect do
-      @policy[:definition] = definition
+      policy[:definition] = definition
     end.to raise_error(Puppet::Error, %r{Invalid max-length value.*future})
   end
 
   it 'accepts and convert the shards-per-node value' do
     definition = { 'shards-per-node' => '1800000' }
-    @policy[:definition] = definition
-    expect(@policy[:definition]['shards-per-node']).to be_a(Integer)
-    expect(@policy[:definition]['shards-per-node']).to eq(1_800_000)
+    policy[:definition] = definition
+    expect(policy[:definition]['shards-per-node']).to be_a(Integer)
+    expect(policy[:definition]['shards-per-node']).to eq(1_800_000)
   end
 
   it 'does not accept non-numeric shards-per-node value' do
     definition = { 'shards-per-node' => 'future' }
     expect do
-      @policy[:definition] = definition
+      policy[:definition] = definition
     end.to raise_error(Puppet::Error, %r{Invalid shards-per-node value.*future})
   end
 
   it 'accepts and convert the ha-sync-batch-size value' do
     definition = { 'ha-sync-batch-size' => '1800000' }
-    @policy[:definition] = definition
-    expect(@policy[:definition]['ha-sync-batch-size']).to be_a(Integer)
-    expect(@policy[:definition]['ha-sync-batch-size']).to eq(1_800_000)
+    policy[:definition] = definition
+    expect(policy[:definition]['ha-sync-batch-size']).to be_a(Integer)
+    expect(policy[:definition]['ha-sync-batch-size']).to eq(1_800_000)
   end
 
   it 'does not accept non-numeric ha-sync-batch-size value' do
     definition = { 'ha-sync-batch-size' => 'future' }
     expect do
-      @policy[:definition] = definition
+      policy[:definition] = definition
     end.to raise_error(Puppet::Error, %r{Invalid ha-sync-batch-size value.*future})
   end
 
   it 'accepts list value in ha-params when ha-mode = nodes' do
     definition = { 'ha-mode' => 'nodes', 'ha-params' => ['rabbit@rabbit-01', 'rabbit@rabbit-02'] }
-    @policy[:definition] = definition
-    expect(@policy[:definition]['ha-mode']).to eq('nodes')
-    expect(@policy[:definition]['ha-params']).to be_a(Array)
-    expect(@policy[:definition]['ha-params'][0]).to eq('rabbit@rabbit-01')
-    expect(@policy[:definition]['ha-params'][1]).to eq('rabbit@rabbit-02')
+    policy[:definition] = definition
+    expect(policy[:definition]['ha-mode']).to eq('nodes')
+    expect(policy[:definition]['ha-params']).to be_a(Array)
+    expect(policy[:definition]['ha-params'][0]).to eq('rabbit@rabbit-01')
+    expect(policy[:definition]['ha-params'][1]).to eq('rabbit@rabbit-02')
   end
 
   it 'does not accept non-list value in ha-params when ha-mode = nodes' do
     definition = { 'ha-mode' => 'nodes', 'ha-params' => 'this-will-fail' }
     expect do
-      @policy[:definition] = definition
+      policy[:definition] = definition
     end.to raise_error(Puppet::Error, %r{Invalid definition, value this-will-fail for key ha-params is not an array})
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_queue_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_queue_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_queue) do
-  before do
-    @queue = Puppet::Type.type(:rabbitmq_queue).new(
+  let(:queue) do
+    Puppet::Type.type(:rabbitmq_queue).new(
       name: 'foo@bar',
       durable: :true,
       arguments: {
@@ -10,9 +10,10 @@ describe Puppet::Type.type(:rabbitmq_queue) do
       }
     )
   end
+
   it 'accepts an queue name' do
-    @queue[:name] = 'dan@pl'
-    expect(@queue[:name]).to eq('dan@pl')
+    queue[:name] = 'dan@pl'
+    expect(queue[:name]).to eq('dan@pl')
   end
   it 'requires a name' do
     expect do
@@ -21,38 +22,38 @@ describe Puppet::Type.type(:rabbitmq_queue) do
   end
   it 'does not allow whitespace in the name' do
     expect do
-      @queue[:name] = 'b r'
+      queue[:name] = 'b r'
     end.to raise_error(Puppet::Error, %r{Valid values match})
   end
   it 'does not allow names without @' do
     expect do
-      @queue[:name] = 'b_r'
+      queue[:name] = 'b_r'
     end.to raise_error(Puppet::Error, %r{Valid values match})
   end
 
   it 'accepts an arguments with numbers value' do
-    @queue[:arguments] = { 'x-message-ttl' => 30 }
-    expect(@queue[:arguments].to_json).to eq('{"x-message-ttl":30}')
-    expect(@queue[:arguments]['x-message-ttl']).to eq(30)
+    queue[:arguments] = { 'x-message-ttl' => 30 }
+    expect(queue[:arguments].to_json).to eq('{"x-message-ttl":30}')
+    expect(queue[:arguments]['x-message-ttl']).to eq(30)
   end
 
   it 'accepts an arguments with string value' do
-    @queue[:arguments] = { 'x-dead-letter-exchange' => 'catchallexchange' }
-    expect(@queue[:arguments].to_json).to eq('{"x-dead-letter-exchange":"catchallexchange"}')
+    queue[:arguments] = { 'x-dead-letter-exchange' => 'catchallexchange' }
+    expect(queue[:arguments].to_json).to eq('{"x-dead-letter-exchange":"catchallexchange"}')
   end
 
   it 'accepts an queue durable' do
-    @queue[:durable] = :true
-    expect(@queue[:durable]).to eq(:true)
+    queue[:durable] = :true
+    expect(queue[:durable]).to eq(:true)
   end
 
   it 'accepts a user' do
-    @queue[:user] = :root
-    expect(@queue[:user]).to eq(:root)
+    queue[:user] = :root
+    expect(queue[:user]).to eq(:root)
   end
 
   it 'accepts a password' do
-    @queue[:password] = :PaSsw0rD
-    expect(@queue[:password]).to eq(:PaSsw0rD)
+    queue[:password] = :PaSsw0rD
+    expect(queue[:password]).to eq(:PaSsw0rD)
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_user_permissions_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_user_permissions_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_user_permissions) do
-  before do
-    @perms = Puppet::Type.type(:rabbitmq_user_permissions).new(name: 'foo@bar')
+  let(:perms) do
+    Puppet::Type.type(:rabbitmq_user_permissions).new(name: 'foo@bar')
   end
+
   it 'accepts a valid hostname name' do
-    @perms[:name] = 'dan@bar'
-    expect(@perms[:name]).to eq('dan@bar')
+    perms[:name] = 'dan@bar'
+    expect(perms[:name]).to eq('dan@bar')
   end
   it 'requires a name' do
     expect do
@@ -14,24 +15,24 @@ describe Puppet::Type.type(:rabbitmq_user_permissions) do
   end
   it 'fails when names dont have a @' do
     expect do
-      @perms[:name] = 'bar'
+      perms[:name] = 'bar'
     end.to raise_error(Puppet::Error, %r{Valid values match})
   end
   [:configure_permission, :read_permission, :write_permission].each do |param|
     it 'does not default to anything' do
-      expect(@perms[param]).to eq(nil)
+      expect(perms[param]).to eq(nil)
     end
     it "should accept a valid regex for #{param}" do
-      @perms[param] = '.*?'
-      expect(@perms[param]).to eq('.*?')
+      perms[param] = '.*?'
+      expect(perms[param]).to eq('.*?')
     end
     it "should accept an empty string for #{param}" do
-      @perms[param] = ''
-      expect(@perms[param]).to eq('')
+      perms[param] = ''
+      expect(perms[param]).to eq('')
     end
     it "should not accept invalid regex for #{param}" do
       expect do
-        @perms[param] = '*'
+        perms[param] = '*'
       end.to raise_error(Puppet::Error, %r{Invalid regexp})
     end
   end
@@ -43,7 +44,7 @@ describe Puppet::Type.type(:rabbitmq_user_permissions) do
                 Puppet::Type.type(k).new(name: 'test', password: 'pass')
               end
       perm = Puppet::Type.type(:rabbitmq_user_permissions).new(name: v)
-      config = Puppet::Resource::Catalog.new :testing do |conf|
+      Puppet::Resource::Catalog.new :testing do |conf|
         [vhost, perm].each { |resource| conf.add_resource resource }
       end
       rel = perm.autorequire[0]

--- a/spec/unit/puppet/type/rabbitmq_user_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_user_spec.rb
@@ -1,16 +1,17 @@
 require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_user) do
-  before do
-    @user = Puppet::Type.type(:rabbitmq_user).new(name: 'foo', password: 'pass')
+  let(:user) do
+    Puppet::Type.type(:rabbitmq_user).new(name: 'foo', password: 'pass')
   end
+
   it 'accepts a user name' do
-    @user[:name] = 'dan'
-    expect(@user[:name]).to eq('dan')
-    expect(@user[:admin]).to eq(:false)
+    user[:name] = 'dan'
+    expect(user[:name]).to eq('dan')
+    expect(user[:admin]).to eq(:false)
   end
   it 'accepts a password' do
-    @user[:password] = 'foo'
-    expect(@user[:password]).to eq('foo')
+    user[:password] = 'foo'
+    expect(user[:password]).to eq('foo')
   end
   it 'requires a password' do
     expect do
@@ -24,28 +25,28 @@ describe Puppet::Type.type(:rabbitmq_user) do
   end
   it 'does not allow whitespace in the name' do
     expect do
-      @user[:name] = 'b r'
+      user[:name] = 'b r'
     end.to raise_error(Puppet::Error, %r{Valid values match})
   end
   [true, false, 'true', 'false'].each do |val|
     it "admin property should accept #{val}" do
-      @user[:admin] = val
-      expect(@user[:admin]).to eq(val.to_s.to_sym)
+      user[:admin] = val
+      expect(user[:admin]).to eq(val.to_s.to_sym)
     end
   end
   it 'does not accept non-boolean values for admin' do
     expect do
-      @user[:admin] = 'yes'
+      user[:admin] = 'yes'
     end.to raise_error(Puppet::Error, %r{Invalid value})
   end
   it 'does not accept tags with spaces' do
     expect do
-      @user[:tags] = ['policy maker']
+      user[:tags] = ['policy maker']
     end.to raise_error(Puppet::Error, %r{Invalid tag})
   end
   it 'does not accept the administrator tag' do
     expect do
-      @user[:tags] = ['administrator']
+      user[:tags] = ['administrator']
     end.to raise_error(Puppet::Error, %r{must use admin property})
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_vhost_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_vhost_spec.rb
@@ -1,11 +1,12 @@
 require 'spec_helper'
 describe Puppet::Type.type(:rabbitmq_vhost) do
-  before do
-    @vhost = Puppet::Type.type(:rabbitmq_vhost).new(name: 'foo')
+  let(:vhost) do
+    Puppet::Type.type(:rabbitmq_vhost).new(name: 'foo')
   end
+
   it 'accepts a vhost name' do
-    @vhost[:name] = 'dan'
-    expect(@vhost[:name]).to eq('dan')
+    vhost[:name] = 'dan'
+    expect(vhost[:name]).to eq('dan')
   end
   it 'requires a name' do
     expect do
@@ -14,7 +15,7 @@ describe Puppet::Type.type(:rabbitmq_vhost) do
   end
   it 'does not allow whitespace in the name' do
     expect do
-      @vhost[:name] = 'b r'
+      vhost[:name] = 'b r'
     end.to raise_error(Puppet::Error, %r{Valid values match})
   end
 end


### PR DESCRIPTION
Switch to 'let(:foo)' syntax (resolves rubocop warnings)