### PR TITLE
update more lint warnings for relative classname inclusion in examples

### DIFF
--- a/examples/erlang_deps.pp
+++ b/examples/erlang_deps.pp
@@ -1,5 +1,5 @@
 # install first the garethr-erlang module. See README.md
-include 'erlang'
+include '::erlang'
 
-class { 'erlang': epel_enable => true}
+class { '::erlang': epel_enable => true}
 Class['erlang'] -> Class['rabbitmq']

--- a/examples/full.pp
+++ b/examples/full.pp
@@ -1,8 +1,8 @@
-class { 'rabbitmq::repo::apt':
+class { '::rabbitmq::repo::apt':
   pin => '900',
 }
 
--> class { 'rabbitmq::server':
+-> class { '::rabbitmq::server':
   delete_guest_user => true,
 #  version           => '2.4.1',
 }

--- a/examples/plugin.pp
+++ b/examples/plugin.pp
@@ -1,4 +1,4 @@
-class { 'rabbitmq::server':
+class { '::rabbitmq::server':
     config_stomp => true,
 }
 

--- a/examples/repo/apt.pp
+++ b/examples/repo/apt.pp
@@ -1,2 +1,2 @@
 # requires pupetlabs-apt
-include rabbitmq::repo::apt
+include ::rabbitmq::repo::apt

--- a/examples/server.pp
+++ b/examples/server.pp
@@ -1,4 +1,4 @@
-class { 'rabbitmq::server':
+class { '::rabbitmq::server':
   port              => '5672',
   delete_guest_user => true,
   version           => 'latest',

--- a/examples/service.pp
+++ b/examples/service.pp
@@ -1,1 +1,1 @@
-class { 'rabbitmq::service': }
+class { '::rabbitmq::service': }

--- a/examples/site.pp
+++ b/examples/site.pp
@@ -2,7 +2,7 @@ node default {
 
   $rabbitmq_plugins = [ 'amqp_client', 'rabbitmq_stomp' ]
 
-  class { 'rabbitmq::server':
+  class { '::rabbitmq::server':
     config => '[ {rabbit_stomp, [{tcp_listeners, [1234]} ]} ].',
   }
 


### PR DESCRIPTION
This seems to make modulesync complain