### PR TITLE
Allow Array values in rabbitmq_parameter

### DIFF
--- a/lib/puppet/type/rabbitmq_parameter.rb
+++ b/lib/puppet/type/rabbitmq_parameter.rb
@@ -71,7 +71,7 @@ DESC
   def validate_value(value)
     raise ArgumentError, 'Invalid value' unless [Hash].include?(value.class)
     value.each do |_k, v|
-      unless [String, TrueClass, FalseClass].include?(v.class)
+      unless [String, TrueClass, FalseClass, Array].include?(v.class)
         raise ArgumentError, 'Invalid value'
       end
     end

--- a/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
@@ -61,7 +61,7 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
 
   it 'does not accept an array for definition' do
     expect do
-      parameter[:value] = { 'message-ttl' => %w[999 100] }
+      parameter[:value] = { 'message-ttl' => Object.new }
     end.to raise_error(Puppet::Error, %r{Invalid value})
   end
 


### PR DESCRIPTION
Array (lists) are allowed values to use with rabbitmqctl.

For example: src-uri when setting up a shovel.