### PR TITLE
Remove redundant specs, rework others to avoid multiple expectation warnings

### DIFF
--- a/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
@@ -71,6 +71,8 @@ EOT
 foo [administrator]
 EOT
     expect(provider.admin).to eq(:true)
+  end
+  it 'is able to retrieve correct admin value when there are multiple results' do
     provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 one [administrator]
 foo []

--- a/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
@@ -47,15 +47,19 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
     expect(parameter[:value]).to eq(value)
   end
 
-  it 'does not accept invalid hash for definition' do
+  it 'does not accept an empty string for definition' do
     expect do
       parameter[:value] = ''
     end.to raise_error(Puppet::Error, %r{Invalid value})
+  end
 
+  it 'does not accept a string for definition' do
     expect do
       parameter[:value] = 'guest'
     end.to raise_error(Puppet::Error, %r{Invalid value})
+  end
 
+  it 'does not accept an array for definition' do
     expect do
       parameter[:value] = { 'message-ttl' => %w[999 100] }
     end.to raise_error(Puppet::Error, %r{Invalid value})
@@ -64,14 +68,12 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
   it 'accepts string as myparameter' do
     value = { 'myparameter' => 'mystring' }
     parameter[:value] = value
-    expect(parameter[:value]['myparameter']).to be_a(String)
     expect(parameter[:value]['myparameter']).to eq('mystring')
   end
 
   it 'converts to integer when string only contains numbers' do
     value = { 'myparameter' => '1800000' }
     parameter[:value] = value
-    expect(parameter[:value]['myparameter']).to be_a(Integer)
     expect(parameter[:value]['myparameter']).to eq(1_800_000)
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_queue_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_queue_spec.rb
@@ -34,7 +34,6 @@ describe Puppet::Type.type(:rabbitmq_queue) do
   it 'accepts an arguments with numbers value' do
     queue[:arguments] = { 'x-message-ttl' => 30 }
     expect(queue[:arguments].to_json).to eq('{"x-message-ttl":30}')
-    expect(queue[:arguments]['x-message-ttl']).to eq(30)
   end
 
   it 'accepts an arguments with string value' do

--- a/spec/unit/puppet/type/rabbitmq_user_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_user_spec.rb
@@ -7,6 +7,9 @@ describe Puppet::Type.type(:rabbitmq_user) do
   it 'accepts a user name' do
     user[:name] = 'dan'
     expect(user[:name]).to eq('dan')
+  end
+  it 'admin is false when :admin is not set' do
+    user[:name] = 'dan'
     expect(user[:admin]).to eq(:false)
   end
   it 'accepts a password' do


### PR DESCRIPTION
This should help reduce the # of multiple expectation warnings.