### PR TITLE
Remove ordering of classes

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -13,13 +13,9 @@ class rabbitmq::repo::apt(
   Optional[String] $architecture = undef,
   ) {
 
-  $pin = $rabbitmq::package_apt_pin
-
-  # ordering / ensure to get the last version of repository
-  Class['rabbitmq::repo::apt']
-  -> Class['apt::update']
-
   $osname = downcase($facts['os']['name'])
+  $pin    = $rabbitmq::package_apt_pin
+
   apt::source { 'rabbitmq':
     ensure       => present,
     location     => "${location}/${osname}",


### PR DESCRIPTION
The resource ```Exec['apt_update']``` is triggered by default since ```puppetlabs/apt 2.4.0```:
* https://github.com/puppetlabs/puppetlabs-apt/blob/master/CHANGELOG.md#supported-release-240
* https://github.com/puppetlabs/puppetlabs-apt/commit/0475e50be8e4994e4c1c22ce103e903f52c2c599

Fixes #780 