### PR TITLE
use correct datatype for $package_gpg_key

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -207,7 +207,7 @@ class rabbitmq(
   Optional[String] $node_ip_address                                = undef,
   Optional[Variant[Numeric, String]] $package_apt_pin              = undef,
   String $package_ensure                                           = $rabbitmq::params::package_ensure,
-  String $package_gpg_key                                          = $rabbitmq::params::package_gpg_key,
+  Optional[String] $package_gpg_key                                = $rabbitmq::params::package_gpg_key,
   String $package_name                                             = $rabbitmq::params::package_name,
   Optional[String] $package_source                                 = undef,
   Optional[String] $package_provider                               = undef,

--- a/manifests/repo/rhel.pp
+++ b/manifests/repo/rhel.pp
@@ -1,8 +1,8 @@
 # Class: rabbitmq::repo::rhel
 # Makes sure that the Packagecloud repo is installed
 class rabbitmq::repo::rhel(
-    $location       = "https://packagecloud.io/rabbitmq/rabbitmq-server/el/${facts['os'][release][major]}/\$basearch",
-    $key_source     = $rabbitmq::package_gpg_key,
+    $location          = "https://packagecloud.io/rabbitmq/rabbitmq-server/el/${facts['os'][release][major]}/\$basearch",
+    String $key_source = $rabbitmq::package_gpg_key,
   ) {
 
   Class['rabbitmq::repo::rhel'] -> Package<| title == 'rabbitmq-server' |>


### PR DESCRIPTION
They parameter $package_gpg_key is only defined if it is a RHEL box. The
setup fails on every other system, because it was a required param. This
PR changes the main class to also accept undef, and updates the RHEL
specific repo class to only accept Strings

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
