### PR TITLE
Allow offline and online mode for plugins

### DIFF
--- a/lib/puppet/provider/rabbitmq_cli.rb
+++ b/lib/puppet/provider/rabbitmq_cli.rb
@@ -52,6 +52,13 @@ class Puppet::Provider::RabbitmqCli < Puppet::Provider
     rabbitmqctl("list_#{resource}", *list_opts, *opts)
   end
 
+  def self.rabbitmq_running
+    rabbitmqctl('-q', 'status')
+    return true
+  rescue Puppet::ExecutionFailure, Timeout::Error
+    return false
+  end
+
   # Retry the given code block 'count' retries or until the
   # command succeeds. Use 'step' delay between retries.
   # Limit each query time by 'timeout'.

--- a/lib/puppet/type/rabbitmq_plugin.rb
+++ b/lib/puppet/type/rabbitmq_plugin.rb
@@ -9,6 +9,12 @@ manages rabbitmq plugins
  rabbitmq_plugin {'rabbitmq_stomp':
    ensure => present,
  }
+
+@example Ensure a rabbitmq_plugin offline resource (with RabbitMQ version >=3.4.0)
+ rabbitmq_plugin {'rabbitmq_stomp':
+   ensure => present,
+   mode   => 'offline',
+ }
 DESC
 
   ensurable do
@@ -24,6 +30,12 @@ DESC
   newparam(:name, namevar: true) do
     desc 'The name of the plugin to enable'
     newvalues(%r{^\S+$})
+  end
+
+  newparam(:mode) do
+    desc 'Define how the plugin should be enabled regarding node status.'
+    newvalues(:online, :offline, :best)
+    defaultto(:best)
   end
 
   newparam(:umask) do

--- a/spec/unit/puppet/provider/rabbitmq_plugin/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_plugin/rabbitmqctl_spec.rb
@@ -13,10 +13,73 @@ describe provider_class do
     provider.expects(:rabbitmqplugins).with('list', '-E', '-m').returns("foo\n")
     expect(provider.exists?).to eq(true)
   end
-  it 'calls rabbitmqplugins to enable' do
+
+  it 'calls rabbitmqplugins to enable when node not running' do
+    provider.class.expects(:rabbitmq_running).returns false
     provider.expects(:rabbitmqplugins).with('enable', 'foo')
     provider.create
   end
+
+  context 'with RabbitMQ version >=3.4.0' do
+    it 'calls rabbitmqplugins to enable' do
+      provider.class.expects(:rabbitmq_version).returns '3.4.0'
+      provider.class.expects(:rabbitmq_running).returns true
+      provider.expects(:rabbitmqplugins).with('enable', 'foo')
+      provider.create
+    end
+    it 'calls rabbitmqplugins to enable with offline' do
+      provider.resource[:mode] = :offline
+      provider.class.expects(:rabbitmq_version).returns '3.4.0'
+      provider.class.expects(:rabbitmq_running).returns true
+      provider.expects(:rabbitmqplugins).with('enable', 'foo', '--offline')
+      provider.create
+    end
+    it 'calls rabbitmqplugins to enable with online' do
+      provider.resource[:mode] = :online
+      provider.class.expects(:rabbitmq_version).returns '3.4.0'
+      provider.class.expects(:rabbitmq_running).returns true
+      provider.expects(:rabbitmqplugins).with('enable', 'foo', '--online')
+      provider.create
+    end
+    it 'calls rabbitmqplugins to enable with best' do
+      provider.resource[:mode] = :best
+      provider.class.expects(:rabbitmq_version).returns '3.4.0'
+      provider.class.expects(:rabbitmq_running).returns true
+      provider.expects(:rabbitmqplugins).with('enable', 'foo')
+      provider.create
+    end
+  end
+
+  context 'with RabbitMQ version < 3.4.0' do
+    it 'calls rabbitmqplugins to enable' do
+      provider.class.expects(:rabbitmq_version).returns '3.3.9'
+      provider.class.expects(:rabbitmq_running).returns true
+      provider.expects(:rabbitmqplugins).with('enable', 'foo')
+      provider.create
+    end
+    it 'calls rabbitmqplugins to enable with offline' do
+      provider.resource[:mode] = :offline
+      provider.class.expects(:rabbitmq_version).returns '3.3.9'
+      provider.class.expects(:rabbitmq_running).returns true
+      provider.expects(:rabbitmqplugins).with('enable', 'foo')
+      provider.create
+    end
+    it 'calls rabbitmqplugins to enable with online' do
+      provider.resource[:mode] = :online
+      provider.class.expects(:rabbitmq_version).returns '3.3.9'
+      provider.class.expects(:rabbitmq_running).returns true
+      provider.expects(:rabbitmqplugins).with('enable', 'foo')
+      provider.create
+    end
+    it 'calls rabbitmqplugins to enable with best' do
+      provider.resource[:mode] = :best
+      provider.class.expects(:rabbitmq_version).returns '3.3.9'
+      provider.class.expects(:rabbitmq_running).returns true
+      provider.expects(:rabbitmqplugins).with('enable', 'foo')
+      provider.create
+    end
+  end
+
   it 'calls rabbitmqplugins to disable' do
     provider.expects(:rabbitmqplugins).with('disable', 'foo')
     provider.destroy

--- a/spec/unit/puppet/type/rabbitmq_plugin_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_plugin_spec.rb
@@ -8,6 +8,18 @@ describe Puppet::Type.type(:rabbitmq_plugin) do
     plugin[:name] = 'plugin-name'
     expect(plugin[:name]).to eq('plugin-name')
   end
+  it 'accepts a mode of offline' do
+    plugin[:mode] = 'offline'
+    expect(plugin[:mode]).to eq(:offline)
+  end
+  it 'accepts a mode of online' do
+    plugin[:mode] = 'online'
+    expect(plugin[:mode]).to eq(:online)
+  end
+  it 'accepts a mode of best' do
+    plugin[:mode] = 'best'
+    expect(plugin[:mode]).to eq(:best)
+  end
   it 'requires a name' do
     expect do
       Puppet::Type.type(:rabbitmq_plugin).new({})
@@ -15,6 +27,9 @@ describe Puppet::Type.type(:rabbitmq_plugin) do
   end
   it 'defaults to a umask of 0022' do
     expect(plugin[:umask]).to eq(0o022)
+  end
+  it 'defaults to a mode of best' do
+    expect(plugin[:mode]).to eq(:best)
   end
   it 'does not allow a non-octal value to be specified' do
     expect do


### PR DESCRIPTION
Hello Pupuli!

In RabbitMQ we could enable a plugin offline or online.
Some plugins should be enabled offline.

See https://www.rabbitmq.com/plugins.html#ways-to-enable-plugins
man rabbitmq-plugins