### PR TITLE
RabbitMQ 3.7.9+ list compatibility and provider cleanup

### DIFF
--- a/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
@@ -19,14 +19,14 @@ Puppet::Type.type(:rabbitmq_binding).provide(:rabbitmqadmin, parent: Puppet::Pro
 
   def self.all_vhosts
     vhosts = []
-    rabbitmqctl('list_vhosts', '-q').split(%r{\n}).map do |vhost|
+    rabbitmqctl_list('vhosts').split(%r{\n}).map do |vhost|
       vhosts.push(vhost)
     end
     vhosts
   end
 
   def self.all_bindings(vhost)
-    rabbitmqctl('list_bindings', '-q', '-p', vhost, 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments').split(%r{\n})
+    rabbitmqctl_list('bindings', '-p', vhost, 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments').split(%r{\n})
   end
 
   def self.instances

--- a/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
@@ -2,14 +2,8 @@ require 'json'
 require 'puppet'
 require 'digest'
 
-Puppet::Type.type(:rabbitmq_binding).provide(:rabbitmqadmin) do
-  has_command(:rabbitmqctl, 'rabbitmqctl') do
-    environment HOME: '/tmp'
-  end
-  has_command(:rabbitmqadmin, '/usr/local/bin/rabbitmqadmin') do
-    environment HOME: '/tmp'
-  end
-
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
+Puppet::Type.type(:rabbitmq_binding).provide(:rabbitmqadmin, parent: Puppet::Provider::RabbitmqCli) do
   confine feature: :posix
 
   # Without this, the composite namevar stuff doesn't work properly.

--- a/lib/puppet/provider/rabbitmq_cli.rb
+++ b/lib/puppet/provider/rabbitmq_cli.rb
@@ -18,9 +18,11 @@ class Puppet::Provider::RabbitmqCli < Puppet::Provider
   home_tmp_command :rabbitmqadmin, '/usr/local/bin/rabbitmqadmin'
 
   def self.rabbitmq_version
+    return @rabbitmq_version if defined? @rabbitmq_version
+
     output = rabbitmqctl('-q', 'status')
     version = output.match(%r{\{rabbit,"RabbitMQ","([\d\.]+)"\}})
-    version[1] if version
+    @rabbitmq_version = version[1] if version
   end
 
   def self.rabbitmqctl_list(resource, *opts)

--- a/lib/puppet/provider/rabbitmq_cli.rb
+++ b/lib/puppet/provider/rabbitmq_cli.rb
@@ -58,10 +58,9 @@ class Puppet::Provider::RabbitmqCli < Puppet::Provider
   end
 
   def self.define_instance_method(name)
-    unless method_defined?(name)
-      define_method(name) do |*args, &block|
-        self.class.send(name, *args, &block)
-      end
+    return if method_defined?(name)
+    define_method(name) do |*args, &block|
+      self.class.send(name, *args, &block)
     end
   end
   private_class_method :define_instance_method

--- a/lib/puppet/provider/rabbitmq_cli.rb
+++ b/lib/puppet/provider/rabbitmq_cli.rb
@@ -54,4 +54,16 @@ class Puppet::Provider::RabbitmqCli < Puppet::Provider
     end
     raise Puppet::Error, "Command is still failing after #{count * step} seconds expired!"
   end
+
+  def self.define_instance_method(name)
+    unless method_defined?(name)
+      define_method(name) do |*args, &block|
+        self.class.send(name, *args, &block)
+      end
+    end
+  end
+  private_class_method :define_instance_method
+
+  define_instance_method :rabbitmqctl_list
+  define_instance_method :run_with_retries
 end

--- a/lib/puppet/provider/rabbitmq_cli.rb
+++ b/lib/puppet/provider/rabbitmq_cli.rb
@@ -23,6 +23,16 @@ class Puppet::Provider::RabbitmqCli < Puppet::Provider
     version[1] if version
   end
 
+  def self.rabbitmqctl_list(resource, *opts)
+    list_opts =
+      if Puppet::Util::Package.versioncmp(rabbitmq_version, '3.7.9') >= 0
+        ['-q', '--no-table-headers']
+      else
+        ['-q']
+      end
+    rabbitmqctl("list_#{resource}", *list_opts, *opts)
+  end
+
   # Retry the given code block 'count' retries or until the
   # command suceeeds. Use 'step' delay between retries.
   # Limit each query time by 'timeout'.

--- a/lib/puppet/provider/rabbitmq_cli.rb
+++ b/lib/puppet/provider/rabbitmq_cli.rb
@@ -1,6 +1,21 @@
-class Puppet::Provider::Rabbitmqctl < Puppet::Provider
+class Puppet::Provider::RabbitmqCli < Puppet::Provider
   initvars
-  commands rabbitmqctl: 'rabbitmqctl'
+
+  def self.rabbitmq_command(name, binary)
+    path = Puppet::Util.which(binary) || "/usr/lib/rabbitmq/bin/#{binary}"
+    home_tmp_command name, path
+  end
+
+  def self.home_tmp_command(name, path)
+    has_command name, path do
+      environment HOME: '/tmp'
+    end
+  end
+
+  rabbitmq_command :rabbitmqctl, 'rabbitmqctl'
+  rabbitmq_command :rabbitmqplugins, 'rabbitmq-plugins'
+
+  home_tmp_command :rabbitmqadmin, '/usr/local/bin/rabbitmqadmin'
 
   def self.rabbitmq_version
     output = rabbitmqctl('-q', 'status')

--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -12,12 +12,12 @@ Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin, parent: Puppet::Pr
   end
 
   def self.all_vhosts
-    run_with_retries { rabbitmqctl('-q', 'list_vhosts') }.split(%r{\n})
+    run_with_retries { rabbitmqctl_list('vhosts') }.split(%r{\n})
   end
 
   def self.all_exchanges(vhost)
     exchange_list = run_with_retries do
-      rabbitmqctl('-q', 'list_exchanges', '-p', vhost, 'name', 'type', 'internal', 'durable', 'auto_delete', 'arguments')
+      rabbitmqctl_list('exchanges', '-p', vhost, 'name', 'type', 'internal', 'durable', 'auto_delete', 'arguments')
     end
     exchange_list.split(%r{\n}).reject { |exchange| exchange =~ %r{^federation:} }
   end

--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -1,17 +1,6 @@
 require 'puppet'
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
-Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin, parent: Puppet::Provider::Rabbitmqctl) do
-  if Puppet::PUPPETVERSION.to_f < 3
-    commands rabbitmqctl: 'rabbitmqctl'
-    commands rabbitmqadmin: '/usr/local/bin/rabbitmqadmin'
-  else
-    has_command(:rabbitmqctl, 'rabbitmqctl') do
-      environment HOME: '/tmp'
-    end
-    has_command(:rabbitmqadmin, '/usr/local/bin/rabbitmqadmin') do
-      environment HOME: '/tmp'
-    end
-  end
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
+Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin, parent: Puppet::Provider::RabbitmqCli) do
   confine feature: :posix
 
   def should_vhost

--- a/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:rabbitmq_parameter).provide(:rabbitmqctl, parent: Puppet::Pro
     unless @parameters[vhost]
       @parameters[vhost] = {}
       parameter_list = run_with_retries do
-        rabbitmqctl('list_parameters', '-q', '-p', vhost)
+        rabbitmqctl_list('parameters', '-p', vhost)
       end
       parameter_list.split(%r{\n}).each do |line|
         raise Puppet::Error, "cannot parse line from list_parameter:#{line}" unless line =~ %r{^(\S+)\s+(\S+)\s+(\S+)$}

--- a/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
@@ -1,8 +1,8 @@
 require 'json'
 require 'puppet/util/package'
 
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
-Puppet::Type.type(:rabbitmq_parameter).provide(:rabbitmqctl, parent: Puppet::Provider::Rabbitmqctl) do
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
+Puppet::Type.type(:rabbitmq_parameter).provide(:rabbitmqctl, parent: Puppet::Provider::RabbitmqCli) do
   confine feature: :posix
 
   # cache parameters

--- a/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
+++ b/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
@@ -26,6 +26,6 @@ Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins, parent: Puppet::Pr
   end
 
   def exists?
-    self.class.run_with_retries { rabbitmqplugins('list', '-E', '-m') }.split(%r{\n}).include? resource[:name]
+    run_with_retries { rabbitmqplugins('list', '-E', '-m') }.split(%r{\n}).include? resource[:name]
   end
 end

--- a/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
+++ b/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
@@ -1,16 +1,5 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
-Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins, parent: Puppet::Provider::Rabbitmqctl) do
-  # Prefer rabbitmq-plugins if it's in $PATH, but fall back to /usr/lib/rabbitmq/bin
-  if Puppet::Util.which('rabbitmq-plugins')
-    has_command(:rabbitmqplugins, 'rabbitmq-plugins') do
-      environment HOME: '/tmp'
-    end
-  else
-    has_command(:rabbitmqplugins, '/usr/lib/rabbitmq/bin/rabbitmq-plugins') do
-      environment HOME: '/tmp'
-    end
-  end
-
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
+Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins, parent: Puppet::Provider::RabbitmqCli) do
   confine feature: :posix
 
   def self.instances

--- a/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:rabbitmq_policy).provide(:rabbitmqctl, parent: Puppet::Provid
     unless @policies[vhost]
       @policies[vhost] = {}
       policy_list = run_with_retries do
-        rabbitmqctl('list_policies', '-q', '-p', vhost)
+        rabbitmqctl_list('policies', '-p', vhost)
       end
 
       # rabbitmq<3.2 does not support the applyto field

--- a/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
@@ -1,8 +1,8 @@
 require 'json'
 require 'puppet/util/package'
 
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
-Puppet::Type.type(:rabbitmq_policy).provide(:rabbitmqctl, parent: Puppet::Provider::Rabbitmqctl) do
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
+Puppet::Type.type(:rabbitmq_policy).provide(:rabbitmqctl, parent: Puppet::Provider::RabbitmqCli) do
   confine feature: :posix
 
   # cache policies

--- a/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
@@ -14,11 +14,11 @@ Puppet::Type.type(:rabbitmq_queue).provide(:rabbitmqadmin, parent: Puppet::Provi
   end
 
   def self.all_vhosts
-    rabbitmqctl('list_vhosts', '-q').split(%r{\n})
+    rabbitmqctl_list('vhosts').split(%r{\n})
   end
 
   def self.all_queues(vhost)
-    rabbitmqctl('list_queues', '-q', '-p', vhost, 'name', 'durable', 'auto_delete', 'arguments').split(%r{\n})
+    rabbitmqctl_list('queues', '-p', vhost, 'name', 'durable', 'auto_delete', 'arguments').split(%r{\n})
   end
 
   def self.instances

--- a/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
@@ -1,17 +1,8 @@
 require 'json'
 require 'puppet'
-Puppet::Type.type(:rabbitmq_queue).provide(:rabbitmqadmin) do
-  if Puppet::PUPPETVERSION.to_f < 3
-    commands rabbitmqctl: 'rabbitmqctl'
-    commands rabbitmqadmin: '/usr/local/bin/rabbitmqadmin'
-  else
-    has_command(:rabbitmqctl, 'rabbitmqctl') do
-      environment HOME: '/tmp'
-    end
-    has_command(:rabbitmqadmin, '/usr/local/bin/rabbitmqadmin') do
-      environment HOME: '/tmp'
-    end
-  end
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
+Puppet::Type.type(:rabbitmq_queue).provide(:rabbitmqadmin, parent: Puppet::Provider::RabbitmqCli) do
   confine feature: :posix
 
   def should_vhost

--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:rabbitmq_user).provide(
 
   def self.instances
     user_list = run_with_retries do
-      rabbitmqctl('-q', 'list_users')
+      rabbitmqctl_list('users')
     end
 
     user_list.split(%r{\n}).map do |line|

--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -1,12 +1,8 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
 Puppet::Type.type(:rabbitmq_user).provide(
   :rabbitmqctl,
-  parent: Puppet::Provider::Rabbitmqctl
+  parent: Puppet::Provider::RabbitmqCli
 ) do
-  has_command(:rabbitmqctl, 'rabbitmqctl') do
-    environment HOME: '/tmp'
-  end
-
   confine feature: :posix
 
   def initialize(value = {})

--- a/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
@@ -1,13 +1,5 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
-Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl, parent: Puppet::Provider::Rabbitmqctl) do
-  if Puppet::PUPPETVERSION.to_f < 3
-    commands rabbitmqctl: 'rabbitmqctl'
-  else
-    has_command(:rabbitmqctl, 'rabbitmqctl') do
-      environment HOME: '/tmp'
-    end
-  end
-
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
+Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl, parent: Puppet::Provider::RabbitmqCli) do
   confine feature: :posix
 
   # cache users permissions

--- a/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl, parent: Pupp
     unless @users[name]
       @users[name] = {}
       user_permission_list = run_with_retries do
-        rabbitmqctl('-q', 'list_user_permissions', name)
+        rabbitmqctl_list('user_permissions', name)
       end
       user_permission_list.split(%r{\n}).each do |line|
         line = strip_backslashes(line)

--- a/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
@@ -1,12 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmqctl'))
-Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl, parent: Puppet::Provider::Rabbitmqctl) do
-  if Puppet::PUPPETVERSION.to_f < 3
-    commands rabbitmqctl: 'rabbitmqctl'
-  else
-    has_command(:rabbitmqctl, 'rabbitmqctl') do
-      environment HOME: '/tmp'
-    end
-  end
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
+Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl, parent: Puppet::Provider::RabbitmqCli) do
+  confine feature: :posix
 
   def self.instances
     vhost_list = run_with_retries do

--- a/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl, parent: Puppet::Provide
 
   def self.instances
     vhost_list = run_with_retries do
-      rabbitmqctl('-q', 'list_vhosts')
+      rabbitmqctl_list('vhosts')
     end
 
     vhost_list.split(%r{\n}).map do |line|
@@ -22,6 +22,6 @@ Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl, parent: Puppet::Provide
   end
 
   def exists?
-    self.class.run_with_retries { rabbitmqctl('-q', 'list_vhosts') }.split(%r{\n}).include? resource[:name]
+    self.class.run_with_retries { self.class.rabbitmqctl_list('vhosts') }.split(%r{\n}).include? resource[:name]
   end
 end

--- a/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
@@ -22,6 +22,6 @@ Puppet::Type.type(:rabbitmq_vhost).provide(:rabbitmqctl, parent: Puppet::Provide
   end
 
   def exists?
-    self.class.run_with_retries { self.class.rabbitmqctl_list('vhosts') }.split(%r{\n}).include? resource[:name]
+    run_with_retries { rabbitmqctl_list('vhosts') }.split(%r{\n}).include? resource[:name]
   end
 end

--- a/lib/puppet/type/rabbitmq_binding.rb
+++ b/lib/puppet/type/rabbitmq_binding.rb
@@ -178,11 +178,11 @@ DESC
   # Validate that we have both source and destination now that these are not
   # necessarily only coming from the resource title.
   validate do
-    if !self[:source] && !defined? provider.source
+    if !self[:source] && provider.source == :absent
       raise ArgumentError, '`source` must be defined'
     end
 
-    if !self[:destination] && !defined? provider.destination
+    if !self[:destination] && provider.destination == :absent
       raise ArgumentError, '`destination` must be defined'
     end
   end

--- a/spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb
@@ -15,11 +15,11 @@ describe provider_class do
   # rubocop:disable RSpec/MultipleExpectations
   describe '#instances' do
     it 'returns instances' do
-      provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
+      provider_class.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
 /
 EOT
-      provider_class.expects(:rabbitmqctl).with(
-        'list_bindings', '-q', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments'
+      provider_class.expects(:rabbitmqctl_list).with(
+        'bindings', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments'
       ).returns <<-EOT
 exchange\tdst_queue\tqueue\t*\t[]
 EOT
@@ -45,11 +45,11 @@ EOT
 
     # rubocop:disable RSpec/MultipleExpectations
     it 'returns multiple instances' do
-      provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
+      provider_class.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
 /
 EOT
-      provider_class.expects(:rabbitmqctl).with(
-        'list_bindings', '-q', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments'
+      provider_class.expects(:rabbitmqctl_list).with(
+        'bindings', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments'
       ).returns <<-EOT
 exchange\tdst_queue\tqueue\trouting_one\t[]
 exchange\tdst_queue\tqueue\trouting_two\t[]
@@ -94,11 +94,11 @@ EOT
     end
 
     it 'exists' do
-      provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
+      provider_class.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
 /
 EOT
-      provider_class.expects(:rabbitmqctl).with(
-        'list_bindings', '-q', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments'
+      provider_class.expects(:rabbitmqctl_list).with(
+        'bindings', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments'
       ).returns <<-EOT
 exchange\tdst_queue\tqueue\t*\t[]
 EOT
@@ -108,11 +108,11 @@ EOT
 
     it 'matches' do
       # Test resource to match against
-      provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
+      provider_class.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
 /
 EOT
-      provider_class.expects(:rabbitmqctl).with(
-        'list_bindings', '-q', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments'
+      provider_class.expects(:rabbitmqctl_list).with(
+        'bindings', '-p', '/', 'source_name', 'destination_name', 'destination_kind', 'routing_key', 'arguments'
       ).returns <<-EOT
 exchange\tdst_queue\tqueue\t*\t[]
 EOT

--- a/spec/unit/puppet/provider/rabbitmq_cli_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_cli_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+require 'puppet/provider/rabbitmq_cli'
+
+provider_class = Puppet::Provider::RabbitmqCli
+describe provider_class do
+  before do
+    # Clear the cached version before each test
+    provider_class.remove_instance_variable(:@rabbitmq_version) \
+      if provider_class.instance_variable_defined?(:@rabbitmq_version)
+  end
+
+  it 'gets the RabbitMQ version' do
+    provider_class.expects(:rabbitmqctl).with('-q', 'status').returns '{rabbit,"RabbitMQ","3.1.5"}'
+    expect(provider_class.rabbitmq_version).to eq('3.1.5')
+  end
+
+  it 'caches the RabbitMQ version' do
+    provider_class.expects(:rabbitmqctl).with('-q', 'status').returns '{rabbit,"RabbitMQ","3.7.10"}'
+    v1 = provider_class.rabbitmq_version
+
+    # No second expects for rabbitmqctl as it shouldn't be called again
+    expect(provider_class.rabbitmq_version).to eq(v1)
+  end
+
+  it 'uses correct list options with RabbitMQ < 3.7.9' do
+    provider_class.expects(:rabbitmq_version).returns '3.7.8'
+    provider_class.expects(:rabbitmqctl).with('list_vhost', '-q').returns ''
+    expect(provider_class.rabbitmqctl_list('vhost')).to eq('')
+  end
+
+  it 'uses correct list options with RabbitMQ >= 3.7.9' do
+    provider_class.expects(:rabbitmq_version).returns '3.7.10'
+    provider_class.expects(:rabbitmqctl).with('list_vhost', '-q', '--no-table-headers').returns ''
+    expect(provider_class.rabbitmqctl_list('vhost')).to eq('')
+  end
+end

--- a/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_exchange/rabbitmqadmin_spec.rb
@@ -17,10 +17,10 @@ describe provider_class do
   let(:provider) { provider_class.new(resource) }
 
   it 'returns instances' do
-    provider_class.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
+    provider_class.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
 /
 EOT
-    provider_class.expects(:rabbitmqctl).with('-q', 'list_exchanges', '-p', '/', 'name', 'type', 'internal', 'durable', 'auto_delete', 'arguments').returns <<-EOT
+    provider_class.expects(:rabbitmqctl_list).with('exchanges', '-p', '/', 'name', 'type', 'internal', 'durable', 'auto_delete', 'arguments').returns <<-EOT
         direct  false   true    false   []
 amq.direct      direct  false   true    false   []
 amq.fanout      fanout  false   true    false   []

--- a/spec/unit/puppet/provider/rabbitmq_parameter/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_parameter/rabbitmqctl_spec.rb
@@ -46,12 +46,12 @@ describe Puppet::Type.type(:rabbitmq_parameter).provider(:rabbitmqctl) do
   end
 
   it 'fails with invalid output from list' do
-    provider.class.expects(:rabbitmqctl).with('list_parameters', '-q', '-p', '/').returns 'foobar'
+    provider.class.expects(:rabbitmqctl_list).with('parameters', '-p', '/').returns 'foobar'
     expect { provider.exists? }.to raise_error(Puppet::Error, %r{cannot parse line from list_parameter})
   end
 
   it 'matches parameters from list' do
-    provider.class.expects(:rabbitmqctl).with('list_parameters', '-q', '-p', '/').returns <<-EOT
+    provider.class.expects(:rabbitmqctl_list).with('parameters', '-p', '/').returns <<-EOT
 shovel  documentumShovel  {"src-uri":"amqp://","src-queue":"my-queue","dest-uri":"amqp://remote-server","dest-queue":"another-queue"}
 EOT
     expect(provider.exists?).to eq(component_name: 'shovel',
@@ -64,7 +64,7 @@ EOT
   end
 
   it 'does not match an empty list' do
-    provider.class.expects(:rabbitmqctl).with('list_parameters', '-q', '-p', '/').returns ''
+    provider.class.expects(:rabbitmqctl_list).with('parameters', '-p', '/').returns ''
     expect(provider.exists?).to eq(nil)
   end
 

--- a/spec/unit/puppet/provider/rabbitmq_policy/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_policy/rabbitmqctl_spec.rb
@@ -40,14 +40,14 @@ describe Puppet::Type.type(:rabbitmq_policy).provider(:rabbitmqctl) do
 
   it 'fails with invalid output from list' do
     provider.class.expects(:rabbitmqctl).with('-q', 'status').returns '{rabbit,"RabbitMQ","3.1.5"}'
-    provider.class.expects(:rabbitmqctl).with('list_policies', '-q', '-p', '/').returns 'foobar'
+    provider.class.expects(:rabbitmqctl_list).with('policies', '-p', '/').returns 'foobar'
     expect { provider.exists? }.to raise_error(Puppet::Error, %r{cannot parse line from list_policies})
   end
 
   context 'with RabbitMQ version >=3.7.0' do
     it 'matches policies from list' do
       provider.class.expects(:rabbitmq_version).returns '3.7.0'
-      provider.class.expects(:rabbitmqctl).with('list_policies', '-q', '-p', '/').returns <<-EOT
+      provider.class.expects(:rabbitmqctl_list).with('policies', '-p', '/').returns <<-EOT
 / ha-all .* all {"ha-mode":"all","ha-sync-mode":"automatic"} 0
 / test .* exchanges {"ha-mode":"all"} 0
 EOT
@@ -64,7 +64,7 @@ EOT
   context 'with RabbitMQ version >=3.2.0 and < 3.7.0' do
     it 'matches policies from list' do
       provider.class.expects(:rabbitmq_version).returns '3.6.9'
-      provider.class.expects(:rabbitmqctl).with('list_policies', '-q', '-p', '/').returns <<-EOT
+      provider.class.expects(:rabbitmqctl_list).with('policies', '-p', '/').returns <<-EOT
 / ha-all all .* {"ha-mode":"all","ha-sync-mode":"automatic"} 0
 / test exchanges .* {"ha-mode":"all"} 0
 EOT
@@ -81,7 +81,7 @@ EOT
   context 'with RabbitMQ version <3.2.0' do
     it 'matches policies from list (<3.2.0)' do
       provider.class.expects(:rabbitmq_version).returns '3.1.5'
-      provider.class.expects(:rabbitmqctl).with('list_policies', '-q', '-p', '/').returns <<-EOT
+      provider.class.expects(:rabbitmqctl_list).with('policies', '-p', '/').returns <<-EOT
 / ha-all .* {"ha-mode":"all","ha-sync-mode":"automatic"} 0
 / test .* {"ha-mode":"all"} 0
 EOT
@@ -97,7 +97,7 @@ EOT
 
   it 'does not match an empty list' do
     provider.class.expects(:rabbitmqctl).with('-q', 'status').returns '{rabbit,"RabbitMQ","3.1.5"}'
-    provider.class.expects(:rabbitmqctl).with('list_policies', '-q', '-p', '/').returns ''
+    provider.class.expects(:rabbitmqctl_list).with('policies', '-p', '/').returns ''
     expect(provider.exists?).to eq(nil)
   end
 

--- a/spec/unit/puppet/provider/rabbitmq_policy/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_policy/rabbitmqctl_spec.rb
@@ -39,8 +39,8 @@ describe Puppet::Type.type(:rabbitmq_policy).provider(:rabbitmqctl) do
   end
 
   it 'fails with invalid output from list' do
-    provider.class.expects(:rabbitmqctl).with('-q', 'status').returns '{rabbit,"RabbitMQ","3.1.5"}'
     provider.class.expects(:rabbitmqctl_list).with('policies', '-p', '/').returns 'foobar'
+    provider.class.expects(:rabbitmq_version).returns '3.1.5'
     expect { provider.exists? }.to raise_error(Puppet::Error, %r{cannot parse line from list_policies})
   end
 
@@ -96,8 +96,8 @@ EOT
   end
 
   it 'does not match an empty list' do
-    provider.class.expects(:rabbitmqctl).with('-q', 'status').returns '{rabbit,"RabbitMQ","3.1.5"}'
     provider.class.expects(:rabbitmqctl_list).with('policies', '-p', '/').returns ''
+    provider.class.expects(:rabbitmq_version).returns '3.1.5'
     expect(provider.exists?).to eq(nil)
   end
 

--- a/spec/unit/puppet/provider/rabbitmq_queue/rabbitmqadmin_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_queue/rabbitmqadmin_spec.rb
@@ -13,10 +13,10 @@ describe provider_class do
   let(:provider) { provider_class.new(resource) }
 
   it 'returns instances' do
-    provider_class.expects(:rabbitmqctl).with('list_vhosts', '-q').returns <<-EOT
+    provider_class.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
 /
 EOT
-    provider_class.expects(:rabbitmqctl).with('list_queues', '-q', '-p', '/', 'name', 'durable', 'auto_delete', 'arguments').returns <<-EOT
+    provider_class.expects(:rabbitmqctl_list).with('queues', '-p', '/', 'name', 'durable', 'auto_delete', 'arguments').returns <<-EOT
 test  true  false []
 test2 true  false [{"x-message-ttl",342423},{"x-expires",53253232},{"x-max-length",2332},{"x-max-length-bytes",32563324242},{"x-dead-letter-exchange","amq.direct"},{"x-dead-letter-routing-key","test.routing"}]
 EOT

--- a/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user/rabbitmqctl_spec.rb
@@ -14,7 +14,7 @@ describe provider_class do
   let(:instance) { provider.class.instances.first }
 
   before do
-    provider.class.stubs(:rabbitmqctl).with('-q', 'list_users').returns(
+    provider.class.stubs(:rabbitmqctl_list).with('users').returns(
       "rmq_x [disk, storage]\nrmq_y [network, cpu, administrator]\nrmq_z []\n"
     )
   end

--- a/spec/unit/puppet/provider/rabbitmq_user_permissions/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_user_permissions/rabbitmqctl_spec.rb
@@ -13,25 +13,25 @@ describe 'Puppet::Type.type(:rabbitmq_user_permissions).provider(:rabbitmqctl)' 
     provider_class.instance_variable_set(:@users, nil)
   end
   it 'matches user permissions from list' do
-    provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+    provider.class.expects(:rabbitmqctl_list).with('user_permissions', 'foo').returns <<-EOT
 bar 1 2 3
 EOT
     expect(provider.exists?).to eq(configure: '1', write: '2', read: '3')
   end
   it 'matches user permissions with empty columns' do
-    provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+    provider.class.expects(:rabbitmqctl_list).with('user_permissions', 'foo').returns <<-EOT
 bar			3
 EOT
     expect(provider.exists?).to eq(configure: '', write: '', read: '3')
   end
   it 'does not match user permissions with more than 3 columns' do
-    provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+    provider.class.expects(:rabbitmqctl_list).with('user_permissions', 'foo').returns <<-EOT
 bar 1 2 3 4
 EOT
     expect { provider.exists? }.to raise_error(Puppet::Error, %r{cannot parse line from list_user_permissions})
   end
   it 'does not match an empty list' do
-    provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+    provider.class.expects(:rabbitmqctl_list).with('user_permissions', 'foo').returns <<-EOT
 EOT
     expect(provider.exists?).to eq(nil)
   end
@@ -49,7 +49,7 @@ EOT
   end
   { configure_permission: '1', write_permission: '2', read_permission: '3' }.each do |k, v|
     it "should be able to retrieve #{k}" do
-      provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+      provider.class.expects(:rabbitmqctl_list).with('user_permissions', 'foo').returns <<-EOT
 bar 1 2 3
 EOT
       expect(provider.send(k)).to eq(v)
@@ -57,7 +57,7 @@ EOT
   end
   { configure_permission: '1', write_permission: '2', read_permission: '3' }.each do |k, v|
     it "should be able to retrieve #{k} after exists has been called" do
-      provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+      provider.class.expects(:rabbitmqctl_list).with('user_permissions', 'foo').returns <<-EOT
 bar 1 2 3
 EOT
       provider.exists?
@@ -68,7 +68,7 @@ EOT
     read_permission: %w[1 2 foo],
     write_permission: %w[1 foo 3] }.each do |perm, columns|
     it "should be able to sync #{perm}" do
-      provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+      provider.class.expects(:rabbitmqctl_list).with('user_permissions', 'foo').returns <<-EOT
 bar 1 2 3
 EOT
       provider.resource[perm] = 'foo'
@@ -77,7 +77,7 @@ EOT
     end
   end
   it 'onlies call set_permissions once' do
-    provider.class.expects(:rabbitmqctl).with('-q', 'list_user_permissions', 'foo').returns <<-EOT
+    provider.class.expects(:rabbitmqctl_list).with('user_permissions', 'foo').returns <<-EOT
 bar 1 2 3
 EOT
     provider.resource[:configure_permission] = 'foo'

--- a/spec/unit/puppet/provider/rabbitmq_vhost/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_vhost/rabbitmqctl_spec.rb
@@ -10,7 +10,7 @@ describe provider_class do
   let(:provider) { provider_class.new(resource) }
 
   it 'matches vhost names' do
-    provider.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
+    provider.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
 Listing vhosts ...
 foo
 ...done.
@@ -18,14 +18,14 @@ EOT
     expect(provider.exists?).to eq(true)
   end
   it 'does not match if no vhosts on system' do
-    provider.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
+    provider.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
 Listing vhosts ...
 ...done.
 EOT
     expect(provider.exists?).to eq(false)
   end
   it 'does not match if no matching vhosts on system' do
-    provider.expects(:rabbitmqctl).with('-q', 'list_vhosts').returns <<-EOT
+    provider.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
 Listing vhosts ...
 fooey
 ...done.


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->
This is an alternative attempt at fixing `rabbitmqctl list_{x}` commands with RabbitMQ 3.7.9+. #751 was also an attempt. This PR takes a different approach by adding a class method in the "parent" provider class for all the providers. This method provides a consistent way to run `rabbitmqctl list_` operations in all provider classes.

This PR also cleans up the process of finding RabbitMQ CLI binaries: all providers now share the same command methods. It also adds caching to the RabbitMQ version value.

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
Fixes #740 