### PR TITLE
Fix no returning rabbitmq_version and add default version?

### DIFF
--- a/lib/puppet/provider/rabbitmq_cli.rb
+++ b/lib/puppet/provider/rabbitmq_cli.rb
@@ -40,6 +40,8 @@ class Puppet::Provider::RabbitmqCli < Puppet::Provider
     output = rabbitmqctl('-q', 'status')
     version = output.match(%r{RabbitMQ.*?([\d\.]+)})
     @rabbitmq_version = version[1] if version
+    return version if version
+    return '3.8.1'
   end
 
   def self.rabbitmqctl_list(resource, *opts)

--- a/lib/puppet/provider/rabbitmq_cli.rb
+++ b/lib/puppet/provider/rabbitmq_cli.rb
@@ -40,7 +40,7 @@ class Puppet::Provider::RabbitmqCli < Puppet::Provider
     output = rabbitmqctl('-q', 'status')
     version = output.match(%r{RabbitMQ.*?([\d\.]+)})
     @rabbitmq_version = version[1] if version
-    return version if version
+    return version[1] if version
     return '3.8.1'
   end
 


### PR DESCRIPTION
Signed-off-by: Justin Gross <justin@jgross.tech>

#### Pull Request (PR) description
I'm installing RabbitMQ 3.8.1 using rabbitmq module params as such:
```
management_enable          => true
package_name                    => rabbitmq-server-3.8.1
service_name                      => rabbitmq-server
use_config_file_for_plugins => true
```

I attempt to add user:
```
 rabbitmq_user { 'SOME_USER':
    password => 'SOME_PASS',
 }
```

A check is done to see what version rabbit is so to know which command line options to use when running the rabbitmq CLI (-q --no-table-headers, or just -q) to determine if the user already exists or not.

The self.rabbitmq_version function returns a version if @rabbitmq_version is declared. 

**When not declared** however it apparently tries to declare it (not a ruby developer) but then afterwords never returns it so whomever has called it is receiving a NilClass? (at least the very first time? presumably, because it sets the @rabbitmq_server?) 

The error produced is as such: 
"Failed to apply catalog: undefined method `scan' for nil:NilClass" because rabbitmq_version never returns anything unless it is globally defined (@rabbitmq_version)

This error is referenced by this issue:
https://github.com/voxpupuli/puppet-rabbitmq/issues/817

#### This Pull Request (PR) fixes the following issues