### PR TITLE
Update fallback path for CLI commands

### DIFF
--- a/lib/puppet/provider/rabbitmq_cli.rb
+++ b/lib/puppet/provider/rabbitmq_cli.rb
@@ -2,7 +2,18 @@ class Puppet::Provider::RabbitmqCli < Puppet::Provider
   initvars
 
   def self.rabbitmq_command(name, binary)
-    path = Puppet::Util.which(binary) || "/usr/lib/rabbitmq/bin/#{binary}"
+    path = if Puppet::Util.which(binary)
+             Puppet::Util.which(binary)
+           # Work around problems on first run with provider not picking up
+           # programs in PATH
+           elsif File.file?("/usr/sbin/#{binary}")
+             "/usr/sbin/#{binary}"
+           else
+             # With certain RabbitMQ versions / distributions still don't have
+             # the wrapper.
+             "/usr/lib/rabbitmq/bin/#{binary}"
+           end
+
     home_tmp_command name, path
   end
 


### PR DESCRIPTION
#### Pull Request (PR) description
This should resolve an idempotency issue, at least on certain platforms, by using the version of `rabbitmqctl` and `rabbitmq-plugins` in `/usr/sbin` (the wrapper) vs. the one in `/usr/lib/rabbitmq/bin`. Open to suggestions of a cleaner fix for this

Possibly related to #748 as well

cc: @JayH5 

#### This Pull Request (PR) fixes the following issues
    Fixes #763 
    Fixes #748