### PR TITLE
Fix Debian 8 support: configure for systemd

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,6 @@ fixtures:
     "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
     "archive": "https://github.com/voxpupuli/puppet-archive.git"
     "erlang": "git://github.com/garethr/garethr-erlang.git"
+    "systemd": "https://github.com/camptocamp/puppet-systemd.git"
   symlinks:
     "rabbitmq": "#{source_dir}"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -194,22 +194,7 @@ class rabbitmq::config {
   }
 
   case $facts['os']['family'] {
-    'Archlinux': {
-      $has_systemd = true
-    }
     'Debian': {
-      case $facts['os']['name'] {
-        'Debian': {
-          $has_systemd = versioncmp($facts['os']['release']['major'], '8') >= 0
-        }
-        'Ubuntu': {
-          $has_systemd = versioncmp($facts['os']['release']['full'], '16.04') >= 0
-        }
-        default: {
-          $has_systemd = false
-        }
-      }
-
       file { '/etc/default/rabbitmq-server':
         ensure  => file,
         content => template('rabbitmq/default.erb'),
@@ -220,8 +205,6 @@ class rabbitmq::config {
       }
     }
     'RedHat': {
-      $has_systemd = versioncmp($facts['os']['release']['major'], '7') >= 0
-
       file { '/etc/security/limits.d/rabbitmq-server.conf':
         content => template('rabbitmq/limits.conf'),
         owner   => '0',
@@ -230,51 +213,14 @@ class rabbitmq::config {
         notify  => Class['Rabbitmq::Service'],
       }
     }
-    'Archlinux': {
-      file { '/etc/systemd/system/rabbitmq.service.d':
-        ensure                  => directory,
-        owner                   => '0',
-        group                   => '0',
-        mode                    => '0755',
-        selinux_ignore_defaults => true,
-      }
-      -> file { '/etc/systemd/system/rabbitmq.service.d/limits.conf':
-        content => template('rabbitmq/rabbitmq-server.service.d/limits.conf'),
-        owner   => '0',
-        group   => '0',
-        mode    => '0644',
-        notify  => Exec['rabbitmq-systemd-reload'],
-      }
-      exec { 'rabbitmq-systemd-reload':
-        command     => '/bin/systemctl daemon-reload',
-        notify      => Class['Rabbitmq::Service'],
-        refreshonly => true,
-      }
-    }
-    default: {
-      $has_systemd = false
-    }
+    default: { }
   }
 
-  if $has_systemd {
-    file { '/etc/systemd/system/rabbitmq-server.service.d':
-      ensure                  => directory,
-      owner                   => '0',
-      group                   => '0',
-      mode                    => '0755',
-      selinux_ignore_defaults => true,
-    }
-    -> file { '/etc/systemd/system/rabbitmq-server.service.d/limits.conf':
-      content => template('rabbitmq/rabbitmq-server.service.d/limits.conf'),
-      owner   => '0',
-      group   => '0',
-      mode    => '0644',
-      notify  => Exec['rabbitmq-systemd-reload'],
-    }
-    exec { 'rabbitmq-systemd-reload':
-      command     => '/bin/systemctl daemon-reload',
-      notify      => Class['Rabbitmq::Service'],
-      refreshonly => true,
+  if $::facts['systemd'] { # systemd fact provided by systemd module
+    systemd::service_limits { 'rabbitmq.service':
+      limits          => {'LimitNOFILE' => $file_limit},
+      # The service will be notified when config changes
+      restart_service => false,
     }
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -216,7 +216,7 @@ class rabbitmq::config {
     default: { }
   }
 
-  if $::facts['systemd'] { # systemd fact provided by systemd module
+  if $facts['systemd'] { # systemd fact provided by systemd module
     systemd::service_limits { 'rabbitmq.service':
       limits          => {'LimitNOFILE' => $file_limit},
       # The service will be notified when config changes

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -32,6 +32,10 @@ class rabbitmq::service(
       hasrestart => true,
       name       => $service_name,
     }
+
+    if $::facts['systemd'] {
+      Class['systemd::systemctl::daemon_reload'] -> Service['rabbitmq-server']
+    }
   }
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -33,7 +33,7 @@ class rabbitmq::service(
       name       => $service_name,
     }
 
-    if $::facts['systemd'] {
+    if $facts['systemd'] {
       Class['systemd::systemctl::daemon_reload'] -> Service['rabbitmq-server']
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -65,6 +65,10 @@
     {
       "name": "puppet/archive",
       "version_requirement": ">= 1.0.0 < 3.0.0"
+    },
+    {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "tags": [

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1438,6 +1438,13 @@ describe 'rabbitmq' do
         }
       end
 
+      context 'on systems with systemd', if: facts[:systemd] do
+        it do
+          is_expected.to contain_service('rabbitmq-server')
+            .that_requires('Class[systemd::systemctl::daemon_reload]')
+        end
+      end
+
       describe 'service with ensure stopped' do
         let :params do
           { service_ensure: 'stopped' }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -17,7 +17,20 @@ describe 'rabbitmq' do
 
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      let(:facts) { facts }
+      let(:facts) do
+        # Unfortunately still have to set this fact ourselves for supported
+        # systems as there is no facter run
+        systemd = (
+          (facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'].to_i >= 7) ||
+          (facts[:os]['family'] == 'Debian' && facts[:os]['name'] == 'Ubuntu' &&
+            facts[:os]['release']['full'] == '16.04') ||
+          (facts[:os]['family'] == 'Debian' && facts[:os]['name'] == 'Debian' &&
+            facts[:os]['release']['major'].to_i >= 8) ||
+          (facts[:os]['family'] == 'Archlinux')
+        )
+
+        facts.merge({:systemd => systemd})
+      end
 
       packagename = case facts[:osfamily]
                     when 'Archlinux'
@@ -25,14 +38,6 @@ describe 'rabbitmq' do
                     else
                       'rabbitmq-server'
                     end
-      has_systemd = (
-        (facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'].to_i >= 7) ||
-        (facts[:os]['family'] == 'Debian' && facts[:os]['name'] == 'Ubuntu' &&
-          facts[:os]['release']['full'] == '16.04') ||
-        (facts[:os]['family'] == 'Debian' && facts[:os]['name'] == 'Debian' &&
-          facts[:os]['release']['major'].to_i >= 8) ||
-        (facts[:os]['family'] == 'Archlinux')
-      )
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('rabbitmq::install') }
@@ -147,17 +152,14 @@ describe 'rabbitmq' do
             it { is_expected.not_to contain_file('/etc/default/rabbitmq-server') }
           end
 
-          if has_systemd
+          if facts[:systemd]
             it do
-              is_expected.to contain_file("/etc/systemd/system/#{packagename}.service.d/limits.conf").
-                with_owner('0').
-                with_group('0').
-                with_mode('0644').
-                that_notifies('Exec[rabbitmq-systemd-reload]').
-                with_content("[Service]\nLimitNOFILE=#{value}\n")
+              is_expected.to contain_systemd__service_limits('rabbitmq.service')
+                .with_limits({'LimitNOFILE' => value})
+                .with_restart_service(false)
             end
           else
-            it { is_expected.not_to contain_file('/etc/systemd/system/rabbitmq-server.service.d/limits.conf') }
+            it { is_expected.not_to contain_systemd__service_limits('rabbitmq.service') }
           end
         end
       end
@@ -172,32 +174,15 @@ describe 'rabbitmq' do
         end
       end
 
-      context 'on systems with systemd', if: has_systemd do
-        it {
-          is_expected.to contain_file("/etc/systemd/system/#{packagename}.service.d").with(
-            'ensure'                  => 'directory',
-            'owner'                   => '0',
-            'group'                   => '0',
-            'mode'                    => '0755',
-            'selinux_ignore_defaults' => true
-          )
-        }
-
-        it { is_expected.to contain_file("/etc/systemd/system/#{packagename}.service.d/limits.conf") }
-
-        it {
-          is_expected.to contain_exec('rabbitmq-systemd-reload').with(
-            command: '/bin/systemctl daemon-reload',
-            notify: 'Class[Rabbitmq::Service]',
-            refreshonly: true
-          )
-        }
+      context 'on systems with systemd', if: facts[:systemd] do
+        it do
+          is_expected.to contain_systemd__service_limits('rabbitmq.service')
+            .with_restart_service(false)
+        end
       end
 
-      context 'on systems without systemd', unless: has_systemd do
-        it { is_expected.not_to contain_file('/etc/systemd/system/rabbitmq-server.service.d') }
-        it { is_expected.not_to contain_file('/etc/systemd/system/rabbitmq-server.service.d/limits.conf') }
-        it { is_expected.not_to contain_exec('rabbitmq-systemd-reload') }
+      context 'on systems without systemd', unless: facts[:systemd] do
+        it { is_expected.not_to contain_systemd__service_limits('rabbitmq.service') }
       end
 
       context 'with admin_enable set to true' do

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -29,7 +29,7 @@ describe 'rabbitmq' do
           (facts[:os]['family'] == 'Archlinux')
         )
 
-        facts.merge({:systemd => systemd})
+        facts.merge(systemd: systemd)
       end
 
       packagename = case facts[:osfamily]
@@ -154,9 +154,9 @@ describe 'rabbitmq' do
 
           if facts[:systemd]
             it do
-              is_expected.to contain_systemd__service_limits('rabbitmq.service')
-                .with_limits({'LimitNOFILE' => value})
-                .with_restart_service(false)
+              is_expected.to contain_systemd__service_limits('rabbitmq.service').
+                with_limits('LimitNOFILE' => value).
+                with_restart_service(false)
             end
           else
             it { is_expected.not_to contain_systemd__service_limits('rabbitmq.service') }
@@ -176,8 +176,8 @@ describe 'rabbitmq' do
 
       context 'on systems with systemd', if: facts[:systemd] do
         it do
-          is_expected.to contain_systemd__service_limits('rabbitmq.service')
-            .with_restart_service(false)
+          is_expected.to contain_systemd__service_limits('rabbitmq.service').
+            with_restart_service(false)
         end
       end
 
@@ -1440,8 +1440,8 @@ describe 'rabbitmq' do
 
       context 'on systems with systemd', if: facts[:systemd] do
         it do
-          is_expected.to contain_service('rabbitmq-server')
-            .that_requires('Class[systemd::systemctl::daemon_reload]')
+          is_expected.to contain_service('rabbitmq-server').
+            that_requires('Class[systemd::systemctl::daemon_reload]')
         end
       end
 

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -27,7 +27,10 @@ describe 'rabbitmq' do
                     end
       has_systemd = (
         (facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'].to_i >= 7) ||
-        (facts[:os]['family'] == 'Debian' && facts[:os]['release']['full'] == '16.04') ||
+        (facts[:os]['family'] == 'Debian' && facts[:os]['name'] == 'Ubuntu' &&
+          facts[:os]['release']['full'] == '16.04') ||
+        (facts[:os]['family'] == 'Debian' && facts[:os]['name'] == 'Debian' &&
+          facts[:os]['release']['major'].to_i >= 8) ||
         (facts[:os]['family'] == 'Archlinux')
       )
 

--- a/templates/rabbitmq-server.service.d/limits.conf
+++ b/templates/rabbitmq-server.service.d/limits.conf
@@ -1,2 +1,0 @@
-[Service]
-LimitNOFILE=<%= @file_limit %>


### PR DESCRIPTION
Debian 8 is listed as a supported platform in `metadata.json`, but the logic to detect systemd configuration seems to expect only Ubuntu within the Debian family. This checks for vanilla Debian vs Ubuntu and applies systemd configuration as necessary.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
