### PR TITLE
Remove unused curl_prefix variable

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -34,13 +34,10 @@ class rabbitmq::install::rabbitmqadmin {
 
     if !($management_ip_address) {
       # Pull from localhost if we don't have an explicit bind address
-      $curl_prefix = ''
       $sanitized_ip = '127.0.0.1'
     } elsif $management_ip_address =~ Stdlib::Compat::Ipv6 {
-      $curl_prefix  = "--noproxy ${management_ip_address} -g -6"
       $sanitized_ip = join(enclose_ipv6(any2array($management_ip_address)), ',')
     } else {
-      $curl_prefix  = "--noproxy ${management_ip_address}"
       $sanitized_ip = $management_ip_address
     }
 


### PR DESCRIPTION
#### Pull Request (PR) description
With change f223f66894e5e948bcd2cf05d7beaa911605b3ff (Convert to use
'archive' instead of 'staging' for rabbitmqadmin install) the
`$curl_prefix` variable became unused:
```
$ grep -ir curl_prefix
manifests/install/rabbitmqadmin.pp:      $curl_prefix = ''
manifests/install/rabbitmqadmin.pp:      $curl_prefix  = "--noproxy ${management_ip_address} -g -6"
manifests/install/rabbitmqadmin.pp:      $curl_prefix  = "--noproxy ${management_ip_address}"
```

Let's just remove them. Users have means to specify options
to the puppet-archive provider anyways.

#### This Pull Request (PR) fixes the following issues
Removes confusing unused variables that led to #799 being opened (not using the Fixes keyword explicitely as it would be incorrect)