### PR TITLE
Refactor rabbitmq_parameter provider

### DIFF
--- a/lib/puppet/type/rabbitmq_parameter.rb
+++ b/lib/puppet/type/rabbitmq_parameter.rb
@@ -34,8 +34,8 @@ DESC
   autorequire(:service) { 'rabbitmq-server' }
 
   validate do
-    raise('component_name parameter is required.') if self[:ensure] == :present && self[:component_name].nil?
-    raise('value parameter is required.') if self[:ensure] == :present && self[:value].nil?
+    raise('component_name parameter is required.') if self[:ensure] == :present && provider.component_name.nil?
+    raise('value parameter is required.') if self[:ensure] == :present && provider.value.nil?
   end
 
   newparam(:name, namevar: true) do

--- a/spec/unit/puppet/provider/rabbitmq_parameter/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_parameter/rabbitmqctl_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-describe Puppet::Type.type(:rabbitmq_parameter).provider(:rabbitmqctl) do
+provider_class = Puppet::Type.type(:rabbitmq_parameter).provider(:rabbitmqctl)
+describe provider_class do
   let(:resource) do
     Puppet::Type.type(:rabbitmq_parameter).new(
       name: 'documentumShovel@/',
@@ -10,75 +11,143 @@ describe Puppet::Type.type(:rabbitmq_parameter).provider(:rabbitmqctl) do
         'src-queue'  => 'my-queue',
         'dest-uri'   => 'amqp://remote-server',
         'dest-queue' => 'another-queue'
-      },
-      provider: described_class.name
+      }
     )
   end
-  let(:provider) { resource.provider }
+  let(:provider) { provider_class.new(resource) }
 
   after do
     described_class.instance_variable_set(:@parameters, nil)
   end
 
-  context 'has "@" in parameter name' do
-    let(:resource) do
-      Puppet::Type.type(:rabbitmq_parameter).new(
-        name: 'documentumShovel@/',
-        component_name: 'shovel',
-        value: {
-          'src-uri'    => 'amqp://',
-          'src-queue'  => 'my-queue',
-          'dest-uri'   => 'amqp://remote-server',
-          'dest-queue' => 'another-queue'
-        },
-        provider: described_class.name
+  describe '#prefetch' do
+    it 'exists' do
+      expect(described_class).to respond_to :prefetch
+    end
+
+    it 'matches' do
+      provider_class.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
+/
+EOT
+      provider_class.expects(:rabbitmqctl_list).with('parameters', '-p', '/').returns <<-EOT
+shovel  documentumShovel  {"src-uri":"amqp://","src-queue":"my-queue","dest-uri":"amqp://remote-server","dest-queue":"another-queue"}
+EOT
+      provider_class.prefetch('documentumShovel@/' => resource)
+    end
+  end
+
+  describe '#instances' do
+    it 'exists' do
+      expect(described_class).to respond_to :instances
+    end
+
+    it 'fail with invalid output from list' do
+      provider_class.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
+/
+EOT
+      provider.class.expects(:rabbitmqctl_list).with('parameters', '-p', '/').returns 'foobar'
+      expect { provider_class.instances }.to raise_error Puppet::Error, %r{cannot parse line from list_parameter}
+    end
+
+    it 'return no instance' do
+      provider_class.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
+/
+EOT
+      provider_class.expects(:rabbitmqctl_list).with('parameters', '-p', '/').returns ''
+      instances = provider_class.instances
+      expect(instances.size).to eq(0)
+    end
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'return one instance' do
+      provider_class.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
+/
+EOT
+      provider_class.expects(:rabbitmqctl_list).with('parameters', '-p', '/').returns <<-EOT
+shovel  documentumShovel  {"src-uri":"amqp://","src-queue":"my-queue","dest-uri":"amqp://remote-server","dest-queue":"another-queue"}
+EOT
+      instances = provider_class.instances
+      expect(instances.size).to eq(1)
+      expect(instances.map do |prov|
+        {
+          name: prov.get(:name),
+          component_name: prov.get(:component_name),
+          value: prov.get(:value)
+        }
+      end).to eq(
+        [
+          {
+            name: 'documentumShovel@/',
+            component_name: 'shovel',
+            value: {
+              'src-uri'    => 'amqp://',
+              'src-queue'  => 'my-queue',
+              'dest-uri'   => 'amqp://remote-server',
+              'dest-queue' => 'another-queue'
+            }
+          }
+        ]
       )
     end
-    let(:provider) { described_class.new(resource) }
+    # rubocop:enable RSpec/MultipleExpectations
 
-    it do
-      expect(provider.should_parameter).to eq('documentumShovel')
-    end
-
-    it do
-      expect(provider.should_vhost).to eq('/')
-    end
-  end
-
-  it 'fails with invalid output from list' do
-    provider.class.expects(:rabbitmqctl_list).with('parameters', '-p', '/').returns 'foobar'
-    expect { provider.exists? }.to raise_error(Puppet::Error, %r{cannot parse line from list_parameter})
-  end
-
-  it 'matches parameters from list' do
-    provider.class.expects(:rabbitmqctl_list).with('parameters', '-p', '/').returns <<-EOT
-shovel  documentumShovel  {"src-uri":["amqp://cl1","amqp://cl2"],"src-queue":"my-queue","dest-uri":"amqp://remote-server","dest-queue":"another-queue"}
+    # rubocop:disable RSpec/MultipleExpectations
+    it 'return multiple instances' do
+      provider_class.expects(:rabbitmqctl_list).with('vhosts').returns <<-EOT
+/
 EOT
-    expect(provider.exists?).to eq(component_name: 'shovel',
-                                   value: {
-                                     'src-uri' => ['amqp://cl1', 'amqp://cl2'],
-                                     'src-queue'  => 'my-queue',
-                                     'dest-uri'   => 'amqp://remote-server',
-                                     'dest-queue' => 'another-queue'
-                                   })
+      provider_class.expects(:rabbitmqctl_list).with('parameters', '-p', '/').returns <<-EOT
+shovel  documentumShovel1  {"src-uri":"amqp://","src-queue":"my-queue","dest-uri":"amqp://remote-server","dest-queue":"another-queue"}
+shovel  documentumShovel2  {"src-uri":["amqp://cl1","amqp://cl2"],"src-queue":"my-queue","dest-uri":"amqp://remote-server","dest-queue":"another-queue"}
+EOT
+      instances = provider_class.instances
+      expect(instances.size).to eq(2)
+      expect(instances.map do |prov|
+        {
+          name: prov.get(:name),
+          component_name: prov.get(:component_name),
+          value: prov.get(:value)
+        }
+      end).to eq(
+        [
+          {
+            name: 'documentumShovel1@/',
+            component_name: 'shovel',
+            value: {
+              'src-uri'    => 'amqp://',
+              'src-queue'  => 'my-queue',
+              'dest-uri'   => 'amqp://remote-server',
+              'dest-queue' => 'another-queue'
+            }
+          },
+          {
+            name: 'documentumShovel2@/',
+            component_name: 'shovel',
+            value: {
+              'src-uri'    => ['amqp://cl1', 'amqp://cl2'],
+              'src-queue'  => 'my-queue',
+              'dest-uri'   => 'amqp://remote-server',
+              'dest-queue' => 'another-queue'
+            }
+          }
+        ]
+      )
+    end
+    # rubocop:enable RSpec/MultipleExpectations
   end
 
-  it 'does not match an empty list' do
-    provider.class.expects(:rabbitmqctl_list).with('parameters', '-p', '/').returns ''
-    expect(provider.exists?).to eq(nil)
+  describe '#create' do
+    it 'create parameter' do
+      provider.expects(:rabbitmqctl).with('set_parameter', '-p', '/', 'shovel', 'documentumShovel',
+                                          '{"src-uri":"amqp://","src-queue":"my-queue","dest-uri":"amqp://remote-server","dest-queue":"another-queue"}')
+      provider.create
+    end
   end
 
-  it 'destroys parameter' do
-    provider.expects(:rabbitmqctl).with('clear_parameter', '-p', '/', 'shovel', 'documentumShovel')
-    provider.destroy
-  end
-
-  it 'onlies call set_parameter once' do
-    provider.expects(:rabbitmqctl).with('set_parameter',
-                                        '-p', '/',
-                                        'shovel',
-                                        'documentumShovel',
-                                        '{"src-uri":"amqp://","src-queue":"my-queue","dest-uri":"amqp://remote-server","dest-queue":"another-queue"}').once
-    provider.create
+  describe '#destroy' do
+    it 'destroy parameter' do
+      provider.expects(:rabbitmqctl).with('clear_parameter', '-p', '/', 'shovel', 'documentumShovel')
+      provider.destroy
+    end
   end
 end


### PR DESCRIPTION

#### Pull Request (PR) description

I refactored the rabbitmq_parameter provider because I need an 'instances' class method to use [puppet-purge](https://github.com/crayfishx/puppet-purge) on undeclared shovels.
