### PR TITLE
Convert to use 'archive' instead of 'staging' for rabbitmqadmin install

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
-    "staging": "git://github.com/voxpupuli/puppet-staging.git"
+    "archive": "https://github.com/puppet-community/puppet-archive.git"
     "erlang": "git://github.com/garethr/garethr-erlang.git"
   symlinks:
     "rabbitmq": "#{source_dir}"

--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -1,6 +1,8 @@
 #
 class rabbitmq::install::rabbitmqadmin {
 
+  require '::archive'
+
   if($rabbitmq::ssl and $rabbitmq::management_ssl) {
     $management_port = $rabbitmq::ssl_management_port
     $protocol        = 'https'
@@ -25,13 +27,14 @@ class rabbitmq::install::rabbitmqadmin {
     $sanitized_ip = $management_ip_address
   }
 
-  staging::file { 'rabbitmqadmin':
-    target      => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
-    source      => "${protocol}://${sanitized_ip}:${management_port}/cli/rabbitmqadmin",
-    curl_option => "-u \"${default_user}:${default_pass}\" -k ${curl_prefix} --retry 30 --retry-delay 6",
-    timeout     => '180',
-    wget_option => '--no-proxy --no-check-certificate',
-    require     => [
+  archive { 'rabbitmqadmin':
+    path           => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
+    source         => "${protocol}://${sanitized_ip}:${management_port}/cli/rabbitmqadmin",
+    username       => $default_user,
+    password       => $default_pass,
+    allow_insecure => true,
+    cleanup        => false,
+    require        => [
       Class['rabbitmq::service'],
       Rabbitmq_plugin['rabbitmq_management']
     ],
@@ -42,7 +45,7 @@ class rabbitmq::install::rabbitmqadmin {
     group   => '0',
     source  => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
     mode    => '0755',
-    require => Staging::File['rabbitmqadmin'],
+    require => Archive['rabbitmqadmin'],
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -55,6 +55,6 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 5.0.0"},
-    {"name":"puppet/staging","version_requirement":">= 0.3.1 < 3.0.0"}
+    {"name":"puppet/archive","version_requirement":">= 1.0.0 < 3.0.0"}
   ]
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -200,7 +200,7 @@ describe 'rabbitmq' do
               'require' => 'Class[Rabbitmq::Install]',
               'notify'  => 'Class[Rabbitmq::Service]'
             )
-            is_expected.to contain_staging__file('rabbitmqadmin').with_source('http://1.1.1.1:15672/cli/rabbitmqadmin')
+            is_expected.to contain_archive('rabbitmqadmin').with_source('http://1.1.1.1:15672/cli/rabbitmqadmin')
           end
         end
         context 'with $management_ip_address undef and service_manage set to true' do
@@ -212,16 +212,17 @@ describe 'rabbitmq' do
               'require' => 'Class[Rabbitmq::Install]',
               'notify'  => 'Class[Rabbitmq::Service]'
             )
-            is_expected.to contain_staging__file('rabbitmqadmin').with_source('http://127.0.0.1:15672/cli/rabbitmqadmin')
+            is_expected.to contain_archive('rabbitmqadmin').with_source('http://127.0.0.1:15672/cli/rabbitmqadmin')
           end
         end
         context 'with service_manage set to true, node_ip_address = undef, and default user/pass specified' do
           let(:params) { { admin_enable: true, default_user: 'foobar', default_pass: 'hunter2', node_ip_address: :undef } }
 
           it 'we use the correct URL to rabbitmqadmin' do
-            is_expected.to contain_staging__file('rabbitmqadmin').with(
+            is_expected.to contain_archive('rabbitmqadmin').with(
               source: 'http://127.0.0.1:15672/cli/rabbitmqadmin',
-              curl_option: '-u "foobar:hunter2" -k  --retry 30 --retry-delay 6'
+              username: 'foobar',
+              password: 'hunter2'
             )
           end
         end
@@ -229,9 +230,10 @@ describe 'rabbitmq' do
           let(:params) { { admin_enable: true, default_user: 'foobar', default_pass: 'hunter2', management_ip_address: '1.1.1.1' } }
 
           it 'we use the correct URL to rabbitmqadmin' do
-            is_expected.to contain_staging__file('rabbitmqadmin').with(
+            is_expected.to contain_archive('rabbitmqadmin').with(
               source: 'http://1.1.1.1:15672/cli/rabbitmqadmin',
-              curl_option: '-u "foobar:hunter2" -k --noproxy 1.1.1.1 --retry 30 --retry-delay 6'
+              username: 'foobar',
+              password: 'hunter2'
             )
           end
         end
@@ -240,9 +242,10 @@ describe 'rabbitmq' do
           let(:params) { { admin_enable: true, management_port: 55_672, management_ip_address: '1.1.1.1' } }
 
           it 'we use the correct URL to rabbitmqadmin' do
-            is_expected.to contain_staging__file('rabbitmqadmin').with(
+            is_expected.to contain_archive('rabbitmqadmin').with(
               source: 'http://1.1.1.1:55672/cli/rabbitmqadmin',
-              curl_option: '-u "guest:guest" -k --noproxy 1.1.1.1 --retry 30 --retry-delay 6'
+              username: 'guest',
+              password: 'guest'
             )
           end
         end
@@ -251,9 +254,10 @@ describe 'rabbitmq' do
           let(:params) { { admin_enable: true, management_port: 55_672, management_ip_address: '::1' } }
 
           it 'we use the correct URL to rabbitmqadmin' do
-            is_expected.to contain_staging__file('rabbitmqadmin').with(
+            is_expected.to contain_archive('rabbitmqadmin').with(
               source: 'http://[::1]:55672/cli/rabbitmqadmin',
-              curl_option: '-u "guest:guest" -k --noproxy ::1 -g -6 --retry 30 --retry-delay 6'
+              username: 'guest',
+              password: 'guest'
             )
           end
         end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -22,7 +22,7 @@ RSpec.configure do |c|
       end
 
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module', 'install', 'puppet-staging'), acceptable_exit_codes: [0, 1]
+      on host, puppet('module', 'install', 'puppet-archive'), acceptable_exit_codes: [0, 1]
 
       if fact('os.family') == 'Debian'
         on host, puppet('module', 'install', 'puppetlabs-apt'), acceptable_exit_codes: [0, 1]

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -2,6 +2,5 @@ require 'rspec-puppet-facts'
 include RspecPuppetFacts
 #                                                                       # Original fact sources:
 add_custom_fact :puppetversion, Puppet.version                          # Facter, but excluded from rspec-puppet-facts
-add_custom_fact :staging_http_get, ''                                   # puppet-staging
 add_custom_fact :rabbitmq_version, '3.6.1'                              # puppet-rabbitmq
 add_custom_fact :erl_ssl_path, '/usr/lib64/erlang/lib/ssl-7.3.3.1/ebin' # puppet-rabbitmq


### PR DESCRIPTION
This PR switches the module to use the 'archive' module instead of 'staging'.