### PR TITLE
Set default LC_ALL => en_US.UTF-8 (#671, #689)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -135,7 +135,7 @@ class rabbitmq::params {
   $ldap_config_variables               = {}
   $wipe_db_on_cookie_change            = false
   $cluster_partition_handling          = 'ignore'
-  $environment_variables               = { 'LC_ALL' => 'C' }
+  $environment_variables               = { 'LC_ALL' => 'en_US.UTF-8' }
   $config_variables                    = {}
   $config_kernel_variables             = {}
   $config_management_variables         = {}


### PR DESCRIPTION
#### Pull Request (PR) description
This sets a (somewhat US-centric) default of en_US.UTF-8 for LC_ALL in `$environment_variables`, to work around a warning given via Elixir in newer version of the RabbitMQ CLI tools, replacing #690.

#### This Pull Request (PR) fixes the following issues
    Fixes #671 
    Fixes #689 
