### PR TITLE
Update link to rabbitmq-autocluster

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -133,7 +133,7 @@ class { 'rabbitmq':
 This will result in the following config appended to the config file:
 {autocluster, [{consul_service, "rabbit"},{cluster_name, "rabbit"}]},
  {foo, [{bar, "baz"}]}
-(This is required for the [autocluster plugin](https://github.com/aweber/rabbitmq-autocluster)
+(This is required for the [autocluster plugin](https://github.com/rabbitmq/rabbitmq-autocluster)
 ```
 
 ##### Use RabbitMQ clustering facilities


### PR DESCRIPTION
#### Pull Request (PR) description
Replace the URL from the archived repo to the current repo of `rabbitmq-autocluster`.

If it is possible for someone to change: The repository description of this repo which is currently "RabbitMQ Puppet Module http://forge.puppetlabs.com/puppetlab…" links to the deprecated forge puppet plugin `https://forge.puppet.com/puppetlabs/rabbitmq` and should link to `https://forge.puppet.com/puppet/rabbitmq`.

#### This Pull Request (PR) fixes the following issues
None