### PR TITLE
Don't crash on rabbitmq_plugins_dirs fact if rabbitmqctl is not present

### DIFF
--- a/lib/facter/rabbitmq_plugins_dirs.rb
+++ b/lib/facter/rabbitmq_plugins_dirs.rb
@@ -2,8 +2,8 @@ Facter.add(:rabbitmq_plugins_dirs) do
   setcode do
     if Facter::Util::Resolution.which('rabbitmqctl')
       rabbitmq_pluginsdirs_env = Facter::Core::Execution.execute("rabbitmqctl eval 'application:get_env(rabbit, plugins_dir).'")
-      rabbitmq_plugins_dirs = %r{^\{ok\,\"(\/.+\/\w+)}.match(rabbitmq_pluginsdirs_env)[1]
-      rabbitmq_plugins_dirs.split(':')
+      rabbitmq_plugins_dirs_match = %r{^\{ok\,\"(\/.+\/\w+)}.match(rabbitmq_pluginsdirs_env)
+      rabbitmq_plugins_dirs_match[1].split(':') if rabbitmq_plugins_dirs_match
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

Before trying to access the contents of a regexp match, see if the
match was successful. On machines without rabbitmqctl this match will
return nil. If we try to index the nil with `[1]`, it will crash.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->

Fixes #783