### PR TITLE
Update the ssl_ciphers parameter to support the OpenSSL style

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -775,8 +775,12 @@ Default value: `undef`
 
 Data type: `Array`
 
-Support only a given list of SSL ciphers. Example: `['dhe_rsa,aes_256_cbc,sha','dhe_dss,aes_256_cbc,sha', 'ecdhe_rsa,aes_256_cbc,sha']`. Supported ciphers in your install can be listed with: rabbitmqctl eval 'ssl:cipher_suites().'
-Functionality can be tested with cipherscan or similar tool: https://github.com/jvehent/cipherscan.git
+Support only a given list of SSL ciphers, using either the Erlang or OpenSSL styles.
+Supported ciphers in your install can be listed with: `rabbitmqctl eval 'ssl:cipher_suites().'`
+Functionality can be tested with cipherscan or similar tool: https://github.com/mozilla/cipherscan
+
+* Erlang style: `['ecdhe_rsa,aes_256_cbc,sha', 'dhe_rsa,aes_256_cbc,sha']`
+* OpenSSL style: `['ECDHE-RSA-AES256-SHA', 'DHE-RSA-AES256-SHA']`
 
 Default value: $rabbitmq::params::ssl_ciphers
 
@@ -1777,4 +1781,3 @@ Valid values: %r{^\S+$}
 namevar
 
 The name of the vhost to add
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -254,8 +254,11 @@
 #   POODLE and BEAST attacks. Please see the
 #   [RabbitMQ SSL](https://www.rabbitmq.com/ssl.html) documentation for more information.
 # @param ssl_ciphers
-#   Support only a given list of SSL ciphers. Example: `['dhe_rsa,aes_256_cbc,sha','dhe_dss,aes_256_cbc,sha', 'ecdhe_rsa,aes_256_cbc,sha']`. Supported ciphers in your install can be listed with: rabbitmqctl eval 'ssl:cipher_suites().'
-#   Functionality can be tested with cipherscan or similar tool: https://github.com/jvehent/cipherscan.git
+#   Support only a given list of SSL ciphers, using either the Erlang or OpenSSL styles.
+#   Supported ciphers in your install can be listed with: `rabbitmqctl eval 'ssl:cipher_suites().'`
+#   Functionality can be tested with cipherscan or similar tool: https://github.com/mozilla/cipherscan
+#   * Erlang style: `['ecdhe_rsa,aes_256_cbc,sha', 'dhe_rsa,aes_256_cbc,sha']`
+#   * OpenSSL style: `['ECDHE-RSA-AES256-SHA', 'DHE-RSA-AES256-SHA']`
 # @param stomp_port
 #   The port to use for Stomp.
 # @param stomp_ssl_only

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1101,7 +1101,7 @@ describe 'rabbitmq' do
         end
       end
 
-      describe 'ssl options with ssl ciphers' do
+      describe 'ssl options with ssl ciphers (in Erlang [pre-3.7.9] format)' do
         let(:params) do
           { ssl: true,
             ssl_port: 3141,
@@ -1112,7 +1112,22 @@ describe 'rabbitmq' do
         end
 
         it 'sets ssl ciphers to specified values' do
-          is_expected.to contain_file('rabbitmq.config').with_content(%r{ciphers,\[[[:space:]]+{dhe_rsa,aes_256_cbc,sha},[[:space:]]+{ecdhe_rsa,aes_256_cbc,sha}[[:space:]]+\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ciphers,\[[[:space:]]+{ecdhe_rsa,aes_256_cbc,sha},[[:space:]]+{dhe_rsa,aes_256_cbc,sha}[[:space:]]+\]})
+        end
+      end
+
+      describe 'ssl options with ssl ciphers (in OpenSSL style)' do
+        let(:params) do
+          { ssl: true,
+            ssl_port: 3141,
+            ssl_cacert: '/path/to/cacert',
+            ssl_cert: '/path/to/cert',
+            ssl_key: '/path/to/key',
+            ssl_ciphers: ['ECDHE-RSA-AES256-SHA', 'DHE-RSA-AES256-SHA'] }
+        end
+
+        it 'sets ssl ciphers to specified values' do
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{ciphers,\[[[:space:]]+"ECDHE-RSA-AES256-SHA",[[:space:]]+"DHE-RSA-AES256-SHA"[[:space:]]+\]})
         end
       end
 

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -1,6 +1,19 @@
 % This file managed by Puppet
 % Template Path: <%= @module_name %>/templates/rabbitmq.config
 [
+<%-
+if @ssl_ciphers && @ssl_ciphers.size > 0
+  ssl_ciphers = @ssl_ciphers.map do |cipher|
+    if cipher.split(',').size > 1
+      "{#{cipher}}"
+    else
+      "\"#{cipher}\""
+    end
+  end.join(",\n                      ")
+else
+  ssl_ciphers = nil
+end
+-%>
 <%- if @ssl and @ssl_versions -%>
   {ssl, [{versions, [<%= @ssl_versions.sort.map { |v| "'#{v}'" }.join(', ') %>]}]},
 <%- end -%>
@@ -79,7 +92,7 @@
                    <%- end -%>
                    <%- if @ssl_ciphers and @ssl_ciphers.size > 0 -%>
                    ,{ciphers,[
-                     <%= @ssl_ciphers.sort.map{|k| "{#{k}}"}.join(",\n                     ") %>
+                     <%= ssl_ciphers %>
                    ]}
                    <%- end -%>
                   ]},
@@ -122,7 +135,7 @@
                    <%- end -%>
                   <%- if @ssl_ciphers and @ssl_ciphers.size > 0 -%>
                   ,{ciphers,[
-                      <%= @ssl_ciphers.sort.map{|k| "{#{k}}"}.join(",\n                      ") %>
+                      <%= ssl_ciphers %>
                   ]}
                   <%- end -%>
                  ]}


### PR DESCRIPTION
#### Pull Request (PR) description
Currently, this module only supports the old Erlang style, but RabbitMQ post-3.7.9 (rabbitmq/rabbitmq-server#1712) supports the OpenSSL style.

This change allows the rabbitmq.config file to determine which style is being used, and apply that when defining SSL cipher suites.

#### This Pull Request (PR) fixes the following issues
n/a
