### PR TITLE
Fix service name in systemd service limits config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -217,7 +217,7 @@ class rabbitmq::config {
   }
 
   if $facts['systemd'] { # systemd fact provided by systemd module
-    systemd::service_limits { 'rabbitmq.service':
+    systemd::service_limits { "${service_name}.service":
       limits          => {'LimitNOFILE' => $file_limit},
       # The service will be notified when config changes
       restart_service => false,

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -21,19 +21,19 @@ describe 'rabbitmq' do
         facts
       end
 
-      packagename = case facts[:osfamily]
-                    when 'Archlinux'
-                      'rabbitmq'
-                    else
-                      'rabbitmq-server'
-                    end
+      name = case facts[:osfamily]
+             when 'Archlinux', 'OpenBSD', 'FreeBSD'
+               'rabbitmq'
+             else
+               'rabbitmq-server'
+             end
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('rabbitmq::install') }
       it { is_expected.to contain_class('rabbitmq::config') }
       it { is_expected.to contain_class('rabbitmq::service') }
 
-      it { is_expected.to contain_package(packagename).with_ensure('installed').with_name(packagename) }
+      it { is_expected.to contain_package(name).with_ensure('installed').with_name(name) }
       if facts[:os]['family'] == 'Suse'
         it { is_expected.to contain_package('rabbitmq-server-plugins') }
       end
@@ -143,12 +143,12 @@ describe 'rabbitmq' do
 
           if facts[:systemd]
             it do
-              is_expected.to contain_systemd__service_limits('rabbitmq.service').
+              is_expected.to contain_systemd__service_limits("#{name}.service").
                 with_limits('LimitNOFILE' => value).
                 with_restart_service(false)
             end
           else
-            it { is_expected.not_to contain_systemd__service_limits('rabbitmq.service') }
+            it { is_expected.not_to contain_systemd__service_limits("#{name}.service") }
           end
         end
       end
@@ -165,13 +165,13 @@ describe 'rabbitmq' do
 
       context 'on systems with systemd', if: facts[:systemd] do
         it do
-          is_expected.to contain_systemd__service_limits('rabbitmq.service').
+          is_expected.to contain_systemd__service_limits("#{name}.service").
             with_restart_service(false)
         end
       end
 
       context 'on systems without systemd', unless: facts[:systemd] do
-        it { is_expected.not_to contain_systemd__service_limits('rabbitmq.service') }
+        it { is_expected.not_to contain_systemd__service_limits("#{name}.service") }
       end
 
       context 'with admin_enable set to true' do
@@ -1422,7 +1422,8 @@ describe 'rabbitmq' do
             'ensure'     => 'running',
             'enable'     => 'true',
             'hasstatus'  => 'true',
-            'hasrestart' => 'true'
+            'hasrestart' => 'true',
+            'name'       => name
           )
         }
       end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->
As pointed out in [this comment](
https://github.com/voxpupuli/puppet-rabbitmq/pull/683#discussion_r216639952), and as I'm finding out in practice now, the override/limits file can be created for the wrong systemd unit name, `rabbitmq.service` instead of `rabbitmq-server.service`.

This is a bug in the 8.3.0 release since #715 which was based on my (broken) code in #683.

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
I haven't created an issue. Can if needed.