### PR TITLE
Add support for enabled plugins config using enabled_plugins file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,7 @@
 class rabbitmq::config {
 
   $admin_enable                        = $rabbitmq::admin_enable
+  $management_enable                   = $rabbitmq::management_enable
   $cluster_node_type                   = $rabbitmq::cluster_node_type
   $cluster_nodes                       = $rabbitmq::cluster_nodes
   $config                              = $rabbitmq::config

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,7 @@ class rabbitmq::config {
 
   $admin_enable                        = $rabbitmq::admin_enable
   $management_enable                   = $rabbitmq::management_enable
+  $use_config_file_for_plugins         = $rabbitmq::use_config_file_for_plugins
   $cluster_node_type                   = $rabbitmq::cluster_node_type
   $cluster_nodes                       = $rabbitmq::cluster_nodes
   $config                              = $rabbitmq::config
@@ -13,6 +14,7 @@ class rabbitmq::config {
   $config_path                         = $rabbitmq::config_path
   $config_ranch                        = $rabbitmq::config_ranch
   $config_stomp                        = $rabbitmq::config_stomp
+  $stomp_ensure                        = $rabbitmq::stomp_ensure
   $config_shovel                       = $rabbitmq::config_shovel
   $config_shovel_statics               = $rabbitmq::config_shovel_statics
   $default_user                        = $rabbitmq::default_user
@@ -178,6 +180,18 @@ class rabbitmq::config {
     owner   => '0',
     group   => $rabbitmq_group,
     mode    => '0640',
+  }
+
+  if $use_config_file_for_plugins {
+    file { 'enabled_plugins':
+      ensure  => file,
+      path    => '/etc/rabbitmq/enabled_plugins',
+      content => template('rabbitmq/enabled_plugins.erb'),
+      owner   => '0',
+      group   => $rabbitmq_group,
+      mode    => '0640',
+      require => File['/etc/rabbitmq'],
+    }
   }
 
   if $admin_enable {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,9 @@
 # @param management_enable
 #   If enabled sets up the management interface/plugin for RabbitMQ.
 #   NOTE: This does not install the rabbitmqadmin command line tool.
+# @param use_config_file_for_plugins
+#   If enabled the /etc/rabbitmq/enabled_plugins config file is created,
+#   replacing the use of the rabbitmqplugins provider to enable plugins.
 # @param auth_backends
 #   An array specifying authorization/authentication backend to use. Single quotes should be placed around array entries,
 #   ex. `['{foo, baz}', 'baz']` Defaults to [rabbit_auth_backend_internal], and if using LDAP defaults to [rabbit_auth_backend_internal,
@@ -285,6 +288,7 @@
 class rabbitmq(
   Boolean $admin_enable                                                                            = $rabbitmq::params::admin_enable,
   Boolean $management_enable                                                                       = $rabbitmq::params::management_enable,
+  Boolean $use_config_file_for_plugins                                                             = $rabbitmq::params::use_config_file_for_plugins,
   Enum['ram', 'disk', 'disc'] $cluster_node_type                                                   = $rabbitmq::params::cluster_node_type,
   Array $cluster_nodes                                                                             = $rabbitmq::params::cluster_nodes,
   String $config                                                                                   = $rabbitmq::params::config,
@@ -413,11 +417,49 @@ class rabbitmq(
   contain rabbitmq::service
   contain rabbitmq::management
 
-  if ($management_enable or $admin_enable) and $service_manage {
-    rabbitmq_plugin { 'rabbitmq_management':
-      ensure   => present,
-      notify   => Class['rabbitmq::service'],
-      provider => 'rabbitmqplugins',
+  unless $use_config_file_for_plugins {
+    # NOTE(hjensas): condition on $service_manage to keep current behaviour.
+    # The condition is likely not required because installiton of rabbitmqadmin
+    # is no longer handled here.
+    # TODO: Remove the condition on $service_manage
+    if ($management_enable or $admin_enable) and $service_manage {
+      rabbitmq_plugin { 'rabbitmq_management':
+        ensure   => present,
+        notify   => Class['rabbitmq::service'],
+        provider => 'rabbitmqplugins',
+      }
+    }
+
+    if ($stomp_ensure) {
+      rabbitmq_plugin { 'rabbitmq_stomp':
+        ensure   => present,
+        notify   => Class['rabbitmq::service'],
+        provider => 'rabbitmqplugins',
+      }
+    }
+
+    if ($ldap_auth) {
+      rabbitmq_plugin { 'rabbitmq_auth_backend_ldap':
+        ensure   => present,
+        notify   => Class['rabbitmq::service'],
+        provider => 'rabbitmqplugins',
+      }
+    }
+
+    if ($config_shovel) {
+      rabbitmq_plugin { 'rabbitmq_shovel':
+        ensure   => present,
+        notify   => Class['rabbitmq::service'],
+        provider => 'rabbitmqplugins',
+      }
+
+      if ($management_enable or $admin_enable) {
+        rabbitmq_plugin { 'rabbitmq_shovel_management':
+          ensure   => present,
+          notify   => Class['rabbitmq::service'],
+          provider => 'rabbitmqplugins',
+        }
+      }
     }
   }
 
@@ -426,36 +468,6 @@ class rabbitmq(
 
     Class['rabbitmq::service'] -> Class['rabbitmq::install::rabbitmqadmin']
     Class['rabbitmq::install::rabbitmqadmin'] -> Rabbitmq_exchange<| |>
-  }
-
-  if $stomp_ensure {
-    rabbitmq_plugin { 'rabbitmq_stomp':
-      ensure => present,
-      notify => Class['rabbitmq::service'],
-    }
-  }
-
-  if ($ldap_auth) {
-    rabbitmq_plugin { 'rabbitmq_auth_backend_ldap':
-      ensure => present,
-      notify => Class['rabbitmq::service'],
-    }
-  }
-
-  if ($config_shovel) {
-    rabbitmq_plugin { 'rabbitmq_shovel':
-      ensure   => present,
-      notify   => Class['rabbitmq::service'],
-      provider => 'rabbitmqplugins',
-    }
-
-    if ($admin_enable) {
-      rabbitmq_plugin { 'rabbitmq_shovel_management':
-        ensure   => present,
-        notify   => Class['rabbitmq::service'],
-        provider => 'rabbitmqplugins',
-      }
-    }
   }
 
   if ($service_restart) {

--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -44,6 +44,12 @@ class rabbitmq::install::rabbitmqadmin {
       $sanitized_ip = $management_ip_address
     }
 
+    if !($rabbitmq::use_config_file_for_plugins) {
+      $rabbitmqadmin_archive_require = [Class['rabbitmq::service'], Rabbitmq_plugin['rabbitmq_management']]
+    } else {
+      $rabbitmqadmin_archive_require = [Class['rabbitmq::service'], File['enabled_plugins']]
+    }
+
     archive { 'rabbitmqadmin':
       path             => "${rabbitmq::rabbitmq_home}/rabbitmqadmin",
       source           => "${protocol}://${sanitized_ip}:${management_port}/cli/rabbitmqadmin",
@@ -52,10 +58,7 @@ class rabbitmq::install::rabbitmqadmin {
       allow_insecure   => true,
       download_options => $archive_options,
       cleanup          => false,
-      require          => [
-        Class['rabbitmq::service'],
-        Rabbitmq_plugin['rabbitmq_management']
-      ],
+      require          => $rabbitmqadmin_archive_require,
     }
 
     file { '/usr/local/bin/rabbitmqadmin':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -84,6 +84,7 @@ class rabbitmq::params {
   #install
   $admin_enable                        = true
   $management_enable                   = false
+  $use_config_file_for_plugins         = false
   $management_port                     = 15672
   $management_ssl                      = true
   $repos_ensure                        = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -83,6 +83,7 @@ class rabbitmq::params {
 
   #install
   $admin_enable                        = true
+  $management_enable                   = false
   $management_port                     = 15672
   $management_ssl                      = true
   $repos_ensure                        = false

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -615,6 +615,50 @@ describe 'rabbitmq' do
         end
       end
 
+      describe 'configure management plugin' do
+        let :params do
+          {
+            admin_enable: true,
+            management_enable: false
+          }
+        end
+
+        it { is_expected.to contain_rabbitmq_plugin('rabbitmq_management') }
+        it 'sets rabbitmq_managment opts to specified values' do
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{listener, \[})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{port, 15672\}})
+        end
+
+        describe 'with admin_enable false' do
+          let :params do
+            {
+              admin_enable: false,
+              management_enable: false
+            }
+          end
+
+          it { is_expected.not_to contain_rabbitmq_plugin('rabbitmq_management') }
+        end
+
+        describe 'with admin_enable false and management_enable true' do
+          let :params do
+            {
+              admin_enable: false,
+              management_enable: true
+            }
+          end
+
+          it { is_expected.to contain_rabbitmq_plugin('rabbitmq_management') }
+          it 'sets rabbitmq_managment opts to specified values' do
+            is_expected.to contain_file('rabbitmq.config').with_content(%r{rabbitmq_management, \[})
+            is_expected.to contain_file('rabbitmq.config').with_content(%r{listener, \[})
+            is_expected.to contain_file('rabbitmq.config').with_content(%r{port, 15672\}})
+          end
+        end
+      end
+
+
       describe 'configuring shovel plugin' do
         let :params do
           {

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -615,6 +615,56 @@ describe 'rabbitmq' do
         end
       end
 
+      context 'use config file for plugins' do
+        describe 'config_plugins_file: true' do
+          let :params do
+            { use_config_file_for_plugins: true }
+          end
+
+          it 'does not use rabbitmqplugin provider' do
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_management')
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_shovel_management')
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_stomp')
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_auth_backend_ldap')
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_shovel')
+          end
+
+          it 'configures enabled_plugins' do
+            is_expected.to contain_file('enabled_plugins').with_content(%r{\[rabbitmq_management\]\.})
+          end
+        end
+
+        describe 'with all plugins enabled admin_enable: false, manamgent_enable: true' do
+          let :params do
+            {
+              use_config_file_for_plugins: true,
+              admin_enable: false,
+              management_enable: true,
+              stomp_ensure: true,
+              ldap_auth: true,
+              config_shovel: true
+            }
+          end
+
+          it 'does not use rabbitmqplugin provider' do
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_management')
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_shovel_management')
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_stomp')
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_auth_backend_ldap')
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_shovel')
+          end
+
+          it 'configures enabled_plugins' do
+            is_expected.to contain_file('enabled_plugins').with_content(%r{rabbitmq_management})
+            is_expected.to contain_file('enabled_plugins').with_content(%r{rabbitmq_stomp})
+            is_expected.to contain_file('enabled_plugins').with_content(%r{rabbitmq_auth_backend_ldap})
+            is_expected.to contain_file('enabled_plugins').with_content(%r{rabbitmq_shovel})
+            is_expected.to contain_file('enabled_plugins').with_content(%r{rabbitmq_shovel_management})
+            is_expected.to contain_file('enabled_plugins').with_content(%r{\[rabbitmq_management,rabbitmq_stomp,rabbitmq_auth_backend_ldap,rabbitmq_shovel,rabbitmq_shovel_management\]\.})
+          end
+        end
+      end
+
       describe 'configure management plugin' do
         let :params do
           {
@@ -657,7 +707,6 @@ describe 'rabbitmq' do
           end
         end
       end
-
 
       describe 'configuring shovel plugin' do
         let :params do

--- a/templates/enabled_plugins.erb
+++ b/templates/enabled_plugins.erb
@@ -1,0 +1,19 @@
+% This file managed by Puppet
+% Template Path: <%= @module_name %>/templates/enabled_plugins
+<%- @_plugins = [] -%>
+<%- if @admin_enable or @management_enable -%>
+  <%- @_plugins << 'rabbitmq_management' -%>
+<%- end -%>
+<%- if @stomp_ensure -%>
+  <%- @_plugins << 'rabbitmq_stomp' -%>
+<%- end -%>
+<%- if @ldap_auth -%>
+  <%- @_plugins << 'rabbitmq_auth_backend_ldap' -%>
+<%- end -%>
+<%- if @config_shovel -%>
+  <%- @_plugins << 'rabbitmq_shovel' -%>
+  <%- if @admin_enable or @management_enable -%>
+    <%- @_plugins << 'rabbitmq_shovel_management' -%>
+  <%- end -%>
+<%- end -%>
+[<%= @_plugins.join(',')%>].

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -96,12 +96,12 @@
     <%= @config_kernel_variables.sort.map{|k,v| "{#{k}, #{v}}"}.join(",\n    ") %>
   ]}
 <%- end -%>
-<%- if @admin_enable or !@config_management_variables.empty? -%>,
+<%- if @admin_enable or @management_enable or !@config_management_variables.empty? -%>,
   {rabbitmq_management, [
     <%- if !@config_management_variables.empty? -%>
     <%= @config_management_variables.sort.map{|k,v| "{#{k}, #{v}}"}.join(",\n    ") %>
     <%- end -%>
-<%- if @admin_enable -%>
+<%- if @admin_enable or @management_enable -%>
 <%- if  !@config_management_variables.empty? -%>,<%-end-%>
     {listener, [
 <%- if @ssl && @management_ssl -%>


### PR DESCRIPTION
#### Pull Request (PR) description
Support configuring plugins using enabled_plugins file

Adds optional support to configure rabbitmq plugins by
writing configuration file (/etc/rabbitmq/enabled_plugins).

New parameter $use_config_file_for_plugins (boolean, default:
false) Can be used to enable this feature. When enabled it
replaces the use of the rabbitmqplugins provider to enable
plugins.

#### This Pull Request (PR) fixes the following issues
Fixes #775
