### PR TITLE
Rework apt to use packagecloud repos as well (#640)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,8 +137,8 @@
 # @param package_apt_pin Whether to pin the package to a particular source
 # @param package_ensure Determines the ensure state of the package.  Set to installed by default, but could be changed to latest.
 # @param package_gpg_key RPM package GPG key to import. Uses source method. Should be a URL for Debian/RedHat OS family, or a file name for
-#  RedHat OS family. Set to http://www.rabbitmq.com/rabbitmq-signing-key-public.asc by default. Note, that `key_content`, if specified,
-#  would override this parameter for Debian OS family.
+#  RedHat OS family. Set to https://packagecloud.io/gpg.key by default. Note, that `key_content`, if specified, would override this
+#  parameter for Debian OS family.
 # @param package_name The name of the package to install.
 # @param package_provider What provider to use to install the package.
 # @param package_source Where should the package be installed from? On Debian- and Arch-based systems using the default package provider,
@@ -322,15 +322,10 @@ class rabbitmq(
   if $repos_ensure {
     case $facts['os']['family'] {
       'RedHat': {
-        class { 'rabbitmq::repo::rhel':
-          key_source  => $package_gpg_key,
-        }
+        contain rabbitmq::repo::rhel
       }
       'Debian': {
-        class { 'rabbitmq::repo::apt' :
-          key_source  => $package_gpg_key,
-          key_content => $key_content,
-        }
+        contain rabbitmq::repo::apt
       }
       default: {
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class rabbitmq::params {
       $rabbitmq_user    = 'rabbitmq'
       $rabbitmq_group   = 'rabbitmq'
       $rabbitmq_home    = '/var/lib/rabbitmq'
+      $package_gpg_key  = undef
     }
     'Debian': {
       $manage_python    = true
@@ -24,6 +25,7 @@ class rabbitmq::params {
       $rabbitmq_user    = 'rabbitmq'
       $rabbitmq_group   = 'rabbitmq'
       $rabbitmq_home    = '/var/lib/rabbitmq'
+      $package_gpg_key  = 'https://packagecloud.io/gpg.key'
     }
     'OpenBSD': {
       $manage_python    = true
@@ -34,6 +36,7 @@ class rabbitmq::params {
       $rabbitmq_user    = '_rabbitmq'
       $rabbitmq_group   = '_rabbitmq'
       $rabbitmq_home    = '/var/rabbitmq'
+      $package_gpg_key  = undef
     }
     'FreeBSD': {
       $manage_python    = true
@@ -44,6 +47,7 @@ class rabbitmq::params {
       $rabbitmq_user    = 'rabbitmq'
       $rabbitmq_group   = 'rabbitmq'
       $rabbitmq_home    = '/var/db/rabbitmq'
+      $package_gpg_key  = undef
     }
     'RedHat': {
       $manage_python    = true
@@ -54,6 +58,7 @@ class rabbitmq::params {
       $rabbitmq_user    = 'rabbitmq'
       $rabbitmq_group   = 'rabbitmq'
       $rabbitmq_home    = '/var/lib/rabbitmq'
+      $package_gpg_key  = 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc'
     }
     'SUSE': {
       $manage_python    = true
@@ -64,6 +69,7 @@ class rabbitmq::params {
       $rabbitmq_user    = 'rabbitmq'
       $rabbitmq_group   = 'rabbitmq'
       $rabbitmq_home    = '/var/lib/rabbitmq'
+      $package_gpg_key  = undef
     }
     default: {
       fail("The ${module_name} module is not supported on an ${facts['os']['family']} based system.")
@@ -75,7 +81,6 @@ class rabbitmq::params {
   $management_port             = 15672
   $management_ssl              = true
   $package_apt_pin             = ''
-  $package_gpg_key             = 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc'
   $repos_ensure                = false
   $service_ensure              = 'running'
   $service_manage              = true

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -2,13 +2,12 @@
 #   puppetlabs-apt
 #   puppetlabs-stdlib
 class rabbitmq::repo::apt(
-  $location     = 'http://www.rabbitmq.com/debian/',
-  $release      = 'testing',
+  $location     = 'https://packagecloud.io/rabbitmq/rabbitmq-server',
   $repos        = 'main',
   $include_src  = false,
-  $key          = '0A9AF2115F4687BD29803A206B73A36E6026DFCA',
-  $key_source   = $rabbitmq::key_source,
-  $key_content  = undef,
+  $key          = '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',
+  $key_source   = $rabbitmq::package_gpg_key,
+  $key_content  = $rabbitmq::key_content,
   $architecture = undef,
   ) {
 
@@ -19,10 +18,10 @@ class rabbitmq::repo::apt(
   -> Class['apt::update']
   -> Package<| title == 'rabbitmq-server' |>
 
+  $osname = downcase($facts['os']['name'])
   apt::source { 'rabbitmq':
     ensure       => present,
-    location     => $location,
-    release      => $release,
+    location     => "${location}/${osname}",
     repos        => $repos,
     include      => { 'src' => $include_src },
     key          => {
@@ -38,7 +37,7 @@ class rabbitmq::repo::apt(
     apt::pin { 'rabbitmq':
       packages => '*',
       priority => $pin,
-      origin   => 'www.rabbitmq.com',
+      origin   => 'packagecloud.io',
     }
   }
 }

--- a/manifests/repo/rhel.pp
+++ b/manifests/repo/rhel.pp
@@ -2,7 +2,7 @@
 # Makes sure that the Packagecloud repo is installed
 class rabbitmq::repo::rhel(
     $location       = "https://packagecloud.io/rabbitmq/rabbitmq-server/el/${facts['os'][release][major]}/\$basearch",
-    $key_source     = 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc',
+    $key_source     = $rabbitmq::package_gpg_key,
   ) {
 
   Class['rabbitmq::repo::rhel'] -> Package<| title == 'rabbitmq-server' |>
@@ -17,6 +17,7 @@ class rabbitmq::repo::rhel(
   }
 
   # This may still be needed to prevent warnings
+  # packagecloud key is gpg-pubkey-d59097ab-52d46e88
   exec { "rpm --import ${key_source}":
     path   => ['/bin','/usr/bin','/sbin','/usr/sbin'],
     unless => 'rpm -q gpg-pubkey-6026dfca-573adfde 2>/dev/null',

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -45,15 +45,15 @@ describe 'rabbitmq' do
         if facts[:os]['family'] == 'Debian'
           it 'includes rabbitmq::repo::apt' do
             is_expected.to contain_class('rabbitmq::repo::apt').
-              with_key_source('https://www.rabbitmq.com/rabbitmq-release-signing-key.asc').
+              with_key_source('https://packagecloud.io/gpg.key').
               with_key_content(nil)
           end
 
           it 'adds a repo with default values' do
             is_expected.to contain_apt__source('rabbitmq').
               with_ensure('present').
-              with_location('http://www.rabbitmq.com/debian/').
-              with_release('testing').
+              with_location("https://packagecloud.io/rabbitmq/rabbitmq-server/#{facts[:os]['name'].downcase}").
+              with_release(nil).
               with_repos('main')
           end
         else
@@ -82,10 +82,9 @@ describe 'rabbitmq' do
         describe 'it sets up an apt::source' do
           it {
             is_expected.to contain_apt__source('rabbitmq').with(
-              'location'    => 'http://www.rabbitmq.com/debian/',
-              'release'     => 'testing',
+              'location'    => "https://packagecloud.io/rabbitmq/rabbitmq-server/#{facts[:os]['name'].downcase}",
               'repos'       => 'main',
-              'key'         => '{"id"=>"0A9AF2115F4687BD29803A206B73A36E6026DFCA", "source"=>"https://www.rabbitmq.com/rabbitmq-release-signing-key.asc", "content"=>:undef}'
+              'key'         => '{"id"=>"418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB", "source"=>"https://packagecloud.io/gpg.key", "content"=>:undef}'
             )
           }
         end
@@ -97,10 +96,9 @@ describe 'rabbitmq' do
         describe 'it sets up an apt::source and pin' do
           it {
             is_expected.to contain_apt__source('rabbitmq').with(
-              'location'    => 'http://www.rabbitmq.com/debian/',
-              'release'     => 'testing',
+              'location'    => "https://packagecloud.io/rabbitmq/rabbitmq-server/#{facts[:os]['name'].downcase}",
               'repos'       => 'main',
-              'key'         => '{"id"=>"0A9AF2115F4687BD29803A206B73A36E6026DFCA", "source"=>"https://www.rabbitmq.com/rabbitmq-release-signing-key.asc", "content"=>:undef}'
+              'key'         => '{"id"=>"418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB", "source"=>"https://packagecloud.io/gpg.key", "content"=>:undef}'
             )
           }
 
@@ -108,7 +106,7 @@ describe 'rabbitmq' do
             is_expected.to contain_apt__pin('rabbitmq').with(
               'packages' => '*',
               'priority' => '700',
-              'origin'   => 'www.rabbitmq.com'
+              'origin'   => 'packagecloud.io'
             )
           }
         end


### PR DESCRIPTION
Could use some feedback on this, especially in terms of whether the packagecloud repo key itself needs to be configurable, and whether using the mit pgp server is the best way to get the key (it seems safer than grabbing it from the packagecloud site directly).

I couldn't find an easy way around doing variable interpolation in the repo source in the spec tests, but open to suggestions / examples of how to do it better.