### PR TITLE
Set lower limit for puppet-archive to 2.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -65,7 +65,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 1.0.0 < 4.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
#### Pull Request (PR) description
Require puppet-archive >=2.0.0 so that `download_options` should be present.

#### This Pull Request (PR) fixes the following issues

Fixes #706 