### PR TITLE
Add auto cluster configuration support

### DIFF
--- a/examples/cluster/join_cluster_and_change_name.pp
+++ b/examples/cluster/join_cluster_and_change_name.pp
@@ -1,0 +1,4 @@
+rabbitmq_cluster { 'test_cluster':
+  init_node => 'host1',
+}
+# This will join host2 to host1s cluster and set the cluster name to test_cluster

--- a/lib/facter/rabbitmq_clustername.rb
+++ b/lib/facter/rabbitmq_clustername.rb
@@ -1,0 +1,8 @@
+Facter.add(:rabbitmq_clustername) do
+  setcode do
+    if Facter::Util::Resolution.which('rabbitmqctl')
+      rabbitmq_clustername = Facter::Core::Execution.execute('rabbitmqctl cluster_status 2>&1')
+      %r{^ {cluster_name,<<"(.*)">>},}.match(rabbitmq_clustername)[1]
+    end
+  end
+end

--- a/lib/puppet/provider/rabbitmq_cluster/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_cluster/rabbitmqctl.rb
@@ -1,0 +1,38 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
+Puppet::Type.type(:rabbitmq_cluster).provide(
+  :rabbitmqctl,
+  parent: Puppet::Provider::Rabbitmqctl
+) do
+  has_command(:rabbitmqctl, 'rabbitmqctl') do
+    environment HOME: '/tmp'
+  end
+
+  confine feature: :posix
+
+  def exists?
+    cluster_status = rabbitmqctl('-q', 'cluster_status')
+    cluster_name = %r{^ {cluster_name,<<"(.*)">>},}.match(cluster_status)[1]
+    return true if cluster_name == @resource[:name].to_s
+  end
+
+  def create
+    storage_type = @resource[:node_disc_type].to_s
+    node_name = Facter.value(:fqdn)
+    init_node = @resource[:init_node].to_s.split('@')[1] unless @resource[:init_node].nil?
+    if node_name == init_node
+      cluster_status = rabbitmqctl('-q', 'cluster_status')
+      cluster_name = %r{^ {cluster_name,<<"(.*)">>},}.match(cluster_status)[1]
+      rabbitmqctl('set_cluster_name', @resource[:name]) unless cluster_name == resource[:name].to_s
+    else
+      rabbitmqctl('stop_app')
+      rabbitmqctl('join_cluster', @resource[:init_node].to_s, "--#{storage_type}")
+      rabbitmqctl('start_app')
+    end
+  end
+
+  def destroy
+    rabbitmqctl('stop_app')
+    rabbitmqctl('reset')
+    rabbitmqctl('start_app')
+  end
+end

--- a/lib/puppet/type/rabbitmq_cluster.rb
+++ b/lib/puppet/type/rabbitmq_cluster.rb
@@ -1,0 +1,50 @@
+Puppet::Type.newtype(:rabbitmq_cluster) do
+  desc <<-DESC
+Native type for managing rabbitmq cluster
+
+@example Configure a cluster, rabbit_cluster
+ rabbitmq_cluster { 'rabbit_cluster':
+   init_node      => 'host1'
+ }
+
+@example Optional parameter tags will set further rabbitmq tags like monitoring, policymaker, etc.
+ To set the cluster name use cluster_name.
+ rabbitmq_cluster { 'rabbit_cluster':
+   init_node      => 'host1',
+   node_disc_type => 'ram',
+ }
+DESC
+
+  ensurable do
+    defaultto(:present)
+    newvalue(:present) do
+      provider.create
+    end
+    newvalue(:absent) do
+      provider.destroy
+    end
+  end
+
+  autorequire(:service) { 'rabbitmq-server' }
+
+  newparam(:name, namevar: true) do
+    desc 'The cluster name'
+  end
+
+  newparam(:init_node) do
+    desc 'Name of which cluster node to join.'
+    validate do |value|
+      resource.validate_init_node(value)
+    end
+  end
+
+  newparam(:node_disc_type) do
+    desc 'Storage type of node, default disc.'
+    newvalues(%r{disc|ram})
+    defaultto('disc')
+  end
+
+  def validate_init_node(value)
+    raise ArgumentError, 'init_node must be defined' if value.empty?
+  end
+end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -90,6 +90,7 @@ class rabbitmq::params {
   $service_ensure                      = 'running'
   $service_manage                      = true
   #config
+  $cluster                             = {}
   $cluster_node_type                   = 'disc'
   $cluster_nodes                       = []
   $config                              = 'rabbitmq/rabbitmq.config.erb'

--- a/spec/acceptance/clustering_spec.rb
+++ b/spec/acceptance/clustering_spec.rb
@@ -5,9 +5,11 @@ describe 'rabbitmq clustering' do
     it 'runs successfully' do
       pp = <<-EOS
       class { 'rabbitmq':
+        cluster                  => { 'rabbit_cluster' => { 'init_node' => $facts['fqdn'], 'node_disc_type' => 'ram' } },
         config_cluster           => true,
         cluster_nodes            => ['rabbit1', 'rabbit2'],
         cluster_node_type        => 'ram',
+        environment_variables    => { 'RABBITMQ_USE_LONGNAME' => true },
         erlang_cookie            => 'TESTCOOKIE',
         wipe_db_on_cookie_change => false,
       }
@@ -28,9 +30,11 @@ describe 'rabbitmq clustering' do
     it 'runs successfully' do
       pp = <<-EOS
       class { 'rabbitmq':
+        cluster                  => { 'rabbit_cluster' => { 'init_node' => $facts['fqdn'], 'node_disc_type' => 'ram' } },
         config_cluster           => true,
         cluster_nodes            => ['rabbit1', 'rabbit2'],
         cluster_node_type        => 'ram',
+        environment_variables    => { 'RABBITMQ_USE_LONGNAME' => true },
         erlang_cookie            => 'TESTCOOKIE',
         wipe_db_on_cookie_change => true,
       }
@@ -54,6 +58,19 @@ describe 'rabbitmq clustering' do
     describe file('/var/lib/rabbitmq/.erlang.cookie') do
       it { is_expected.to be_file }
       it { is_expected.to contain 'TESTCOOKIE' }
+    end
+
+    describe 'rabbitmq_cluster' do
+      context 'cluster_name => rabbit_cluster' do
+        # rubocop:disable RSpec/MultipleExpectations
+        it 'cluster has name' do
+          shell('rabbitmqctl cluster_status -q') do |r|
+            expect(r.stdout).to match(%r{^ {cluster_name,<<"rabbit_cluster">>},})
+            expect(r.exit_code).to be_zero
+          end
+          # rubocop:enable RSpec/MultipleExpectations
+        end
+      end
     end
   end
 end

--- a/spec/unit/facter/util/fact_rabbitmq_clustername_spec.rb
+++ b/spec/unit/facter/util/fact_rabbitmq_clustername_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+end
+
+describe Facter::Util::Fact do
+  before { Facter.clear }
+
+  describe 'rabbitmq_clustername' do
+    context 'with value' do
+      before do
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqctl') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with('rabbitmqctl cluster_status 2>&1') { ' {cluster_name,<<"monty">>},' }
+      end
+      it do
+        expect(Facter.fact(:rabbitmq_clustername).value).to eq('monty')
+      end
+    end
+
+    context 'with dashes in hostname' do
+      before do
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqctl') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with('rabbitmqctl cluster_status 2>&1') { ' {cluster_name,<<"monty@rabbit-1">>},' }
+      end
+      it do
+        expect(Facter.fact(:rabbitmq_clustername).value).to eq('monty@rabbit-1')
+      end
+    end
+
+    context 'with dashes in clustername/hostname' do
+      before do
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqctl') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with('rabbitmqctl cluster_status 2>&1') { ' {cluster_name,<<"monty-python@rabbit-1">>},' }
+      end
+      it do
+        expect(Facter.fact(:rabbitmq_clustername).value).to eq('monty-python@rabbit-1')
+      end
+    end
+
+    context 'with quotes around node name' do
+      before do
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqctl') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with('rabbitmqctl cluster_status 2>&1') { ' {cluster_name,<<"\'monty@rabbit-1\'">>},' }
+      end
+      it do
+        expect(Facter.fact(:rabbitmq_clustername).value).to eq('\'monty@rabbit-1\'')
+      end
+    end
+
+    context 'rabbitmq is not running' do
+      before do
+        error_string = <<-EOS
+Status of node 'monty@rabbit-1' ...
+Error: unable to connect to node 'monty@rabbit-1': nodedown
+
+DIAGNOSTICS
+===========
+
+attempted to contact: ['monty@rabbit-1']
+
+monty@rabbit-1:
+  * connected to epmd (port 4369) on centos-7-x64
+  * epmd reports: node 'rabbit' not running at all
+                  no other nodes on centos-7-x64
+  * suggestion: start the node
+
+current node details:
+- node name: 'rabbitmq-cli-73@centos-7-x64'
+- home dir: /var/lib/rabbitmq
+- cookie hash: 6WdP0nl6d3HYqA5vTKMkIg==
+
+        EOS
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqctl') { true }
+        allow(Facter::Core::Execution).to receive(:execute).with('rabbitmqctl cluster_status 2>&1') { error_string }
+      end
+      it do
+        expect(Facter.fact(:rabbitmq_clustername).value).to be_nil
+      end
+    end
+
+    context 'rabbitmqctl is not in path' do
+      before do
+        allow(Facter::Util::Resolution).to receive(:which).with('rabbitmqctl') { false }
+      end
+      it do
+        expect(Facter.fact(:rabbitmq_clustername).value).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/provider/rabbitmq_cluster/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_cluster/rabbitmqctl_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:rabbitmq_cluster).provider(:rabbitmqctl)
+describe provider_class do
+  let(:resource) do
+    Puppet::Type::Rabbitmq_cluster.new(
+      name: 'test_cluster',
+      init_node: 'host1'
+    )
+  end
+  let(:provider) { provider_class.new(resource) }
+
+  describe '#exists?' do
+    it {
+      provider.expects(:rabbitmqctl).with('-q', 'cluster_status').returns(
+        ' {cluster_name,<<"test_cluster">>},}'
+      )
+      expect(provider.exists?).to be true
+    }
+  end
+
+  describe '#create on every other node' do
+    it 'joins a cluster or changes the cluster name' do
+      provider.expects(:rabbitmqctl).with('stop_app')
+      provider.expects(:rabbitmqctl).with('join_cluster', 'host1', '--disc')
+      provider.expects(:rabbitmqctl).with('start_app')
+      provider.create
+    end
+  end
+
+  describe '#destroy' do
+    it 'remove cluster setup' do
+      provider.expects(:rabbitmqctl).with('stop_app')
+      provider.expects(:rabbitmqctl).with('reset')
+      provider.expects(:rabbitmqctl).with('start_app')
+      provider.destroy
+    end
+  end
+end

--- a/spec/unit/puppet/type/rabbitmq_cluster_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_cluster_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+describe Puppet::Type.type(:rabbitmq_cluster) do
+  let(:rabbitmq_cluster) do
+    Puppet::Type.type(:rabbitmq_cluster).new(name: 'test_cluster')
+  end
+
+  it 'accepts a cluster name' do
+    rabbitmq_cluster[:name] = 'test_cluster'
+    expect(rabbitmq_cluster[:name]).to eq('test_cluster')
+  end
+  it 'requires a name' do
+    expect do
+      Puppet::Type.type(:rabbitmq_cluster).new({})
+    end.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+  it 'check if init_node set to host1' do
+    rabbitmq_cluster[:init_node] = 'host1'
+    expect(rabbitmq_cluster[:init_node]).to eq('host1')
+  end
+  it 'try to set node_disc_type to ram' do
+    rabbitmq_cluster[:node_disc_type] = 'ram'
+    expect(rabbitmq_cluster[:node_disc_type]).to eq('ram')
+  end
+  it 'node_disc_type not set should default to disc' do
+    rabbitmq_cluster[:name] = 'test_cluster'
+    expect(rabbitmq_cluster[:node_disc_type]).to eq('disc')
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds two things:
1. A fact for the cluster name of a rabbitmq cluster.
2. New resource rabbitmq_cluster{} which can be used to join nodes to a cluster and manage rabbitmq_cluster name.

#### This Pull Request (PR) fixes the following issues
Fixes #130 
