### PR TITLE
Ensure version fact does not throw an error for invalid match

### DIFF
--- a/lib/facter/rabbitmq_version.rb
+++ b/lib/facter/rabbitmq_version.rb
@@ -2,7 +2,7 @@ Facter.add(:rabbitmq_version) do
   setcode do
     if Facter::Util::Resolution.which('rabbitmqadmin')
       rabbitmq_version = Facter::Core::Execution.execute('rabbitmqadmin --version 2>&1')
-      %r{^rabbitmqadmin ([\w\.]+)}.match(rabbitmq_version)[1]
+      %r{^rabbitmqadmin ([\w\.]+)}.match(rabbitmq_version).to_a[1]
     end
   end
 end

--- a/spec/unit/facter/util/fact_rabbitmq_version_spec.rb
+++ b/spec/unit/facter/util/fact_rabbitmq_version_spec.rb
@@ -19,6 +19,15 @@ describe Facter::Util::Fact do
         expect(Facter.fact(:rabbitmq_version).value).to eq('3.6.0')
       end
     end
+    context 'with invalid value' do
+      before do
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqadmin') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with('rabbitmqadmin --version 2>&1') { 'rabbitmqadmin %%VSN%%' }
+      end
+      it do
+        expect(Facter.fact(:rabbitmq_version).value).to be_nil
+      end
+    end
     context 'rabbitmqadmin is not in path' do
       before do
         allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqadmin') { false }


### PR DESCRIPTION
#### Pull Request (PR) description
If the `rabbitmq_version` string returned from `rabbitmqadmin --version` contains invalid characters it throws an error because the array is nil. This will make a empty array out of it so it won't throw an error in that case.

#### This Pull Request (PR) fixes the following issues
Fixes #704
