### PR TITLE
Support enabling rabbitmq_management without rabbitmqadmin

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,7 @@
 class rabbitmq::config {
 
   $admin_enable                        = $rabbitmq::admin_enable
+  $management_enable                   = $rabbitmq::management_enable
   $cluster_node_type                   = $rabbitmq::cluster_node_type
   $cluster_nodes                       = $rabbitmq::cluster_nodes
   $config                              = $rabbitmq::config

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -83,6 +83,7 @@ class rabbitmq::params {
 
   #install
   $admin_enable                        = true
+  $management_enable                   = false
   $management_port                     = 15672
   $management_ssl                      = true
   $repos_ensure                        = false

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -615,6 +615,50 @@ describe 'rabbitmq' do
         end
       end
 
+      describe 'configure management plugin' do
+        let :params do
+          {
+            admin_enable: true,
+            management_enable: false
+          }
+        end
+
+        it { is_expected.to contain_rabbitmq_plugin('rabbitmq_management') }
+        it 'sets rabbitmq_managment opts to specified values' do
+            is_expected.to contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
+            is_expected.to contain_file('rabbitmq.config').with_content(%r{listener, \[})
+            is_expected.to contain_file('rabbitmq.config').with_content(%r{port, 15672\}})
+        end
+
+        describe 'with admin_enable false' do
+          let :params do
+            {
+              admin_enable: false,
+              management_enable: false
+            }
+          end
+
+          it { is_expected.not_to contain_rabbitmq_plugin('rabbitmq_management') }
+        end
+
+        describe 'with admin_enable false and management_enable true' do
+          let :params do
+            {
+              admin_enable: false,
+              management_enable: true
+            }
+          end
+
+          it { is_expected.to contain_rabbitmq_plugin('rabbitmq_management')}
+          it 'sets rabbitmq_managment opts to specified values' do
+            is_expected.to contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
+            is_expected.to contain_file('rabbitmq.config').with_content(%r{listener, \[})
+            is_expected.to contain_file('rabbitmq.config').with_content(%r{port, 15672\}})
+          end
+        end
+      end
+
+
       describe 'configuring shovel plugin' do
         let :params do
           {

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -96,12 +96,12 @@
     <%= @config_kernel_variables.sort.map{|k,v| "{#{k}, #{v}}"}.join(",\n    ") %>
   ]}
 <%- end -%>
-<%- if @admin_enable or !@config_management_variables.empty? -%>,
+<%- if @admin_enable or @management_enable or !@config_management_variables.empty? -%>,
   {rabbitmq_management, [
     <%- if !@config_management_variables.empty? -%>
     <%= @config_management_variables.sort.map{|k,v| "{#{k}, #{v}}"}.join(",\n    ") %>
     <%- end -%>
-<%- if @admin_enable -%>
+<%- if @admin_enable or @management_enable -%>
 <%- if  !@config_management_variables.empty? -%>,<%-end-%>
     {listener, [
 <%- if @ssl && @management_ssl -%>


### PR DESCRIPTION
#### Pull Request (PR) description
Support enabling rabbitmq_management without rabbitmqadmin

Enabling the rabbitmq_managemnt interface and installing the
rabbitmqadmin client was both controlled by the admin_enable
parameter.

Adds option enable_management (default: false). When this is
set to true, and admin_enable is false the rabbitmq_management
plugin is enabled, but the rabbitmqadmin client is not
installed.

For backward compatiblity the rabbitmq_management plugin is
also enabled when admin_enable is set to true.

#### This Pull Request (PR) fixes the following issues
Related #775
