### PR TITLE
Explicitly set LC_ALL to C (#689)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -135,7 +135,7 @@ class rabbitmq::params {
   $ldap_config_variables               = {}
   $wipe_db_on_cookie_change            = false
   $cluster_partition_handling          = 'ignore'
-  $environment_variables               = {}
+  $environment_variables               = { 'LC_ALL' => 'C' }
   $config_variables                    = {}
   $config_kernel_variables             = {}
   $config_management_variables         = {}


### PR DESCRIPTION
This attempts to work around issues experienced related to LC_ALL not being set in a fairly conservative way, by setting it explicitly in the `$environment_variables` hash.

Not sure if we should do a merge with user-passed in ones, or if there is a better way to format this, but seems like it could help avoid issues? I will see if this runs against Ubuntu 16 in acceptance tests, but would be great if someone could test that this works properly and doesn't cause unintended consequences.

I guess that the main way it could cause issues would be if someone had a resource with 8 bit characters in the name, and didn't explicitly set another env? We could default to UTF-8, but C seems more conservative.