### PR TITLE
Add support for multiple LDAP servers

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -157,7 +157,7 @@
 # @param ldap_auth
 #   Set to true to enable LDAP auth.
 # @param ldap_server
-#   LDAP server to use for auth.
+#   LDAP server or servers to use for auth.
 # @param ldap_user_dn_pattern
 #   User DN pattern for LDAP auth.
 # @param ldap_other_bind
@@ -370,7 +370,7 @@ class rabbitmq (
   Array $ssl_ciphers                                                                               = [],
   Boolean $stomp_ensure                                                                            = false,
   Boolean $ldap_auth                                                                               = false,
-  String $ldap_server                                                                              = 'ldap',
+  Variant[String[1],Array[String[1]]] $ldap_server                                                 = 'ldap',
   Optional[String] $ldap_user_dn_pattern                                                           = undef,
   String $ldap_other_bind                                                                          = 'anon',
   Boolean $ldap_use_ssl                                                                            = false,

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -167,7 +167,11 @@ end
 % Configure the LDAP authentication plugin
   {rabbitmq_auth_backend_ldap, [
     {other_bind, <%= @ldap_other_bind %>},
+<% if @ldap_server.class == Array -%>
+    {servers, <%= @ldap_server %>},
+<% else -%>
     {servers, ["<%= @ldap_server %>"]},
+<% end -%>
 <% if @ldap_user_dn_pattern -%>
     {user_dn_pattern, "<%= @ldap_user_dn_pattern %>"},
 <%- end -%>


### PR DESCRIPTION
The RabbitMQ LDAP plug-in supports multiple servers being listed in the the "servers" field, but the puppet module currently only accepts a single String value.

My simple pull request allows an array of servers to be passed, which is then correctly formatted in the rabbitmq.confg template. I additionally attempt to detect an array that has already been flattened to a string, as happens if you configure the ldap_servers variable from hiera by way of sourcing an array variable that is already defined else where in puppet (rabbitmq::ldap_server: "%{ldap::servers}").

Tested and working with a string, an array, and a array flattened to a string.