### PR TITLE
Changed rabbitmq_queue regex

### DIFF
--- a/lib/puppet/type/rabbitmq_queue.rb
+++ b/lib/puppet/type/rabbitmq_queue.rb
@@ -28,7 +28,7 @@ DESC
 
   newparam(:name, namevar: true) do
     desc 'Name of queue'
-    newvalues(%r{^\S*@\S+$})
+    newvalues(%r{^.*@.*$})
   end
 
   newparam(:durable) do


### PR DESCRIPTION
#### Pull Request (PR) description
Changed regex for rabbitmq_queue parameter.
Queues and vhosts are able to have spaces in their names, so the regex is to restrictive.

