### PR TITLE
Add service_restart option to prevent automatic service reload

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -158,7 +158,6 @@ class rabbitmq::config {
     owner   => '0',
     group   => $rabbitmq_group,
     mode    => '0640',
-    notify  => Class['rabbitmq::service'],
   }
 
   file { 'rabbitmq-env.config':
@@ -168,7 +167,6 @@ class rabbitmq::config {
     owner   => '0',
     group   => $rabbitmq_group,
     mode    => '0640',
-    notify  => Class['rabbitmq::service'],
   }
 
   file { 'rabbitmq-inetrc':
@@ -178,7 +176,6 @@ class rabbitmq::config {
     owner   => '0',
     group   => $rabbitmq_group,
     mode    => '0640',
-    notify  => Class['rabbitmq::service'],
   }
 
   if $admin_enable {
@@ -201,7 +198,6 @@ class rabbitmq::config {
         mode    => '0644',
         owner   => '0',
         group   => '0',
-        notify  => Class['rabbitmq::service'],
       }
     }
     'RedHat': {
@@ -210,7 +206,6 @@ class rabbitmq::config {
         owner   => '0',
         group   => '0',
         mode    => '0644',
-        notify  => Class['Rabbitmq::Service'],
       }
     }
     default: { }
@@ -235,7 +230,6 @@ class rabbitmq::config {
       rabbitmq_home  => $rabbitmq_home,
       service_name   => $service_name,
       before         => File['rabbitmq.config'],
-      notify         => Class['rabbitmq::service'],
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,6 +146,7 @@
 # @param service_ensure The state of the service.
 # @param service_manage Determines if the service is managed.
 # @param service_name The name of the service to manage.
+# @param $service_restart. Default defined in param.pp. Whether to resetart the service on config change.
 # @param ssl Configures the service for using SSL.
 #  port => UNSET
 # @param ssl_cacert CA cert path to use for SSL.
@@ -281,6 +282,7 @@ class rabbitmq(
   Optional[String] $rabbitmqadmin_package                                                          = $rabbitmq::params::rabbitmqadmin_package,
   Array $archive_options                                                                           = $rabbitmq::params::archive_options,
   Array $loopback_users                                                                            = $rabbitmq::params::loopback_users,
+  Boolean $service_restart                                                                         = $rabbitmq::params::service_restart,
 ) inherits rabbitmq::params {
 
   if $ssl_only and ! $ssl {
@@ -360,9 +362,13 @@ class rabbitmq(
     }
   }
 
+  if ($service_restart) {
+    Class['rabbitmq::config'] ~> Class['rabbitmq::service']
+  }
+
   Class['rabbitmq::install']
   -> Class['rabbitmq::config']
-  ~> Class['rabbitmq::service']
+  -> Class['rabbitmq::service']
   -> Class['rabbitmq::management']
 
   # Make sure the various providers have their requirements in place.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -146,4 +146,5 @@ class rabbitmq::params {
   $inetrc_config_path                  = '/etc/rabbitmq/inetrc'
   $archive_options                     = []
   $loopback_users                      = ['guest']
+  $service_restart                     = true
 }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -30,7 +30,7 @@ describe 'rabbitmq' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('rabbitmq::install') }
-      it { is_expected.to contain_class('rabbitmq::config') }
+      it { is_expected.to contain_class('rabbitmq::config').that_notifies('Class[rabbitmq::service]') }
       it { is_expected.to contain_class('rabbitmq::service') }
 
       it { is_expected.to contain_package(name).with_ensure('installed').with_name(name) }
@@ -43,6 +43,12 @@ describe 'rabbitmq' do
         it { is_expected.not_to contain_apt__source('rabbitmq') }
         it { is_expected.not_to contain_class('rabbitmq::repo::rhel') }
         it { is_expected.not_to contain_yumrepo('rabbitmq') }
+      end
+
+      context 'with service_restart => false' do
+        let(:params) { { service_restart: false } }
+
+        it { is_expected.not_to contain_class('rabbitmq::config').that_notifies('Class[rabbitmq::service]') }
       end
 
       context 'with repos_ensure => true' do


### PR DESCRIPTION
#### Pull Request (PR) description

Make the restart optional since it is dangerous to do an uncontrolled rolling restart. We lost many messages this way. 
It has been many years since I have written any puppet code so I don't have high confidence that I did this entirely correct. It is based off of how the kafka module prevents rolling restarts https://github.com/voxpupuli/puppet-kafka/search?q=service_restart&unscoped_q=service_restart

#### This Pull Request (PR) fixes the following issues

Fixes #727 
