### PR TITLE
Fix 'puppet resource rabbitmq_binding' and add tests (#650)

### DIFF
--- a/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
@@ -3,17 +3,13 @@ require 'puppet'
 require 'digest'
 
 Puppet::Type.type(:rabbitmq_binding).provide(:rabbitmqadmin) do
-  if Puppet::PUPPETVERSION.to_f < 3
-    commands rabbitmqctl: 'rabbitmqctl'
-    commands rabbitmqadmin: '/usr/local/bin/rabbitmqadmin'
-  else
-    has_command(:rabbitmqctl, 'rabbitmqctl') do
-      environment HOME: '/tmp'
-    end
-    has_command(:rabbitmqadmin, '/usr/local/bin/rabbitmqadmin') do
-      environment HOME: '/tmp'
-    end
+  has_command(:rabbitmqctl, 'rabbitmqctl') do
+    environment HOME: '/tmp'
   end
+  has_command(:rabbitmqadmin, '/usr/local/bin/rabbitmqadmin') do
+    environment HOME: '/tmp'
+  end
+
   defaultfor feature: :posix
 
   # Without this, the composite namevar stuff doesn't work properly.

--- a/lib/puppet/type/rabbitmq_binding.rb
+++ b/lib/puppet/type/rabbitmq_binding.rb
@@ -178,8 +178,12 @@ DESC
   # Validate that we have both source and destination now that these are not
   # necessarily only coming from the resource title.
   validate do
-    unless self[:source] && self[:destination]
-      raise ArgumentError, 'Source and destination must both be defined.'
+    if !self[:source] && !defined? provider.source
+      raise ArgumentError, '`source` must be defined'
+    end
+
+    if !self[:destination] && !defined? provider.destination
+      raise ArgumentError, '`destination` must be defined'
     end
   end
 end

--- a/spec/acceptance/queue_spec.rb
+++ b/spec/acceptance/queue_spec.rb
@@ -159,6 +159,12 @@ describe 'rabbitmq binding:' do
       end
     end
     # rubocop:enable RSpec/MultipleExpectations
+
+    it 'puppet resource shows a binding' do
+      shell('puppet resource rabbitmq_binding') do |r|
+        expect(r.stdout).to match(%r{source\s+=>\s+'exchange1',})
+      end
+    end
   end
 
   context 'create binding and queue resources when using a non-default management port' do

--- a/spec/unit/puppet/type/rabbitmq_binding_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_binding_spec.rb
@@ -22,7 +22,7 @@ describe Puppet::Type.type(:rabbitmq_binding) do
         name: 'test binding',
         destination: 'foobar'
       )
-    end.to raise_error(Puppet::Error, %r{Source and destination must both be defined})
+    end.to raise_error(Puppet::Error, %r{`source` must be defined})
   end
   it 'errors when missing destination' do
     expect do
@@ -30,7 +30,7 @@ describe Puppet::Type.type(:rabbitmq_binding) do
         name: 'test binding',
         source: 'foobar'
       )
-    end.to raise_error(Puppet::Error, %r{Source and destination must both be defined})
+    end.to raise_error(Puppet::Error, %r{`destination` must be defined})
   end
   it 'accepts an binding destination_type' do
     binding[:destination_type] = :exchange


### PR DESCRIPTION
This should fix #650. It also
- Reformats the binding provider spec tests to be a little easier to read
- Adds a basic test for `puppet resource rabbitmq_binding` in the acceptance tests. This way, we should notice if a problem comes up with this command in the future.

Since we got feedback on how to test this in the type rather than in the create method in the provider, I can try to submit a separate PR to fix this for the rabbitmq_user resource.

Some of the other providers don't have instances implemented, so won't work with `puppet resource`; this is a separate issue, though refactoring them would be a good project for someone with the time on their hands 😉 