### PR TITLE
BREAKING: Remove deprecated manage_repos parameter and disallow strings for integer parameters

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,7 +126,6 @@
 # @param ldap_log Set to true to log LDAP auth.
 # @param manage_python If enabled, on platforms that don't provide a Python 2 package by default, ensure that the python package is
 #  installed (for rabbitmqadmin). This will only apply if `admin_enable` and `service_manage` are set.
-# @param manage_repos Whether or not to manage package repositories.
 # @param management_hostname The hostname for the RabbitMQ management interface.
 # @param management_port The port for the RabbitMQ management interface.
 # @param management_ip_address Allows you to set the IP for management interface to bind to separately. Set to 127.0.0.1 to bind to
@@ -140,10 +139,6 @@
 #  RedHat OS family. Set to https://packagecloud.io/gpg.key by default. Note, that `key_content`, if specified, would override this
 #  parameter for Debian OS family.
 # @param package_name The name of the package to install.
-# @param package_provider What provider to use to install the package.
-# @param package_source Where should the package be installed from? On Debian- and Arch-based systems using the default package provider,
-#  this parameter is ignored and the package is installed from the rabbitmq repository, if enabled with manage_repo => true, or from the
-#  system repository otherwise. If you want to use dpkg as the package_provider, you must specify a local package_source.
 # @param port The RabbitMQ port.
 # @param repos_ensure Ensure that a repo with the official (and newer) RabbitMQ package is configured, along with its signing key.
 #  Defaults to false (use system packages). This does not ensure that soft dependencies (like EPEL on RHEL systems) are present.
@@ -183,111 +178,99 @@
 # @param tcp_keepalive Enable TCP connection keepalive for RabbitMQ service.
 # @param tcp_recbuf Corresponds to recbuf in RabbitMQ `tcp_listen_options`
 # @param tcp_sndbuf Integer, corresponds to sndbuf in RabbitMQ `tcp_listen_options`
-# @param version Sets the version to install. On Debian- and Arch-based operating systems, the version parameter is ignored and the latest
-#  version is installed from the rabbitmq repository, if enabled with manage_repo => true, or from the system repository otherwise.
 # @param wipe_db_on_cookie_change Boolean to determine if we should DESTROY AND DELETE the RabbitMQ database.
 # @param rabbitmq_user OS dependent, default defined in param.pp. The system user the rabbitmq daemon runs as.
 # @param rabbitmq_group OS dependent, default defined in param.pp. The system group the rabbitmq daemon runs as.
 # @param rabbitmq_home OS dependent. default defined in param.pp. The home directory of the rabbitmq deamon.
 class rabbitmq(
-  Boolean $admin_enable                          = $rabbitmq::params::admin_enable,
-  Enum['ram', 'disk', 'disc'] $cluster_node_type = $rabbitmq::params::cluster_node_type,
-  Array $cluster_nodes                           = $rabbitmq::params::cluster_nodes,
-  String $config                                 = $rabbitmq::params::config,
-  Boolean $config_cluster                        = $rabbitmq::params::config_cluster,
-  Stdlib::Absolutepath $config_path              = $rabbitmq::params::config_path,
-  Boolean $config_ranch                          = $rabbitmq::params::config_ranch,
-  Boolean $config_stomp                          = $rabbitmq::params::config_stomp,
-  Boolean $config_shovel                         = $rabbitmq::params::config_shovel,
-  Hash $config_shovel_statics                    = $rabbitmq::params::config_shovel_statics,
-  String $default_user                           = $rabbitmq::params::default_user,
-  String $default_pass                           = $rabbitmq::params::default_pass,
-  Boolean $delete_guest_user                     = $rabbitmq::params::delete_guest_user,
-  String $env_config                             = $rabbitmq::params::env_config,
-  Stdlib::Absolutepath $env_config_path          = $rabbitmq::params::env_config_path,
-  Optional[String] $erlang_cookie                = undef,
-  Optional[String] $interface                    = undef,
-  Optional[String] $management_ip_address        = undef,
-  $management_port                               = $rabbitmq::params::management_port,
-  Boolean $management_ssl                        = $rabbitmq::params::management_ssl,
-  Optional[String] $management_hostname          = undef,
-  Optional[String] $node_ip_address              = undef,
-  $package_apt_pin                               = $rabbitmq::params::package_apt_pin,
-  String $package_ensure                         = $rabbitmq::params::package_ensure,
-  String $package_gpg_key                        = $rabbitmq::params::package_gpg_key,
-  String $package_name                           = $rabbitmq::params::package_name,
-  Optional[String] $package_source               = undef,
-  Optional[String] $package_provider             = undef,
-  Boolean $repos_ensure                          = $rabbitmq::params::repos_ensure,
-  $manage_repos                                  = undef,
-  Boolean $manage_python                         = $rabbitmq::params::manage_python,
-  $rabbitmq_user                                 = $rabbitmq::params::rabbitmq_user,
-  $rabbitmq_group                                = $rabbitmq::params::rabbitmq_group,
-  $rabbitmq_home                                 = $rabbitmq::params::rabbitmq_home,
-  Integer $port                                  = $rabbitmq::params::port,
-  Boolean $tcp_keepalive                         = $rabbitmq::params::tcp_keepalive,
-  Integer $tcp_backlog                           = $rabbitmq::params::tcp_backlog,
-  Optional[Integer] $tcp_sndbuf                  = undef,
-  Optional[Integer] $tcp_recbuf                  = undef,
-  Optional[Integer] $heartbeat                   = undef,
-  Enum['running', 'stopped'] $service_ensure     = $rabbitmq::params::service_ensure,
-  Boolean $service_manage                        = $rabbitmq::params::service_manage,
-  String $service_name                           = $rabbitmq::params::service_name,
-  Boolean $ssl                                   = $rabbitmq::params::ssl,
-  Boolean $ssl_only                              = $rabbitmq::params::ssl_only,
-  Optional[String] $ssl_cacert                   = undef,
-  Optional[String] $ssl_cert                     = undef,
-  Optional[String] $ssl_key                      = undef,
-  Optional[Integer] $ssl_depth                   = undef,
-  Optional[String] $ssl_cert_password            = undef,
-  $ssl_port                                      = $rabbitmq::params::ssl_port,
-  Optional[String] $ssl_interface                = undef,
-  Integer $ssl_management_port                   = $rabbitmq::params::ssl_management_port,
-  Integer $ssl_stomp_port                                = $rabbitmq::params::ssl_stomp_port,
-  $ssl_verify                                    = $rabbitmq::params::ssl_verify,
-  $ssl_fail_if_no_peer_cert                      = $rabbitmq::params::ssl_fail_if_no_peer_cert,
-  Optional[Array] $ssl_versions                  = undef,
-  Boolean $ssl_secure_renegotiate                = $rabbitmq::params::ssl_secure_renegotiate,
-  Boolean $ssl_reuse_sessions                    = $rabbitmq::params::ssl_reuse_sessions,
-  Boolean $ssl_honor_cipher_order                = $rabbitmq::params::ssl_honor_cipher_order,
-  Optional[String] $ssl_dhfile                   = undef,
-  Array $ssl_ciphers                             = $rabbitmq::params::ssl_ciphers,
-  Boolean $stomp_ensure                          = $rabbitmq::params::stomp_ensure,
-  Boolean $ldap_auth                             = $rabbitmq::params::ldap_auth,
-  String $ldap_server                            = $rabbitmq::params::ldap_server,
-  Optional[String] $ldap_user_dn_pattern         = $rabbitmq::params::ldap_user_dn_pattern,
-  String $ldap_other_bind                        = $rabbitmq::params::ldap_other_bind,
-  Boolean $ldap_use_ssl                          = $rabbitmq::params::ldap_use_ssl,
-  $ldap_port                                     = $rabbitmq::params::ldap_port,
-  Boolean $ldap_log                              = $rabbitmq::params::ldap_log,
-  Hash $ldap_config_variables                    = $rabbitmq::params::ldap_config_variables,
-  Integer $stomp_port                            = $rabbitmq::params::stomp_port,
-  Boolean $stomp_ssl_only                        = $rabbitmq::params::stomp_ssl_only,
-  Optional[String] $version                      = undef,
-  Boolean $wipe_db_on_cookie_change              = $rabbitmq::params::wipe_db_on_cookie_change,
-  $cluster_partition_handling                    = $rabbitmq::params::cluster_partition_handling,
-  Variant[Integer, String] $file_limit           = $rabbitmq::params::file_limit,
-  Hash $environment_variables                    = $rabbitmq::params::environment_variables,
-  Hash $config_variables                         = $rabbitmq::params::config_variables,
-  Hash $config_kernel_variables                  = $rabbitmq::params::config_kernel_variables,
-  Hash $config_management_variables              = $rabbitmq::params::config_management_variables,
-  Hash $config_additional_variables              = $rabbitmq::params::config_additional_variables,
-  Optional[Array] $auth_backends                 = undef,
-  $key_content                                   = undef,
-  Optional[Integer] $collect_statistics_interval = undef,
-  Boolean $ipv6                                  = $rabbitmq::params::ipv6,
-  String $inetrc_config                          = $rabbitmq::params::inetrc_config,
-  Stdlib::Absolutepath $inetrc_config_path       = $rabbitmq::params::inetrc_config_path,
-  Boolean $ssl_erl_dist                          = $rabbitmq::params::ssl_erl_dist,
+  Boolean $admin_enable                                            = $rabbitmq::params::admin_enable,
+  Enum['ram', 'disk', 'disc'] $cluster_node_type                   = $rabbitmq::params::cluster_node_type,
+  Array $cluster_nodes                                             = $rabbitmq::params::cluster_nodes,
+  String $config                                                   = $rabbitmq::params::config,
+  Boolean $config_cluster                                          = $rabbitmq::params::config_cluster,
+  Stdlib::Absolutepath $config_path                                = $rabbitmq::params::config_path,
+  Boolean $config_ranch                                            = $rabbitmq::params::config_ranch,
+  Boolean $config_stomp                                            = $rabbitmq::params::config_stomp,
+  Boolean $config_shovel                                           = $rabbitmq::params::config_shovel,
+  Hash $config_shovel_statics                                      = $rabbitmq::params::config_shovel_statics,
+  String $default_user                                             = $rabbitmq::params::default_user,
+  String $default_pass                                             = $rabbitmq::params::default_pass,
+  Boolean $delete_guest_user                                       = $rabbitmq::params::delete_guest_user,
+  String $env_config                                               = $rabbitmq::params::env_config,
+  Stdlib::Absolutepath $env_config_path                            = $rabbitmq::params::env_config_path,
+  Optional[String] $erlang_cookie                                  = undef,
+  Optional[String] $interface                                      = undef,
+  Optional[String] $management_ip_address                          = undef,
+  Integer[1, 65535] $management_port                               = $rabbitmq::params::management_port,
+  Boolean $management_ssl                                          = $rabbitmq::params::management_ssl,
+  Optional[String] $management_hostname                            = undef,
+  Optional[String] $node_ip_address                                = undef,
+  Optional[Variant[Numeric, String]] $package_apt_pin              = undef,
+  String $package_ensure                                           = $rabbitmq::params::package_ensure,
+  String $package_gpg_key                                          = $rabbitmq::params::package_gpg_key,
+  String $package_name                                             = $rabbitmq::params::package_name,
+  Optional[String] $package_source                                 = undef,
+  Optional[String] $package_provider                               = undef,
+  Boolean $repos_ensure                                            = $rabbitmq::params::repos_ensure,
+  Boolean $manage_python                                           = $rabbitmq::params::manage_python,
+  String $rabbitmq_user                                            = $rabbitmq::params::rabbitmq_user,
+  String $rabbitmq_group                                           = $rabbitmq::params::rabbitmq_group,
+  Stdlib::Absolutepath $rabbitmq_home                              = $rabbitmq::params::rabbitmq_home,
+  Integer $port                                                    = $rabbitmq::params::port,
+  Boolean $tcp_keepalive                                           = $rabbitmq::params::tcp_keepalive,
+  Integer $tcp_backlog                                             = $rabbitmq::params::tcp_backlog,
+  Optional[Integer] $tcp_sndbuf                                    = undef,
+  Optional[Integer] $tcp_recbuf                                    = undef,
+  Optional[Integer] $heartbeat                                     = undef,
+  Enum['running', 'stopped'] $service_ensure                       = $rabbitmq::params::service_ensure,
+  Boolean $service_manage                                          = $rabbitmq::params::service_manage,
+  String $service_name                                             = $rabbitmq::params::service_name,
+  Boolean $ssl                                                     = $rabbitmq::params::ssl,
+  Boolean $ssl_only                                                = $rabbitmq::params::ssl_only,
+  Optional[Stdlib::Absolutepath] $ssl_cacert                       = undef,
+  Optional[Stdlib::Absolutepath] $ssl_cert                         = undef,
+  Optional[Stdlib::Absolutepath] $ssl_key                          = undef,
+  Optional[Integer] $ssl_depth                                     = undef,
+  Optional[String] $ssl_cert_password                              = undef,
+  Integer[1, 65535] $ssl_port                                      = $rabbitmq::params::ssl_port,
+  Optional[String] $ssl_interface                                  = undef,
+  Integer[1, 65535] $ssl_management_port                           = $rabbitmq::params::ssl_management_port,
+  Integer[1, 65535] $ssl_stomp_port                                = $rabbitmq::params::ssl_stomp_port,
+  Enum['verify_none','verify_peer'] $ssl_verify                    = $rabbitmq::params::ssl_verify,
+  Boolean $ssl_fail_if_no_peer_cert                                = $rabbitmq::params::ssl_fail_if_no_peer_cert,
+  Optional[Array] $ssl_versions                                    = undef,
+  Boolean $ssl_secure_renegotiate                                  = $rabbitmq::params::ssl_secure_renegotiate,
+  Boolean $ssl_reuse_sessions                                      = $rabbitmq::params::ssl_reuse_sessions,
+  Boolean $ssl_honor_cipher_order                                  = $rabbitmq::params::ssl_honor_cipher_order,
+  Optional[Stdlib::Absolutepath] $ssl_dhfile                       = undef,
+  Array $ssl_ciphers                                               = $rabbitmq::params::ssl_ciphers,
+  Boolean $stomp_ensure                                            = $rabbitmq::params::stomp_ensure,
+  Boolean $ldap_auth                                               = $rabbitmq::params::ldap_auth,
+  String $ldap_server                                              = $rabbitmq::params::ldap_server,
+  Optional[String] $ldap_user_dn_pattern                           = $rabbitmq::params::ldap_user_dn_pattern,
+  String $ldap_other_bind                                          = $rabbitmq::params::ldap_other_bind,
+  Boolean $ldap_use_ssl                                            = $rabbitmq::params::ldap_use_ssl,
+  Integer[1, 65535] $ldap_port                                     = $rabbitmq::params::ldap_port,
+  Boolean $ldap_log                                                = $rabbitmq::params::ldap_log,
+  Hash $ldap_config_variables                                      = $rabbitmq::params::ldap_config_variables,
+  Integer[1, 65535] $stomp_port                                    = $rabbitmq::params::stomp_port,
+  Boolean $stomp_ssl_only                                          = $rabbitmq::params::stomp_ssl_only,
+  Boolean $wipe_db_on_cookie_change                                = $rabbitmq::params::wipe_db_on_cookie_change,
+  String $cluster_partition_handling                               = $rabbitmq::params::cluster_partition_handling,
+  Variant[Integer[-1,], Enum['unlimited', 'infinity']] $file_limit = $rabbitmq::params::file_limit,
+  Hash $environment_variables                                      = $rabbitmq::params::environment_variables,
+  Hash $config_variables                                           = $rabbitmq::params::config_variables,
+  Hash $config_kernel_variables                                    = $rabbitmq::params::config_kernel_variables,
+  Hash $config_management_variables                                = $rabbitmq::params::config_management_variables,
+  Hash $config_additional_variables                                = $rabbitmq::params::config_additional_variables,
+  Optional[Array] $auth_backends                                   = undef,
+  Optional[String] $key_content                                    = undef,
+  Optional[Integer] $collect_statistics_interval                   = undef,
+  Boolean $ipv6                                                    = $rabbitmq::params::ipv6,
+  String $inetrc_config                                            = $rabbitmq::params::inetrc_config,
+  Stdlib::Absolutepath $inetrc_config_path                         = $rabbitmq::params::inetrc_config_path,
+  Boolean $ssl_erl_dist                                            = $rabbitmq::params::ssl_erl_dist,
 ) inherits rabbitmq::params {
-
-  # Validate install parameters.
-  validate_re($package_apt_pin, '^(|\d+)$')
-
-  # using sprintf for conversion to string, because "${file_limit}" doesn't
-  # pass lint, despite being nicer
-  validate_re(sprintf('%s', $file_limit),
-              '^(\d+|-1|unlimited|infinity)$', '$file_limit must be a positive integer, \'-1\', \'unlimited\', or \'infinity\'.')
 
   if $ssl_only and ! $ssl {
     fail('$ssl_only => true requires that $ssl => true')
@@ -301,22 +284,6 @@ class rabbitmq(
     unless $ssl {
       fail('$ssl_versions requires that $ssl => true')
     }
-  }
-
-  if $package_source != undef {
-    warning('$package_source is now deprecated. Please use yum installation or handle outside of this module.')
-  }
-
-  if $package_provider != undef {
-    warning('$package_provider is now deprecated. Please use yum installation or handle outside of this module.')
-  }
-
-  if $manage_repos != undef {
-    warning('$manage_repos is now deprecated. Please use $repos_ensure instead.')
-  }
-
-  if $version != undef {
-    warning('$version is now deprecated, and will not have any effect. If you need to pin to a particular version, use $package_ensure')
   }
 
   if $repos_ensure {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -80,7 +80,6 @@ class rabbitmq::params {
   $admin_enable                = true
   $management_port             = 15672
   $management_ssl              = true
-  $package_apt_pin             = ''
   $repos_ensure                = false
   $service_ensure              = 'running'
   $service_manage              = true
@@ -133,7 +132,7 @@ class rabbitmq::params {
   $config_kernel_variables     = {}
   $config_management_variables = {}
   $config_additional_variables = {}
-  $file_limit                  = '16384'
+  $file_limit                  = 16384
   $ipv6                        = false
   $inetrc_config               = 'rabbitmq/inetrc.erb'
   $inetrc_config_path          = '/etc/rabbitmq/inetrc'

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -2,13 +2,13 @@
 #   puppetlabs-apt
 #   puppetlabs-stdlib
 class rabbitmq::repo::apt(
-  $location     = 'https://packagecloud.io/rabbitmq/rabbitmq-server',
-  $repos        = 'main',
-  $include_src  = false,
-  $key          = '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',
-  $key_source   = $rabbitmq::package_gpg_key,
-  $key_content  = $rabbitmq::key_content,
-  $architecture = undef,
+  String $location               = 'https://packagecloud.io/rabbitmq/rabbitmq-server',
+  String $repos                  = 'main',
+  Boolean $include_src           = false,
+  String $key                    = '418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB',
+  String $key_source             = $rabbitmq::package_gpg_key,
+  Optional[String] $key_content  = $rabbitmq::key_content,
+  Optional[String] $architecture = undef,
   ) {
 
   $pin = $rabbitmq::package_apt_pin
@@ -32,8 +32,7 @@ class rabbitmq::repo::apt(
     architecture => $architecture,
   }
 
-  if $pin != '' {
-    validate_re($pin, '\d{1,4}')
+  if $pin {
     apt::pin { 'rabbitmq':
       packages => '*',
       priority => $pin,

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -112,7 +112,7 @@ describe 'rabbitmq' do
         end
       end
 
-      ['unlimited', 'infinity', '-1', '1234'].each do |value|
+      ['unlimited', 'infinity', -1, 1234].each do |value|
         context "with file_limit => '#{value}'" do
           let(:params) { { file_limit: value } }
 
@@ -150,12 +150,12 @@ describe 'rabbitmq' do
         end
       end
 
-      ['-42', 'foo'].each do |value|
+      [-42, '-42', 'foo', '42'].each do |value|
         context "with file_limit => '#{value}'" do
           let(:params) { { file_limit: value } }
 
           it 'does not compile' do
-            expect { catalogue }.to raise_error(Puppet::Error, %r{\$file_limit must be a positive integer, '-1', 'unlimited', or 'infinity'})
+            expect { catalogue }.to raise_error(Puppet::PreformattedError, %r{Error while evaluating a Resource Statement})
           end
         end
       end


### PR DESCRIPTION
I think this also gets rid of the remaining `validate_` calls.

for `package_apt_pin`, I have:
`Optional[Variant[Numeric, String]] $package_apt_pin`, which is a little looser than what was there before, but seems consistent to what the apt module itself allows? I could require it to be numeric instead if we think that's better.

for `file_limit`, I have:
`Variant[Integer[-1,], Enum['unlimited', 'infinity']] $file_limit = $rabbitmq::params::file_limit,`
which I think approximates the old behavior, except requiring integers to be numeric rather than strings.

Open to suggestions on how (maybe just do custom types instead, in a separate file) to avoid having this push the spacing so far out in the class params.