### PR TITLE
Add official support for Ubuntu 16.04

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,7 +2,7 @@
 .travis.yml:
   secure: "Ojc0h2mbt9Y+eCyiKD+x1iYNONOP27Me63hjo9jo2v1bSs3aiM7djlcpz/sG+jRJ7JQoUyaGzHSn+gvxwWqdagFfFgDmipMKD0OXQinq7upRaG2hR+akKo0jllq9zLjJGBDoxurioKfOzPGlt2bX3UYY5KyeJ3AIM4dwCGVtSh4="
   docker_sets:
-    - set: docker/ubuntu-14.04
+    - set: docker/ubuntu-16.04
     - set: docker/centos-7
 appveyor.yml:
   delete: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
   - rvm: 2.1.9
     bundler_args: --without development
     dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04 CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-16.04 CHECK=beaker
     services: docker
     sudo: required
   - rvm: 2.1.9

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -241,7 +241,7 @@ class rabbitmq::config {
           notify  => Exec['rabbitmq-systemd-reload'],
         }
         exec { 'rabbitmq-systemd-reload':
-          command     => '/usr/bin/systemctl daemon-reload',
+          command     => '/bin/systemctl daemon-reload',
           notify      => Class['Rabbitmq::Service'],
           refreshonly => true,
         }

--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "12.04",
-        "14.04"
+        "14.04",
+        "16.04"
       ]
     },
     {

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -177,9 +177,9 @@ describe 'rabbitmq' do
 
         it {
           is_expected.to contain_exec('rabbitmq-systemd-reload').with(
-            command: '/usr/bin/systemctl daemon-reload',
+            command: '/bin/systemctl daemon-reload',
             notify: 'Class[Rabbitmq::Service]',
-            refreshonly: :true
+            refreshonly: true
           )
         }
       end


### PR DESCRIPTION
I think we can avoid making bigger changes to tests or systemd for now by just hitting `/bin/systemctl` on both Ubuntu and CentOS systems.

This will still depend on #623 (or the equivalent) for acceptance tests to pass in Travis, however, unless we explicitly force the python package in the Docker image.