### PR TITLE
Do not use defaultfor to choose the only existing provider

### DIFF
--- a/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:rabbitmq_binding).provide(:rabbitmqadmin) do
     environment HOME: '/tmp'
   end
 
-  confine :feature => :posix
+  confine feature: :posix
 
   # Without this, the composite namevar stuff doesn't work properly.
   mk_resource_methods

--- a/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:rabbitmq_binding).provide(:rabbitmqadmin) do
     environment HOME: '/tmp'
   end
 
-  defaultfor feature: :posix
+  confine :feature => :posix
 
   # Without this, the composite namevar stuff doesn't work properly.
   mk_resource_methods

--- a/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
+++ b/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
@@ -1,7 +1,7 @@
 require 'puppet'
 require 'set'
 Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
-  defaultfor feature: :posix
+  confine :feature => :posix
 
   def exists?
     # Hack to prevent the create method from being called.

--- a/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
+++ b/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
@@ -1,7 +1,7 @@
 require 'puppet'
 require 'set'
 Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
-  confine :feature => :posix
+  confine feature: :posix
 
   def exists?
     # Hack to prevent the create method from being called.

--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin, parent: Puppet::Pr
       environment HOME: '/tmp'
     end
   end
-  defaultfor feature: :posix
+  confine :feature => :posix
 
   def should_vhost
     if @should_vhost

--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin, parent: Puppet::Pr
       environment HOME: '/tmp'
     end
   end
-  confine :feature => :posix
+  confine feature: :posix
 
   def should_vhost
     if @should_vhost

--- a/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
@@ -3,7 +3,7 @@ require 'puppet/util/package'
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
 Puppet::Type.type(:rabbitmq_parameter).provide(:rabbitmqctl, parent: Puppet::Provider::Rabbitmqctl) do
-  defaultfor feature: :posix
+  confine :feature => :posix
 
   # cache parameters
   def self.parameters(name, vhost)

--- a/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
@@ -3,7 +3,7 @@ require 'puppet/util/package'
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
 Puppet::Type.type(:rabbitmq_parameter).provide(:rabbitmqctl, parent: Puppet::Provider::Rabbitmqctl) do
-  confine :feature => :posix
+  confine feature: :posix
 
   # cache parameters
   def self.parameters(name, vhost)

--- a/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
+++ b/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins, parent: Puppet::Pr
     end
   end
 
-  defaultfor feature: :posix
+  confine :feature => :posix
 
   def self.instances
     plugin_list = run_with_retries do

--- a/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
+++ b/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins, parent: Puppet::Pr
     end
   end
 
-  confine :feature => :posix
+  confine feature: :posix
 
   def self.instances
     plugin_list = run_with_retries do

--- a/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
@@ -3,7 +3,7 @@ require 'puppet/util/package'
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
 Puppet::Type.type(:rabbitmq_policy).provide(:rabbitmqctl, parent: Puppet::Provider::Rabbitmqctl) do
-  defaultfor feature: :posix
+  confine :feature => :posix
 
   # cache policies
   def self.policies(name, vhost)

--- a/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
@@ -3,7 +3,7 @@ require 'puppet/util/package'
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
 Puppet::Type.type(:rabbitmq_policy).provide(:rabbitmqctl, parent: Puppet::Provider::Rabbitmqctl) do
-  confine :feature => :posix
+  confine feature: :posix
 
   # cache policies
   def self.policies(name, vhost)

--- a/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:rabbitmq_queue).provide(:rabbitmqadmin) do
       environment HOME: '/tmp'
     end
   end
-  confine :feature => :posix
+  confine feature: :posix
 
   def should_vhost
     if @should_vhost

--- a/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:rabbitmq_queue).provide(:rabbitmqadmin) do
       environment HOME: '/tmp'
     end
   end
-  defaultfor feature: :posix
+  confine :feature => :posix
 
   def should_vhost
     if @should_vhost

--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:rabbitmq_user).provide(
     environment HOME: '/tmp'
   end
 
-  defaultfor feature: :posix
+  confine :feature => :posix
 
   def initialize(value = {})
     super(value)

--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:rabbitmq_user).provide(
     environment HOME: '/tmp'
   end
 
-  confine :feature => :posix
+  confine feature: :posix
 
   def initialize(value = {})
     super(value)

--- a/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl, parent: Pupp
     end
   end
 
-  confine :feature => :posix
+  confine feature: :posix
 
   # cache users permissions
   def self.users(name, vhost)

--- a/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl, parent: Pupp
     end
   end
 
-  defaultfor feature: :posix
+  confine :feature => :posix
 
   # cache users permissions
   def self.users(name, vhost)


### PR DESCRIPTION
It is sometimes useful to be able to noop (or change) a provider in
certain situations [1] (Think running a temporary container with puppet
tags to create proper config files). Currently, using defaultfor makes
overriding the current provider rabbitmqctl a very hard thing to do.

Let's switch to using the confine mechanism to make sure the provider
runs only on posix OSes while still allowing an operator to override it.

[1] https://github.com/openstack/puppet-tripleo/blob/master/lib/puppet/parser/functions/noop_resource.rb
