### PR TITLE
update various small warnings

### DIFF
--- a/lib/facter/erl_ssl_path.rb
+++ b/lib/facter/erl_ssl_path.rb
@@ -11,6 +11,6 @@ Facter.add('erl_ssl_path') do
       end
     end
     # erl returns the string with quotes, strip them off
-    data.gsub!(/\A"|"\Z/, '')
+    data.gsub!(%r{\A"|"\Z}, '')
   end
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -76,7 +76,7 @@ class rabbitmq::config {
   } else {
     $default_ssl_env_variables = {
       'NODE_PORT'        => $port,
-      'NODE_IP_ADDRESS'  => $node_ip_address
+      'NODE_IP_ADDRESS'  => $node_ip_address,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,8 +5,10 @@
 # @example Declaring the class
 #   class { 'rabbitmq': }
 #
-# @param management_ip_address Allows you to set the IP for management interface to bind to separately. Set to 127.0.0.1 to bind to localhost only, or 0.0.0.0 to bind to all interfaces.
-# @param node_ip_address Allows you to set the IP for RabbitMQ service to bind to. Set to 127.0.0.1 to bind to localhost only, or 0.0.0.0 to bind to all interfaces.
+# @param management_ip_address Allows you to set the IP for management interface to bind to separately. Set to 127.0.0.1 to bind to
+#  localhost only, or 0.0.0.0 to bind to all interfaces.
+# @param node_ip_address Allows you to set the IP for RabbitMQ service to bind to. Set to 127.0.0.1 to bind to localhost only, or 0.0.0.0
+#  to bind to all interfaces.
 class rabbitmq(
   Boolean $admin_enable                          = $rabbitmq::params::admin_enable,
   Enum['ram', 'disk', 'disc'] $cluster_node_type = $rabbitmq::params::cluster_node_type,

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -28,7 +28,7 @@ class rabbitmq::repo::apt(
     key          => {
       'id'      => $key,
       'source'  => $key_source,
-      'content' =>  $key_content
+      'content' =>  $key_content,
     },
     architecture => $architecture,
   }

--- a/manifests/repo/rhel.pp
+++ b/manifests/repo/rhel.pp
@@ -13,7 +13,7 @@ class rabbitmq::repo::rhel(
     baseurl  => $location,
     gpgkey   => $key_source,
     enabled  => 1,
-    gpgcheck => 1
+    gpgcheck => 1,
   }
 
   # This may still be needed to prevent warnings


### PR DESCRIPTION
This just fixes some linter warnings, plus 2 minor rubocop warnings I forgot to enforce for another recent PR.