### PR TITLE
Fix runs with RabbitMQ >= 3.7.9

### DIFF
--- a/lib/puppet/provider/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmqctl.rb
@@ -8,6 +8,14 @@ class Puppet::Provider::Rabbitmqctl < Puppet::Provider
     version[1] if version
   end
 
+  # rabbitmqctl version 3.7.9 introduced --no-table-headers flag
+  # which began causing problems for parsing. This resolves the issue
+  # by automatically adding the required flag in the event the RabbitMQ
+  # version is at or above 3.7.9
+  if Puppet::Util::Package.versioncmp(rabbitmq_version, '3.7.9') >= 0
+    commands rabbitmqctl: 'rabbitmqctl --no-table-headers'
+  end
+
   # Retry the given code block 'count' retries or until the
   # command suceeeds. Use 'step' delay between retries.
   # Limit each query time by 'timeout'.


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
RabbitMQ >= 3.7.9 `rabbitmqctl` exec produces table/column header output which does not parse cleanly with the current way that the module is setup. This implements a version check, which will update the command in the event a version with the `--no-table-headers` flag should be used.

(I apologize for the commit mess, I took the easy way out in creating a PR with the changes I made in a forked repo that was required for my day job. I hope that squash merging is possible here 😄 )

#### This Pull Request (PR) fixes the following issues
Fixes #740 
