### PR TITLE
move these tests to a context block, and use 'let(:foo)' syntax

### DIFF
--- a/spec/unit/puppet/provider/rabbitmq_parameter/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_parameter/rabbitmqctl_spec.rb
@@ -19,28 +19,35 @@ describe Puppet::Type.type(:rabbitmq_parameter).provider(:rabbitmqctl) do
       provider: described_class.name
     )
   end
-
   let(:provider) { resource.provider }
 
   after do
     described_class.instance_variable_set(:@parameters, nil)
   end
 
-  it 'accepts @ in parameter name' do
-    resource = Puppet::Type.type(:rabbitmq_parameter).new(
-      name: 'documentumShovel@/',
-      component_name: 'shovel',
-      value: {
-        'src-uri'    => 'amqp://',
-        'src-queue'  => 'my-queue',
-        'dest-uri'   => 'amqp://remote-server',
-        'dest-queue' => 'another-queue'
-      },
-      provider: described_class.name
-    )
-    provider = described_class.new(resource)
-    expect(provider.should_parameter).to eq('documentumShovel')
-    expect(provider.should_vhost).to eq('/')
+  context 'has "@" in parameter name' do
+    let(:resource) do
+      Puppet::Type.type(:rabbitmq_parameter).new(
+        name: 'documentumShovel@/',
+        component_name: 'shovel',
+        value: {
+          'src-uri'    => 'amqp://',
+          'src-queue'  => 'my-queue',
+          'dest-uri'   => 'amqp://remote-server',
+          'dest-queue' => 'another-queue'
+        },
+        provider: described_class.name
+      )
+    end
+    let(:provider) { described_class.new(resource) }
+
+    it do
+      expect(provider.should_parameter).to eq('documentumShovel')
+    end
+
+    it do
+      expect(provider.should_vhost).to eq('/')
+    end
   end
 
   it 'fails with invalid output from list' do

--- a/spec/unit/puppet/provider/rabbitmq_policy/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_policy/rabbitmqctl_spec.rb
@@ -16,25 +16,32 @@ describe Puppet::Type.type(:rabbitmq_policy).provider(:rabbitmqctl) do
       provider: described_class.name
     )
   end
-
   let(:provider) { resource.provider }
 
   after do
     described_class.instance_variable_set(:@policies, nil)
   end
 
-  it 'accepts @ in policy name' do
-    resource = Puppet::Type.type(:rabbitmq_policy).new(
-      name: 'ha@home@/',
-      pattern: '.*',
-      definition: {
-        'ha-mode' => 'all'
-      },
-      provider: described_class.name
-    )
-    provider = described_class.new(resource)
-    expect(provider.should_policy).to eq('ha@home')
-    expect(provider.should_vhost).to eq('/')
+  context 'has "@" in policy name' do
+    let(:resource) do
+      Puppet::Type.type(:rabbitmq_policy).new(
+        name: 'ha@home@/',
+        pattern: '.*',
+        definition: {
+          'ha-mode' => 'all'
+        },
+        provider: described_class.name
+      )
+    end
+    let(:provider) { described_class.new(resource) }
+
+    it do
+      expect(provider.should_policy).to eq('ha@home')
+    end
+
+    it do
+      expect(provider.should_vhost).to eq('/')
+    end
   end
 
   it 'fails with invalid output from list' do


### PR DESCRIPTION
I think this is an improvement.