### PR TITLE
Add archive_options parameter for Archive download of rabbitmqadmin

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -185,6 +185,7 @@
 # @param rabbitmq_group OS dependent, default defined in param.pp. The system group the rabbitmq daemon runs as.
 # @param rabbitmq_home OS dependent. default defined in param.pp. The home directory of the rabbitmq deamon.
 # @param $rabbitmqadmin_package OS dependent. default defined in param.pp. If undef: install rabbitmqadmin via archive, otherwise via package
+# @param $archive_options. default defined in param.pp.  Extra options to Archive resource to download rabbitmqadmin file
 class rabbitmq(
   Boolean $admin_enable                                            = $rabbitmq::params::admin_enable,
   Enum['ram', 'disk', 'disc'] $cluster_node_type                   = $rabbitmq::params::cluster_node_type,
@@ -276,6 +277,7 @@ class rabbitmq(
   Stdlib::Absolutepath $inetrc_config_path                         = $rabbitmq::params::inetrc_config_path,
   Boolean $ssl_erl_dist                                            = $rabbitmq::params::ssl_erl_dist,
   Optional[String] $rabbitmqadmin_package                          = $rabbitmq::params::rabbitmqadmin_package,
+  Array $archive_options                                           = $rabbitmq::params::archive_options,
 ) inherits rabbitmq::params {
 
   if $ssl_only and ! $ssl {

--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -28,6 +28,7 @@ class rabbitmq::install::rabbitmqadmin {
     $default_user = $rabbitmq::default_user
     $default_pass = $rabbitmq::default_pass
     $management_ip_address = $rabbitmq::management_ip_address
+    $archive_options = $rabbitmq::archive_options
 
     if !($management_ip_address) {
       # Pull from localhost if we don't have an explicit bind address
@@ -42,13 +43,14 @@ class rabbitmq::install::rabbitmqadmin {
     }
 
     archive { 'rabbitmqadmin':
-      path           => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
-      source         => "${protocol}://${sanitized_ip}:${management_port}/cli/rabbitmqadmin",
-      username       => $default_user,
-      password       => $default_pass,
-      allow_insecure => true,
-      cleanup        => false,
-      require        => [
+      path             => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
+      source           => "${protocol}://${sanitized_ip}:${management_port}/cli/rabbitmqadmin",
+      username         => $default_user,
+      password         => $default_pass,
+      allow_insecure   => true,
+      download_options => $archive_options,
+      cleanup          => false,
+      require          => [
         Class['rabbitmq::service'],
         Rabbitmq_plugin['rabbitmq_management']
       ],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -144,4 +144,5 @@ class rabbitmq::params {
   $ipv6                                = false
   $inetrc_config                       = 'rabbitmq/inetrc.erb'
   $inetrc_config_path                  = '/etc/rabbitmq/inetrc'
+  $archive_options                     = []
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -263,6 +263,22 @@ describe 'rabbitmq' do
             )
           end
         end
+        context 'with service_manage set to true and archive_options set' do
+          let(:params) do
+            {
+              admin_enable: true,
+              management_ip_address: '1.1.1.1',
+              archive_options: %w[fizz pop]
+            }
+          end
+
+          it 'we use the correct archive_options to rabbitmqadmin' do
+            is_expected.to contain_archive('rabbitmqadmin').with(
+              source: 'http://1.1.1.1:15672/cli/rabbitmqadmin',
+              download_options: %w[fizz pop]
+            )
+          end
+        end
         context 'with service_manage set to true and management port specified' do
           # note that the 2.x management port is 55672 not 15672
           let(:params) { { admin_enable: true, management_port: 55_672, management_ip_address: '1.1.1.1' } }


### PR DESCRIPTION
This adds a new parameter `archive_options`, allowing an array of options which can be passed to the archive module for downloading rabbitmqadmin.