### PR TITLE
Slightly improved documentation of the ensure_repos parameter.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -201,6 +201,8 @@
 # @param repos_ensure
 #   Ensure that a repo with the official (and newer) RabbitMQ package is configured, along with its signing key.
 #   Defaults to false (use system packages). This does not ensure that soft dependencies (like EPEL on RHEL systems) are present.
+#   It also does not solve the erlang dependency.  See https://www.rabbitmq.com/which-erlang.html for a good breakdown of the
+#   different ways of handling the erlang deps.  See also https://github.com/voxpupuli/puppet-rabbitmq/issues/788
 # @param service_ensure
 #   The state of the service.
 # @param service_manage


### PR DESCRIPTION

#### Pull Request (PR) description
This is a very simple suggestion on how to improve the documentation. It may be natural to assume that `ensure_repos => True` should fix erlang dependencies, a minor comment that it doesn't could be sufficient to avoid frustrations.

This pull request does not fix any issues, but does improve the situation wrg of #788.
