### PR TITLE
Fix namevar parameter documentation in types

### DIFF
--- a/lib/puppet/type/rabbitmq_plugin.rb
+++ b/lib/puppet/type/rabbitmq_plugin.rb
@@ -12,7 +12,7 @@ Puppet::Type.newtype(:rabbitmq_plugin) do
   end
 
   newparam(:name, namevar: true) do
-    'name of the plugin to enable'
+    desc 'The name of the plugin to enable'
     newvalues(%r{^\S+$})
   end
 

--- a/lib/puppet/type/rabbitmq_vhost.rb
+++ b/lib/puppet/type/rabbitmq_vhost.rb
@@ -14,7 +14,7 @@ Puppet::Type.newtype(:rabbitmq_vhost) do
   autorequire(:service) { 'rabbitmq-server' }
 
   newparam(:name, namevar: true) do
-    'name of the vhost to add'
+    desc 'The name of the vhost to add'
     newvalues(%r{^\S+$})
   end
 end


### PR DESCRIPTION
This also caused two Lint/Void rubocop violations which are now fixed.