### PR TITLE
Install package via title, not name (#684)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -298,9 +298,11 @@ class rabbitmq(
     case $facts['os']['family'] {
       'RedHat': {
         contain rabbitmq::repo::rhel
+        Class['rabbitmq::repo::rhel'] -> Class['rabbitmq::install']
       }
       'Debian': {
         contain rabbitmq::repo::apt
+        Class['rabbitmq::repo::apt'] -> Class['rabbitmq::install']
       }
       default: {
       }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,9 +6,8 @@ class rabbitmq::install {
   $package_name     = $rabbitmq::package_name
   $rabbitmq_group   = $rabbitmq::rabbitmq_group
 
-  package { 'rabbitmq-server':
+  package { $package_name:
     ensure => $package_ensure,
-    name   => $package_name,
     notify => Class['rabbitmq::service'],
   }
 
@@ -18,7 +17,7 @@ class rabbitmq::install {
       owner   => 'root',
       group   => $rabbitmq_group,
       mode    => '0775',
-      require => Package['rabbitmq-server'],
+      require => Package[$package_name],
     }
   }
 }

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -16,7 +16,6 @@ class rabbitmq::repo::apt(
   # ordering / ensure to get the last version of repository
   Class['rabbitmq::repo::apt']
   -> Class['apt::update']
-  -> Package<| title == 'rabbitmq-server' |>
 
   $osname = downcase($facts['os']['name'])
   apt::source { 'rabbitmq':

--- a/manifests/repo/rhel.pp
+++ b/manifests/repo/rhel.pp
@@ -5,8 +5,6 @@ class rabbitmq::repo::rhel(
     String $key_source = $rabbitmq::package_gpg_key,
   ) {
 
-  Class['rabbitmq::repo::rhel'] -> Package<| title == 'rabbitmq-server' |>
-
   yumrepo { 'rabbitmq':
     ensure   => present,
     name     => 'rabbitmq_rabbitmq-server',

--- a/metadata.json
+++ b/metadata.json
@@ -36,6 +36,12 @@
       ]
     },
     {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "11"
+      ]
+    },
+    {
       "operatingsystem": "FreeBSD"
     },
     {

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -36,7 +36,10 @@ describe 'rabbitmq' do
       it { is_expected.to contain_class('rabbitmq::config') }
       it { is_expected.to contain_class('rabbitmq::service') }
 
-      it { is_expected.to contain_package('rabbitmq-server').with_ensure('installed').with_name(packagename) }
+      it { is_expected.to contain_package(packagename).with_ensure('installed').with_name(packagename) }
+      if facts[:os]['family'] == 'Suse'
+        it { is_expected.to contain_package('rabbitmq-server-plugins') }
+      end
 
       context 'with default params' do
         it { is_expected.not_to contain_class('rabbitmq::repo::apt') }


### PR DESCRIPTION
This fixes an issue with the package resource accepting an array for `$title`, but not for the name parameter. I'm not sure why it was originally coded this way, but it seems to work with one more minor adjustment to the Arch tests (now that #685 is merged).

It adds support in metadata.json for SLES 11 (only) to test the additional package we expect there. I didn't add support for SLES 12 or openSUSE because I'm not 100% sure about the versioning, and >=12 has systemd, so there are some additional adjustments needed there that should probably be done by someone who can do more testing and who knows the versioning situation (for example, we may not want to just do systemd based on >=12 because of the weird numbering w/ openSUSE).

Additionally, it slightly simplifies the resource requirement for the package(s) and moves them to `init.pp`