### PR TITLE
Typo in .fixtures.yml breaking unit tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,6 @@ fixtures:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
     "staging": "git://github.com/voxpupuli/puppet-staging.git"
-    "erlang:": "git://github.com/garethr/garethr-erlang.git"
+    "erlang": "git://github.com/garethr/garethr-erlang.git"
   symlinks:
     "rabbitmq": "#{source_dir}"


### PR DESCRIPTION
Typo in .fixtures.yml breaking unit tests ( at least on a windows machine )