### PR TITLE
Resolve issue with "puppet resource rabbitmq_user" failing (#147)

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -24,6 +24,8 @@ Puppet::Type.type(:rabbitmq_user).provide(:rabbitmqctl, parent: Puppet::Provider
   end
 
   def create
+    raise Puppet::Error, "Password is a required parameter for rabbitmq_user (user: #{name})" if @resource[:password].nil?
+
     rabbitmqctl('add_user', resource[:name], resource[:password])
     make_user_admin if resource[:admin] == :true
     set_user_tags(resource[:tags]) unless resource[:tags].empty?

--- a/lib/puppet/type/rabbitmq_user.rb
+++ b/lib/puppet/type/rabbitmq_user.rb
@@ -99,10 +99,4 @@ DESC
       end
     end
   end
-
-  validate do
-    if self[:ensure] == :present && !self[:password]
-      raise ArgumentError, 'must set password when creating user' unless self[:password]
-    end
-  end
 end

--- a/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
@@ -26,12 +26,6 @@ EOT
 EOT
     expect(provider.exists?).to be_nil
   end
-  it 'does not match if no matching users on system' do
-    provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
-fooey
-EOT
-    expect(provider.exists?).to be_nil
-  end
   it 'matches user names from list' do
     provider.expects(:rabbitmqctl).with('-q', 'list_users').returns <<-EOT
 one
@@ -40,6 +34,19 @@ foo
 bar
 EOT
     expect(provider.exists?).to eq('foo')
+  end
+  context 'when no password is given' do
+    let(:resource) do
+      Puppet::Type::Rabbitmq_user.new(
+        name: 'rmq_x'
+      )
+    end
+
+    it 'raises an error' do
+      expect do
+        provider.create
+      end.to raise_error(Puppet::Error, 'Password is a required parameter for rabbitmq_user (user: rmq_x)')
+    end
   end
   it 'creates user and set password' do
     resource[:password] = 'bar'

--- a/spec/unit/puppet/type/rabbitmq_user_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_user_spec.rb
@@ -16,11 +16,6 @@ describe Puppet::Type.type(:rabbitmq_user) do
     user[:password] = 'foo'
     expect(user[:password]).to eq('foo')
   end
-  it 'requires a password' do
-    expect do
-      Puppet::Type.type(:rabbitmq_user).new(name: 'foo')
-    end.to raise_error(%r{must set password})
-  end
   it 'requires a name' do
     expect do
       Puppet::Type.type(:rabbitmq_user).new({})


### PR DESCRIPTION
This breaks out the fix for #147 (though it's also handled in #598 with the alternate implementation of rabbitmq_user type / provider)