### PR TITLE
fix a couple of problems with erl_ssl_path fact

### DIFF
--- a/lib/facter/erl_ssl_path.rb
+++ b/lib/facter/erl_ssl_path.rb
@@ -4,13 +4,10 @@
 # [1] https://www.rabbitmq.com/clustering-ssl.html
 Facter.add('erl_ssl_path') do
   setcode do
-    data = false
     if Facter::Util::Resolution.which('erl')
-      Facter::Util::Resolution.with_env('HOME' => '/root') do
-        data = Facter::Core::Execution.execute("erl -eval 'io:format(\"~p\", [code:lib_dir(ssl, ebin)]),halt().' -noshell")
-      end
+      data = Facter::Core::Execution.execute("erl -eval 'io:format(\"~p\", [code:lib_dir(ssl, ebin)]),halt().' -noshell")
+      # erl returns the string with quotes, strip them off
+      data.gsub!(%r{\A"|"\Z}, '')
     end
-    # erl returns the string with quotes, strip them off
-    data.gsub!(%r{\A"|"\Z}, '')
   end
 end

--- a/spec/unit/facter/util/fact_erl_ssl_path_spec.rb
+++ b/spec/unit/facter/util/fact_erl_ssl_path_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+RSpec.configure do |config|
+  config.mock_with :rspec
+end
+
+describe Facter::Util::Fact do
+  before { Facter.clear }
+
+  describe 'erl_ssl_path' do
+    context 'with valid value' do
+      before do
+        allow(Facter::Util::Resolution).to receive(:which).with('erl') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with("erl -eval 'io:format(\"~p\", [code:lib_dir(ssl, ebin)]),halt().' -noshell") { '"/usr/lib64/erlang/lib/ssl-5.3.3/ebin"' }
+      end
+
+      it do
+        expect(Facter.fact(:erl_ssl_path).value).to eq('/usr/lib64/erlang/lib/ssl-5.3.3/ebin')
+      end
+    end
+
+    context 'with error message' do
+      before do
+        allow(Facter::Util::Resolution).to receive(:which).with('erl') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with("erl -eval 'io:format(\"~p\", [code:lib_dir(ssl, ebin)]),halt().' -noshell") { '{error,bad_name}' }
+      end
+
+      it do
+        expect(Facter.fact(:erl_ssl_path).value).to be_nil
+      end
+    end
+
+    context 'with erl not present' do
+      before do
+        allow(Facter::Util::Resolution).to receive(:which).with('erl') { false }
+      end
+
+      it do
+        expect(Facter.fact(:erl_ssl_path).value).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
(this is a re-submission of #606)

Hi there,

This small PR fixes two small issues with the `erl_ssl_path` fact.
The first is pretty straightforward: avoid the `.gsub` call if we didn't actually get any data to mangle.
The second is a bit less clear-cut: drop the use of `.with_env` while calling `erl`. Newer versions of facter (>=3) AFAIK stopped supporting it (compare [2.x docs](https://puppetlabs.github.io/facter/2.0.x/Facter/Util/Resolution.html) with [3.x docs](https://puppetlabs.github.io/facter/master/structfacter_1_1ruby_1_1resolution.html)) and it was unclear why we needed it in the first place. If I'm missing something and it *is* needed in some case, I'd be happy to find another workaround.

It also adds simple testing for `erl_ssl_path`.

Cheers