### PR TITLE
Remove `archive require` in rabbitmqadmin class

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -7,7 +7,6 @@ class rabbitmq::install::rabbitmqadmin {
       name   => $rabbitmq::rabbitmqadmin_package,
     }
   } else {
-    require archive
 
     $python_package = $rabbitmq::params::python_package
     # Some systems (e.g., Ubuntu 16.04) don't ship Python 2 by default

--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -6,8 +6,7 @@ class rabbitmq::install::rabbitmqadmin {
       ensure => 'present',
       name   => $rabbitmq::rabbitmqadmin_package,
     }
-  } else {
-    require archive
+  }
 
     $python_package = $rabbitmq::params::python_package
     # Some systems (e.g., Ubuntu 16.04) don't ship Python 2 by default

--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -6,7 +6,8 @@ class rabbitmq::install::rabbitmqadmin {
       ensure => 'present',
       name   => $rabbitmq::rabbitmqadmin_package,
     }
-  }
+  } else {
+    require archive
 
     $python_package = $rabbitmq::params::python_package
     # Some systems (e.g., Ubuntu 16.04) don't ship Python 2 by default


### PR DESCRIPTION
 due to the dependency of the module from `puppet-archive`, there is no need to make the require. Is also really hard to debug, because the puppet exception doesn't clearly refers to the module requirement (duplicate declaration)