### PR TITLE
Allow Array values in rabbitmq_parameter

### DIFF
--- a/lib/puppet/type/rabbitmq_parameter.rb
+++ b/lib/puppet/type/rabbitmq_parameter.rb
@@ -71,7 +71,7 @@ DESC
   def validate_value(value)
     raise ArgumentError, 'Invalid value' unless [Hash].include?(value.class)
     value.each do |_k, v|
-      unless [String, TrueClass, FalseClass].include?(v.class)
+      unless [String, TrueClass, FalseClass, Array].include?(v.class)
         raise ArgumentError, 'Invalid value'
       end
     end

--- a/spec/unit/puppet/provider/rabbitmq_parameter/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_parameter/rabbitmqctl_spec.rb
@@ -52,11 +52,11 @@ describe Puppet::Type.type(:rabbitmq_parameter).provider(:rabbitmqctl) do
 
   it 'matches parameters from list' do
     provider.class.expects(:rabbitmqctl_list).with('parameters', '-p', '/').returns <<-EOT
-shovel  documentumShovel  {"src-uri":"amqp://","src-queue":"my-queue","dest-uri":"amqp://remote-server","dest-queue":"another-queue"}
+shovel  documentumShovel  {"src-uri":["amqp://cl1","amqp://cl2"],"src-queue":"my-queue","dest-uri":"amqp://remote-server","dest-queue":"another-queue"}
 EOT
     expect(provider.exists?).to eq(component_name: 'shovel',
                                    value: {
-                                     'src-uri' => 'amqp://',
+                                     'src-uri' => ['amqp://cl1', 'amqp://cl2'],
                                      'src-queue'  => 'my-queue',
                                      'dest-uri'   => 'amqp://remote-server',
                                      'dest-queue' => 'another-queue'

--- a/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
@@ -59,10 +59,16 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
     end.to raise_error(Puppet::Error, %r{Invalid value})
   end
 
-  it 'does not accept an array for definition' do
+  it 'does not accept an object for definition' do
     expect do
-      parameter[:value] = { 'message-ttl' => %w[999 100] }
+      parameter[:value] = { 'message-ttl' => Object.new }
     end.to raise_error(Puppet::Error, %r{Invalid value})
+  end
+
+  it 'accepts array as myparameter' do
+    value = { 'myparameter' => %w[my string] }
+    parameter[:value] = value
+    expect(parameter[:value]['myparameter']).to eq(%w[my string])
   end
 
   it 'accepts string as myparameter' do


### PR DESCRIPTION
Array (lists) are allowed values to use with rabbitmqctl.

For example: src-uri when setting up a shovel.

@wyardley could you re-review this, had to create a new pr since I have left the vrtdev organisation since the previous one :)