### PR TITLE
Ignore remaining multiple expectations warnings

### DIFF
--- a/spec/acceptance/parameter_spec.rb
+++ b/spec/acceptance/parameter_spec.rb
@@ -36,11 +36,13 @@ describe 'rabbitmq parameter on a vhost:' do
       apply_manifest(pp, catch_changes: true)
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'has the parameter' do
       shell('rabbitmqctl list_parameters -p fedhost') do |r|
         expect(r.stdout).to match(%r{federation-upstream.*documentumFed.*expires.*3600000})
         expect(r.exit_code).to be_zero
       end
     end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 end

--- a/spec/acceptance/policy_spec.rb
+++ b/spec/acceptance/policy_spec.rb
@@ -47,6 +47,7 @@ describe 'rabbitmq policy on a vhost:' do
       expect(apply_manifest(pp, catch_changes: true).exit_code).to be_zero
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'has the policy' do
       shell('rabbitmqctl list_policies -p myhost') do |r|
         expect(r.stdout).to match(%r{myhost.*ha-all.*ha-sync-mode})
@@ -54,5 +55,6 @@ describe 'rabbitmq policy on a vhost:' do
         expect(r.exit_code).to be_zero
       end
     end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 end

--- a/spec/acceptance/queue_spec.rb
+++ b/spec/acceptance/queue_spec.rb
@@ -60,6 +60,7 @@ describe 'rabbitmq binding:' do
       apply_manifest(pp, catch_changes: true)
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'has the binding' do
       shell('rabbitmqctl list_bindings -q -p host1') do |r|
         expect(r.stdout).to match(%r{exchange1\sexchange\squeue1\squeue\s#})
@@ -73,6 +74,7 @@ describe 'rabbitmq binding:' do
         expect(r.exit_code).to be_zero
       end
     end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 
   context 'create multiple bindings when same source / destination / vhost but different routing keys' do
@@ -148,6 +150,7 @@ describe 'rabbitmq binding:' do
       apply_manifest(pp, catch_changes: true)
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'has the bindings' do
       shell('rabbitmqctl list_bindings -q -p host1') do |r|
         expect(r.stdout).to match(%r{exchange1\sexchange\squeue1\squeue\stest1})
@@ -155,6 +158,7 @@ describe 'rabbitmq binding:' do
         expect(r.exit_code).to be_zero
       end
     end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 
   context 'create binding and queue resources when using a non-default management port' do
@@ -217,6 +221,7 @@ describe 'rabbitmq binding:' do
       apply_manifest(pp, catch_changes: true)
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'has the binding' do
       shell('rabbitmqctl list_bindings -q -p host2') do |r|
         expect(r.stdout).to match(%r{exchange2\sexchange\squeue2\squeue\s#})
@@ -230,5 +235,6 @@ describe 'rabbitmq binding:' do
         expect(r.exit_code).to be_zero
       end
     end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 end

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -25,11 +25,13 @@ describe 'rabbitmq user:' do
       apply_manifest(pp, catch_changes: true)
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'has the user' do
       shell('rabbitmqctl list_users') do |r|
         expect(r.stdout).to match(%r{dan.*administrator})
         expect(r.exit_code).to be_zero
       end
     end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 end

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -24,11 +24,13 @@ describe 'rabbitmq vhost:' do
       apply_manifest(pp, catch_changes: true)
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'has the vhost' do
       shell('rabbitmqctl list_vhosts') do |r|
         expect(r.stdout).to match(%r{myhost})
         expect(r.exit_code).to be_zero
       end
     end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 end

--- a/spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb
@@ -15,6 +15,7 @@ describe provider_class do
   end
   let(:provider) { provider_class.new(resource) }
 
+  # rubocop:disable RSpec/MultipleExpectations
   describe '#instances' do
     it 'returns instances' do
       provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
@@ -41,7 +42,9 @@ EOT
                    }
                  ])
     end
+    # rubocop:enable RSpec/MultipleExpectations
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'returns multiple instances' do
       provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
 /
@@ -75,6 +78,7 @@ EOT
                  ])
     end
   end
+  # rubocop:enable RSpec/MultipleExpectations
 
   describe 'Test for prefetch error' do
     let(:resource) do

--- a/spec/unit/puppet/type/rabbitmq_user_permissions_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_user_permissions_spec.rb
@@ -36,6 +36,7 @@ describe Puppet::Type.type(:rabbitmq_user_permissions) do
       end.to raise_error(Puppet::Error, %r{Invalid regexp})
     end
   end
+  # rubocop:disable RSpec/MultipleExpectations
   { rabbitmq_vhost: 'dan@test', rabbitmq_user: 'test@dan' }.each do |k, v|
     it "should autorequire #{k}" do
       vhost = if k == :rabbitmq_vhost
@@ -52,4 +53,5 @@ describe Puppet::Type.type(:rabbitmq_user_permissions) do
       expect(rel.target.ref).to eq(perm.ref)
     end
   end
+  # rubocop:enable RSpec/MultipleExpectations
 end


### PR DESCRIPTION
Disable / ignore the remaining 'multiple expectations' warnings in acceptance tests and in 2 other specs until we can get good fixes in place for them.