### PR TITLE
BREAKING: Ensure python package (adds manage_python option)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,6 +124,8 @@
 # @param ldap_use_ssl Set to true to use SSL for the LDAP server.
 # @param ldap_port Numeric port for LDAP server.
 # @param ldap_log Set to true to log LDAP auth.
+# @param manage_python If enabled, on platforms that don't provide a Python 2 package by default, ensure that the python package is
+#  installed (for rabbitmqadmin). This will only apply if `admin_enable` and `service_manage` are set.
 # @param manage_repos Whether or not to manage package repositories.
 # @param management_hostname The hostname for the RabbitMQ management interface.
 # @param management_port The port for the RabbitMQ management interface.
@@ -213,6 +215,7 @@ class rabbitmq(
   Optional[String] $package_provider             = undef,
   Boolean $repos_ensure                          = $rabbitmq::params::repos_ensure,
   $manage_repos                                  = undef,
+  Boolean $manage_python                         = $rabbitmq::params::manage_python,
   $rabbitmq_user                                 = $rabbitmq::params::rabbitmq_user,
   $rabbitmq_group                                = $rabbitmq::params::rabbitmq_group,
   $rabbitmq_home                                 = $rabbitmq::params::rabbitmq_home,

--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -3,6 +3,15 @@ class rabbitmq::install::rabbitmqadmin {
 
   require '::archive'
 
+  $python_package = $rabbitmq::params::python_package
+  # Some systems (e.g., Ubuntu 16.04) don't ship Python 2 by default
+  if $rabbitmq::manage_python {
+    ensure_packages([$python_package])
+    $rabbitmqadmin_require = [Archive['rabbitmqadmin'], Package[$python_package]]
+  } else {
+    $rabbitmqadmin_require = Archive['rabbitmqadmin']
+  }
+
   if($rabbitmq::ssl and $rabbitmq::management_ssl) {
     $management_port = $rabbitmq::ssl_management_port
     $protocol        = 'https'
@@ -45,7 +54,7 @@ class rabbitmq::install::rabbitmqadmin {
     group   => '0',
     source  => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
     mode    => '0755',
-    require => Archive['rabbitmqadmin'],
+    require => $rabbitmqadmin_require,
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,8 @@ class rabbitmq::params {
 
   case $facts['os']['family'] {
     'Archlinux': {
+      $manage_python    = true
+      $python_package   = 'python2'
       $package_ensure   = 'installed'
       $package_name     = 'rabbitmq'
       $service_name     = 'rabbitmq'
@@ -14,6 +16,8 @@ class rabbitmq::params {
       $rabbitmq_home    = '/var/lib/rabbitmq'
     }
     'Debian': {
+      $manage_python    = true
+      $python_package   = 'python'
       $package_ensure   = 'installed'
       $package_name     = 'rabbitmq-server'
       $service_name     = 'rabbitmq-server'
@@ -22,6 +26,8 @@ class rabbitmq::params {
       $rabbitmq_home    = '/var/lib/rabbitmq'
     }
     'OpenBSD': {
+      $manage_python    = true
+      $python_package   = 'python2'
       $package_ensure   = 'installed'
       $package_name     = 'rabbitmq'
       $service_name     = 'rabbitmq'
@@ -30,6 +36,8 @@ class rabbitmq::params {
       $rabbitmq_home    = '/var/rabbitmq'
     }
     'FreeBSD': {
+      $manage_python    = true
+      $python_package   = 'python2'
       $package_ensure   = 'installed'
       $package_name     = 'rabbitmq'
       $service_name     = 'rabbitmq'
@@ -38,6 +46,8 @@ class rabbitmq::params {
       $rabbitmq_home    = '/var/db/rabbitmq'
     }
     'RedHat': {
+      $manage_python    = true
+      $python_package   = 'python'
       $package_ensure   = 'installed'
       $package_name     = 'rabbitmq-server'
       $service_name     = 'rabbitmq-server'
@@ -46,6 +56,8 @@ class rabbitmq::params {
       $rabbitmq_home    = '/var/lib/rabbitmq'
     }
     'SUSE': {
+      $manage_python    = true
+      $python_package   = 'python'
       $package_ensure   = 'installed'
       $package_name     = 'rabbitmq-server'
       $service_name     = 'rabbitmq-server'

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -177,9 +177,9 @@ describe 'rabbitmq' do
 
         it {
           is_expected.to contain_exec('rabbitmq-systemd-reload').with(
-            'command'     => '/usr/bin/systemctl daemon-reload',
-            'notify'      => 'Class[Rabbitmq::Service]',
-            'refreshonly' => true
+            command: '/usr/bin/systemctl daemon-reload',
+            notify: 'Class[Rabbitmq::Service]',
+            refreshonly: :true
           )
         }
       end
@@ -197,9 +197,14 @@ describe 'rabbitmq' do
           it 'we enable the admin interface by default' do
             is_expected.to contain_class('rabbitmq::install::rabbitmqadmin')
             is_expected.to contain_rabbitmq_plugin('rabbitmq_management').with(
-              'notify'  => 'Class[Rabbitmq::Service]'
+              notify: 'Class[Rabbitmq::Service]'
             )
             is_expected.to contain_archive('rabbitmqadmin').with_source('http://1.1.1.1:15672/cli/rabbitmqadmin')
+          end
+          if facts[:os]['family'] == 'Debian'
+            it 'python is in the catalog on Debian / Ubuntu' do
+              is_expected.to contain_package('python')
+            end
           end
         end
         context 'with $management_ip_address undef and service_manage set to true' do
@@ -208,7 +213,7 @@ describe 'rabbitmq' do
           it 'we enable the admin interface by default' do
             is_expected.to contain_class('rabbitmq::install::rabbitmqadmin')
             is_expected.to contain_rabbitmq_plugin('rabbitmq_management').with(
-              'notify'  => 'Class[Rabbitmq::Service]'
+              notify: 'Class[Rabbitmq::Service]'
             )
             is_expected.to contain_archive('rabbitmqadmin').with_source('http://127.0.0.1:15672/cli/rabbitmqadmin')
           end


### PR DESCRIPTION
This is needed for Ubuntu 16.04+ where only Python 3 is installed by default.

This could cause issues in some cases where people have defined the Python package elsewhere, I'm open to suggestions on how to do this more sanely, though really hoping to avoid an additional parameter.

If RabbitMQ distributed it in the package, the dependency could be handled more cleanly.