### PR TITLE
Some boolean properties were being ignored when `false`.

### DIFF
--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -85,9 +85,9 @@ Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin, parent: Puppet::Pr
     arguments = resource[:arguments]
     arguments = {} if arguments.nil?
     cmd = ['declare', 'exchange', vhost_opt, "--user=#{resource[:user]}", "--password=#{resource[:password]}", "name=#{name}", "type=#{resource[:type]}"]
-    cmd << "internal=#{resource[:internal]}" if resource[:internal]
-    cmd << "durable=#{resource[:durable]}" if resource[:durable]
-    cmd << "auto_delete=#{resource[:auto_delete]}" if resource[:auto_delete]
+    cmd << "internal=#{resource[:internal]}"
+    cmd << "durable=#{resource[:durable]}"
+    cmd << "auto_delete=#{resource[:auto_delete]}"
     cmd += ["arguments=#{arguments.to_json}", '-c', '/etc/rabbitmq/rabbitmqadmin.conf']
     rabbitmqadmin(*cmd)
     @property_hash[:ensure] = :present


### PR DESCRIPTION
For instance, if you set `durable = false` it would not define `durable` which would default to `true`.