### PR TITLE
Switch $releasevar to ${::os[release][major]}

### DIFF
--- a/manifests/repo/rhel.pp
+++ b/manifests/repo/rhel.pp
@@ -1,7 +1,7 @@
 # Class: rabbitmq::repo::rhel
 # Makes sure that the Packagecloud repo is installed
 class rabbitmq::repo::rhel(
-    $location       = 'https://packagecloud.io/rabbitmq/rabbitmq-server/el/$releasever/$basearch',
+    $location       = "https://packagecloud.io/rabbitmq/rabbitmq-server/el/${::os[release][major]}/\$basearch",
     $key_source     = 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc',
   ) {
 

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -200,7 +200,7 @@ EOS
     end
     it 'the repo should be present, and contain the expected values' do
       is_expected.to contain_yumrepo('rabbitmq').with(ensure: 'present',
-                                                      baseurl: 'https://packagecloud.io/rabbitmq/rabbitmq-server/el/$releasever/$basearch',
+                                                      baseurl: 'https://packagecloud.io/rabbitmq/rabbitmq-server/el/7/$basearch',
                                                       gpgkey: 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc')
     end
   end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -12,14 +12,17 @@ end
 
 def with_debian_facts
   let :facts do
-    super().merge(operatingsystemmajrelease: '6',
-                  lsbdistcodename: 'squeeze',
-                  lsbdistid: 'Debian',
-                  osfamily: 'Debian',
-                  os: {
-                    name: 'Debian',
-                    release: { full: '6.0' }
-                  })
+    super().merge(
+      operatingsystemmajrelease: '6',
+      lsbdistcodename: 'squeeze',
+      lsbdistid: 'Debian',
+      osfamily: 'Debian',
+      os:
+      {
+        name: 'Debian',
+        release: { full: '6.0' }
+      }
+    )
   end
 end
 
@@ -28,15 +31,24 @@ def with_openbsd_facts
   # operatingsystemrelease may contain X.X-current
   # or other prefixes
   let :facts do
-    super().merge(kernelversion: '5.9',
-                  osfamily: 'OpenBSD')
+    super().merge(
+      kernelversion: '5.9',
+      osfamily: 'OpenBSD'
+    )
   end
 end
 
 def with_redhat_facts
   let :facts do
-    super().merge(operatingsystemmajrelease: '7',
-                  osfamily: 'Redhat')
+    super().merge(
+      operatingsystemmajrelease: '7',
+      osfamily: 'Redhat',
+      os:
+      {
+        name: 'CentOS',
+        release: { major: '7' }
+      }
+    )
   end
 end
 


### PR DESCRIPTION
Proposed fix for #573 -- this works around the issue where RHEL wants to hit 7Client / 7Server instead of 7 (which Packagecloud doesn't seem to have setup as valid names).