### PR TITLE
Make ldap_user_dn_pattern optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -255,7 +255,7 @@ class rabbitmq(
   Boolean $stomp_ensure                          = $rabbitmq::params::stomp_ensure,
   Boolean $ldap_auth                             = $rabbitmq::params::ldap_auth,
   String $ldap_server                            = $rabbitmq::params::ldap_server,
-  String $ldap_user_dn_pattern                   = $rabbitmq::params::ldap_user_dn_pattern,
+  Optional[String] $ldap_user_dn_pattern         = $rabbitmq::params::ldap_user_dn_pattern,
   String $ldap_other_bind                        = $rabbitmq::params::ldap_other_bind,
   Boolean $ldap_use_ssl                          = $rabbitmq::params::ldap_use_ssl,
   $ldap_port                                     = $rabbitmq::params::ldap_port,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -120,7 +120,7 @@ class rabbitmq::params {
   $stomp_ssl_only              = false
   $ldap_auth                   = false
   $ldap_server                 = 'ldap'
-  $ldap_user_dn_pattern        = 'cn=username,ou=People,dc=example,dc=com'
+  $ldap_user_dn_pattern        = undef
   $ldap_other_bind             = 'anon'
   $ldap_use_ssl                = false
   $ldap_port                   = 389

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -530,6 +530,32 @@ describe 'rabbitmq' do
         end
       end
 
+      describe 'configuring ldap authentication' do
+        let :params do
+          { config_stomp: false,
+            ldap_auth: true,
+            ldap_server: 'ldap.example.com',
+            ldap_other_bind: 'as_user',
+            ldap_use_ssl: false,
+            ldap_port: 389,
+            ldap_log: true,
+            ldap_config_variables: { 'foo' => 'bar' } }
+        end
+
+        it { is_expected.to contain_rabbitmq_plugin('rabbitmq_auth_backend_ldap') }
+
+        it 'does not set user_dn_pattern when none is specified' do
+          verify_contents(catalogue, 'rabbitmq.config',
+                          ['[', '  {rabbit, [', '    {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_ldap]},', '  ]}',
+                           '  {rabbitmq_auth_backend_ldap, [', '    {other_bind, as_user},',
+                           '    {servers, ["ldap.example.com"]},',
+                           '    {use_ssl, false},',
+                           '    {port, 389},', '    {foo, bar},', '    {log, true}'])
+          content = catalogue.resource('file', 'rabbitmq.config').send(:parameters)[:content]
+          expect(content).not_to include 'user_dn_pattern'
+        end
+      end
+
       describe 'configuring auth_backends' do
         let :params do
           { auth_backends: ['{baz, foo}', 'bar'] }

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -152,7 +152,9 @@
   {rabbitmq_auth_backend_ldap, [
     {other_bind, <%= @ldap_other_bind %>},
     {servers, ["<%= @ldap_server %>"]},
+<% if @ldap_user_dn_pattern -%>
     {user_dn_pattern, "<%= @ldap_user_dn_pattern %>"},
+<%- end -%>
     {use_ssl, <%= @ldap_use_ssl %>},
     {port, <%= @ldap_port %>},
 <% if @ldap_config_variables -%>


### PR DESCRIPTION
This change makes ldap_user_dn_pattern optional.

Per the [docs](https://www.rabbitmq.com/ldap.html):

> If you set both dn_lookup_attribute and user_dn_pattern then the approaches are combined: the plugin fills out the template and then searches for the DN

Sometimes this behaviour isn't wanted and user_dn_pattern needs to be omitted.