### PR TITLE
Extend version regex for RabbitMQ 3.8

### DIFF
--- a/lib/puppet/provider/rabbitmq_cli.rb
+++ b/lib/puppet/provider/rabbitmq_cli.rb
@@ -38,13 +38,14 @@ class Puppet::Provider::RabbitmqCli < Puppet::Provider
     return @rabbitmq_version if defined? @rabbitmq_version
 
     output = rabbitmqctl('-q', 'status')
-    version = output.match(%r{\{rabbit,"RabbitMQ","([\d\.]+)"\}})
+    version = output.match(%r{RabbitMQ.*?([\d\.]+)})
     @rabbitmq_version = version[1] if version
   end
 
   def self.rabbitmqctl_list(resource, *opts)
+    version = rabbitmq_version
     list_opts =
-      if Puppet::Util::Package.versioncmp(rabbitmq_version, '3.7.9') >= 0
+      if version && Puppet::Util::Package.versioncmp(version, '3.7.9') >= 0
         ['-q', '--no-table-headers']
       else
         ['-q']


### PR DESCRIPTION
Where the output from `rabbitmqctl -q status` isn't printed as an Erlang
property list.

Without this change, you get a crash with error:

> Failed to apply catalog: undefined method `scan' for nil:NilClass