### PR TITLE
Add a custom fact for rabbitmq's plugins folder.

### DIFF
--- a/lib/facter/rabbitmq_plugins_dirs.rb
+++ b/lib/facter/rabbitmq_plugins_dirs.rb
@@ -1,0 +1,9 @@
+Facter.add(:rabbitmq_plugins_dirs) do
+  setcode do
+    if Facter::Util::Resolution.which('rabbitmqctl')
+      rabbitmq_pluginsdirs_env = Facter::Core::Execution.execute("rabbitmqctl eval 'application:get_env(rabbit, plugins_dir).'")
+      rabbitmq_plugins_dirs = %r{^\{ok\,\"(\/.+\/\w+)}.match(rabbitmq_pluginsdirs_env)[1]
+      rabbitmq_plugins_dirs.split(':')
+    end
+  end
+end

--- a/spec/unit/facter/util/fact_rabbitmq_plugins_dirs_spec.rb
+++ b/spec/unit/facter/util/fact_rabbitmq_plugins_dirs_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe Facter::Util::Fact do
+  before { Facter.clear }
+
+  describe 'rabbitmq_plugins_dirs' do
+    context 'with multiple plugins dirs' do
+      it do
+        Facter::Util::Resolution.expects(:which).with('rabbitmqctl').returns(true)
+        Facter::Core::Execution.expects(:execute).with("rabbitmqctl eval 'application:get_env(rabbit, plugins_dir).'").returns('{ok,"/usr/lib/rabbitmq/plugins:/usr/lib/rabbitmq/lib/rabbitmq_server-3.7.10/plugins"}')
+        expect(Facter.fact(:rabbitmq_plugins_dirs).value).to match_array(
+          [
+            '/usr/lib/rabbitmq/plugins',
+            '/usr/lib/rabbitmq/lib/rabbitmq_server-3.7.10/plugins'
+          ]
+        )
+      end
+    end
+
+    context 'with only 1 plugins dir' do
+      it do
+        Facter::Util::Resolution.expects(:which).with('rabbitmqctl').returns(true)
+        Facter::Core::Execution.expects(:execute).with("rabbitmqctl eval 'application:get_env(rabbit, plugins_dir).'").returns('{ok,"/usr/lib/rabbitmq/lib/rabbitmq_server-0.0.0/plugins"}')
+        expect(Facter.fact(:rabbitmq_plugins_dirs).value).to match_array(
+          [
+            '/usr/lib/rabbitmq/lib/rabbitmq_server-0.0.0/plugins'
+          ]
+        )
+      end
+    end
+
+    context 'rabbitmqctl is not in path' do
+      it do
+        Facter::Util::Resolution.expects(:which).with('rabbitmqctl').returns(false)
+        expect(Facter.fact(:rabbitmq_plugins_dirs).value).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
If you want to add third party plugins with puppet you need to know
where the plugins folder is located.
This can differ depending on rabbitmq version or OS.
