### PR TITLE
Add docs for config_ranch parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ class { 'rabbitmq':
 }
 ```
 
+For RabbitMQ versions < 3.6.0 (which don't use Ranch), you will need to
+manually set `config_ranch` to `false`.
+
 ### Environment Variables
 To use RabbitMQ Environment Variables, use the parameters `environment_variables` e.g.:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,6 +92,7 @@
 # @param config_cluster Enable or disable clustering support.
 # @param config_kernel_variables Hash of Erlang kernel configuration variables to set (see [Variables Configurable in rabbitmq.config](#variables-configurable-in-rabbitmq.config)).
 # @param config_path The path to write the RabbitMQ configuration file to.
+# @param config_ranch When true, suppress config directives needed for older (<3.6) RabbitMQ versions.
 # @param config_management_variables Hash of configuration variables for the [Management Plugin](https://www.rabbitmq.com/management.html).
 # @param config_stomp Enable or disable stomp.
 # @param config_shovel Enable or disable shovel.


### PR DESCRIPTION
#### Pull Request (PR) description
This adds a note in the README, and adds missing Puppet strings docs for `config_ranch` in the main manifest.

See #618 and #621 for more details.

#### This Pull Request (PR) fixes the following issues
    Fixes #719
