### PR TITLE
COVERALLS POC: DO NOT MERGE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     env: PUPPET_VERSION="~> 4.0" CHECK=test
   - rvm: 2.4.1
     bundler_args: --without system_tests development
-    env: PUPPET_VERSION="~> 5.0" CHECK=test
+    env: PUPPET_VERSION="~> 5.0" CHECK=test_with_coveralls
   - rvm: 2.4.1
     bundler_args: --without system_tests development
     env: PUPPET_VERSION="~> 5.0" CHECK=rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -31,6 +31,17 @@ task test: [
   :release_checks,
 ]
 
+desc "Run main 'test' task and report merged results to coveralls"
+task test_with_coveralls: [:test] do
+  if Dir.exist?(File.expand_path('../lib', __FILE__))
+    require 'coveralls/rake/task'
+    Coveralls::RakeTask.new
+    Rake::Task['coveralls:push'].invoke
+  else
+    puts 'Skipping reporting to coveralls.  Module has no lib dir'
+  end
+end
+
 begin
   require 'github_changelog_generator/task'
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,7 @@ if Dir.exist?(File.expand_path('../../lib', __FILE__))
   require 'simplecov-console'
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::Console,
-    Coveralls::SimpleCov::Formatter
+    SimpleCov::Formatter::Console
   ]
   SimpleCov.start do
     track_files 'lib/**/*.rb'


### PR DESCRIPTION
This proof of concept attempts to solve 2 issues.

We use parallel_tests, so we should wait for simplecov to merge results
before reporting to coveralls.

We are reporting in two jobs, (once for puppet 4 and again for puppet
5).

See:
https://coveralls.zendesk.com/hc/en-us/articles/201769485-Ruby-Rails
https://github.com/colszowka/simplecov#merging-results

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
