### PR TITLE
Lower required Puppet version from 4.8.0 to 4.7.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.8.0 < 6.0.0"
+      "version_requirement": ">= 4.7.1 < 6.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
switch lowest supported version back to 4.7.1