### PR TITLE
Avoid error when rabbitmqctl is not present), update spec syntax (#614)

### DIFF
--- a/lib/facter/rabbitmq_nodename.rb
+++ b/lib/facter/rabbitmq_nodename.rb
@@ -1,6 +1,6 @@
 Facter.add(:rabbitmq_nodename) do
   setcode do
-    if Facter::Core::Execution.which('rabbitmqctl')
+    if Facter::Util::Resolution.which('rabbitmqctl')
       rabbitmq_nodename = Facter::Core::Execution.execute('rabbitmqctl status 2>&1')
       %r{^Status of node '?([\w\.]+@[\w\.\-]+)'?}.match(rabbitmq_nodename)[1]
     end

--- a/lib/facter/rabbitmq_version.rb
+++ b/lib/facter/rabbitmq_version.rb
@@ -1,6 +1,6 @@
 Facter.add(:rabbitmq_version) do
   setcode do
-    if Facter::Core::Execution.which('rabbitmqadmin')
+    if Facter::Util::Resolution.which('rabbitmqadmin')
       rabbitmq_version = Facter::Core::Execution.execute('rabbitmqadmin --version 2>&1')
       %r{^rabbitmqadmin ([\w\.]+)}.match(rabbitmq_version)[1]
     end

--- a/spec/unit/facter/util/fact_rabbitmq_nodename_spec.rb
+++ b/spec/unit/facter/util/fact_rabbitmq_nodename_spec.rb
@@ -1,49 +1,91 @@
 require 'spec_helper'
 
+RSpec.configure do |config|
+  config.mock_with :rspec
+end
+
 describe Facter::Util::Fact do
-  before do
-    Facter.clear
-  end
+  before { Facter.clear }
 
   describe 'rabbitmq_nodename' do
     context 'with value' do
       before do
-        Facter::Core::Execution.stubs(:which).with('rabbitmqctl').returns(true)
-        Facter::Core::Execution.stubs(:execute).with('rabbitmqctl status 2>&1').returns('Status of node monty@rabbit1 ...')
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqctl') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with('rabbitmqctl status 2>&1') { 'Status of node monty@rabbit1 ...' }
       end
-      it {
+      it do
         expect(Facter.fact(:rabbitmq_nodename).value).to eq('monty@rabbit1')
-      }
+      end
     end
 
     context 'with dashes in hostname' do
       before do
-        Facter::Core::Execution.stubs(:which).with('rabbitmqctl').returns(true)
-        Facter::Core::Execution.stubs(:execute).with('rabbitmqctl status 2>&1').returns('Status of node monty@rabbit-1 ...')
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqctl') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with('rabbitmqctl status 2>&1') { 'Status of node monty@rabbit-1 ...' }
       end
-      it {
+      it do
         expect(Facter.fact(:rabbitmq_nodename).value).to eq('monty@rabbit-1')
-      }
+      end
     end
 
     context 'with quotes around node name' do
       before do
-        Facter::Core::Execution.stubs(:which).with('rabbitmqctl').returns(true)
-        Facter::Core::Execution.stubs(:execute).with('rabbitmqctl status 2>&1').returns('Status of node \'monty@rabbit-1\' ...')
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqctl') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with('rabbitmqctl status 2>&1') { 'Status of node \'monty@rabbit-1\' ...' }
       end
-      it {
+      it do
         expect(Facter.fact(:rabbitmq_nodename).value).to eq('monty@rabbit-1')
-      }
+      end
     end
 
     context 'without trailing points' do
       before do
-        Facter::Core::Execution.stubs(:which).with('rabbitmqctl').returns(true)
-        Facter::Core::Execution.stubs(:execute).with('rabbitmqctl status 2>&1').returns('Status of node monty@rabbit-1')
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqctl') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with('rabbitmqctl status 2>&1') { 'Status of node monty@rabbit-1' }
       end
-      it {
+      it do
         expect(Facter.fact(:rabbitmq_nodename).value).to eq('monty@rabbit-1')
-      }
+      end
+    end
+
+    context 'rabbitmq is not running' do
+      before do
+        error_string = <<-EOS
+Status of node 'monty@rabbit-1' ...
+Error: unable to connect to node 'monty@rabbit-1': nodedown
+
+DIAGNOSTICS
+===========
+
+attempted to contact: ['monty@rabbit-1']
+
+monty@rabbit-1:
+  * connected to epmd (port 4369) on centos-7-x64
+  * epmd reports: node 'rabbit' not running at all
+                  no other nodes on centos-7-x64
+  * suggestion: start the node
+
+current node details:
+- node name: 'rabbitmq-cli-73@centos-7-x64'
+- home dir: /var/lib/rabbitmq
+- cookie hash: 6WdP0nl6d3HYqA5vTKMkIg==
+
+        EOS
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqctl') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with('rabbitmqctl status 2>&1') { error_string }
+      end
+      it do
+        expect(Facter.fact(:rabbitmq_nodename).value).to eq('monty@rabbit-1')
+      end
+    end
+
+    context 'rabbitmqctl is not in path' do
+      before do
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqctl') { false }
+      end
+      it do
+        expect(Facter.fact(:rabbitmq_nodename).value).to be_nil
+      end
     end
   end
 end

--- a/spec/unit/facter/util/fact_rabbitmq_version_spec.rb
+++ b/spec/unit/facter/util/fact_rabbitmq_version_spec.rb
@@ -1,5 +1,9 @@
 require 'spec_helper'
 
+RSpec.configure do |config|
+  config.mock_with :rspec
+end
+
 describe Facter::Util::Fact do
   before do
     Facter.clear
@@ -8,12 +12,20 @@ describe Facter::Util::Fact do
   describe 'rabbitmq_version' do
     context 'with value' do
       before do
-        Facter::Core::Execution.stubs(:which).with('rabbitmqadmin').returns(true)
-        Facter::Core::Execution.stubs(:execute).with('rabbitmqadmin --version 2>&1').returns('rabbitmqadmin 3.6.0')
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqadmin') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with('rabbitmqadmin --version 2>&1') { 'rabbitmqadmin 3.6.0' }
       end
-      it {
+      it do
         expect(Facter.fact(:rabbitmq_version).value).to eq('3.6.0')
-      }
+      end
+    end
+    context 'rabbitmqadmin is not in path' do
+      before do
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqadmin') { false }
+      end
+      it do
+        expect(Facter.fact(:rabbitmq_version).value).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
This updates to 'expect' style rspec syntax, and switch to `Facter::Util::Resolution` (vs `Execution`), thanks @dhollinger 