### PR TITLE
Fix runs with RabbitMQ >= 3.7.9

### DIFF
--- a/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
@@ -25,14 +25,14 @@ Puppet::Type.type(:rabbitmq_binding).provide(:rabbitmqadmin) do
 
   def self.all_vhosts
     vhosts = []
-    rabbitmqctl('list_vhosts', '-q').split(%r{\n}).map do |vhost|
+    rabbitmqctl("#{@format_table_headers} -q list_vhosts".split(' ')).split(%r{\n}).map do |vhost|
       vhosts.push(vhost)
     end
     vhosts
   end
 
   def self.all_bindings(vhost)
-    rabbitmqctl('list_bindings', '-q', '-p', vhost, 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments').split(%r{\n})
+    rabbitmqctl("#{@format_table_headers} list_bindings -q -p #{vhost} source_name destination_name destination_kind routing_key arguments".split(' ')).split(%r{\n})
   end
 
   def self.instances

--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -23,12 +23,12 @@ Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin, parent: Puppet::Pr
   end
 
   def self.all_vhosts
-    run_with_retries { rabbitmqctl('-q', 'list_vhosts') }.split(%r{\n})
+    run_with_retries { rabbitmqctl("#{@format_table_headers} -q list_vhosts".split(' ')) }.split(%r{\n})
   end
 
   def self.all_exchanges(vhost)
     exchange_list = run_with_retries do
-      rabbitmqctl('-q', 'list_exchanges', '-p', vhost, 'name', 'type', 'internal', 'durable', 'auto_delete', 'arguments')
+      rabbitmqctl("#{@format_table_headers} -q list_exchanges -p #{vhost} name type internal durable auto_delete arguments".split(' '))
     end
     exchange_list.split(%r{\n}).reject { |exchange| exchange =~ %r{^federation:} }
   end

--- a/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:rabbitmq_parameter).provide(:rabbitmqctl, parent: Puppet::Pro
     unless @parameters[vhost]
       @parameters[vhost] = {}
       parameter_list = run_with_retries do
-        rabbitmqctl('list_parameters', '-q', '-p', vhost)
+        rabbitmqctl("#{@format_table_headers} list_parameters -q -p #{vhost}".split(' '))
       end
       parameter_list.split(%r{\n}).each do |line|
         raise Puppet::Error, "cannot parse line from list_parameter:#{line}" unless line =~ %r{^(\S+)\s+(\S+)\s+(\S+)$}

--- a/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:rabbitmq_policy).provide(:rabbitmqctl, parent: Puppet::Provid
     unless @policies[vhost]
       @policies[vhost] = {}
       policy_list = run_with_retries do
-        rabbitmqctl('list_policies', '-q', '-p', vhost)
+        rabbitmqctl("#{@format_table_headers} list_policies -q -p #{vhost}".split(' '))
       end
 
       # rabbitmq<3.2 does not support the applyto field

--- a/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
@@ -23,11 +23,11 @@ Puppet::Type.type(:rabbitmq_queue).provide(:rabbitmqadmin) do
   end
 
   def self.all_vhosts
-    rabbitmqctl('list_vhosts', '-q').split(%r{\n})
+    rabbitmqctl("#{@format_table_headers} -q list_vhosts".split(' ')).split(%r{\n})
   end
 
   def self.all_queues(vhost)
-    rabbitmqctl('list_queues', '-q', '-p', vhost, 'name', 'durable', 'auto_delete', 'arguments').split(%r{\n})
+    rabbitmqctl("#{@format_table_headers} list_queues -q -p #{vhost} name durable auto_delete arguments".split(" ")).split(%r{\n})
   end
 
   def self.instances

--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:rabbitmq_user).provide(
 
   def self.instances
     user_list = run_with_retries do
-      rabbitmqctl('-q', 'list_users')
+      rabbitmqctl("#{@format_table_headers} -q list_users".split(' '))
     end
 
     user_list.split(%r{\n}).map do |line|

--- a/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl, parent: Pupp
     unless @users[name]
       @users[name] = {}
       user_permission_list = run_with_retries do
-        rabbitmqctl('-q', 'list_user_permissions', name)
+        rabbitmqctl("#{@format_table_headers} -q list_user_permissions #{name}".split(' '))
       end
       user_permission_list.split(%r{\n}).each do |line|
         line = strip_backslashes(line)

--- a/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl, parent: Puppet::Provide
 
   def self.instances
     vhost_list = run_with_retries do
-      rabbitmqctl('-q', 'list_vhosts')
+      rabbitmqctl("#{@format_table_headers} -q list_vhosts".split(' '))
     end
 
     vhost_list.split(%r{\n}).map do |line|
@@ -28,6 +28,6 @@ Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl, parent: Puppet::Provide
   end
 
   def exists?
-    self.class.run_with_retries { rabbitmqctl('-q', 'list_vhosts') }.split(%r{\n}).include? resource[:name]
+    self.class.run_with_retries { rabbitmqctl("#{@format_table_headers} -q list_vhosts".split(' ')) }.split(%r{\n}).include? resource[:name]
   end
 end

--- a/lib/puppet/provider/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmqctl.rb
@@ -5,7 +5,14 @@ class Puppet::Provider::Rabbitmqctl < Puppet::Provider
   def self.rabbitmq_version
     output = rabbitmqctl('-q', 'status')
     version = output.match(%r{\{rabbit,"RabbitMQ","([\d\.]+)"\}})
-    version[1] if version
+    if version
+      if Puppet::Util::Package.versioncmp(version[1], '3.7.9') >= 0
+        @format_table_headers = '--no-table-headers'
+      else
+        @format_table_headers = nil
+      end
+      version[1]
+    end
   end
 
   # Retry the given code block 'count' retries or until the


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
RabbitMQ >= 3.7.9 `rabbitmqctl` exec produces table/column header output which does not parse cleanly with the current way that the module is setup. This implements a version check, which will update the command in the event a version with the `--no-table-headers` flag should be used.

(I apologize for the commit mess, I took the easy way out in creating a PR with the changes I made in a forked repo that was required for my day job. I hope that squash merging is possible here 😄 )

#### This Pull Request (PR) fixes the following issues
Fixes #740 
