### PR TITLE
Fix env_config_path on FreeBSD

### DIFF
--- a/data/family/FreeBSD.yaml
+++ b/data/family/FreeBSD.yaml
@@ -2,5 +2,5 @@
 rabbitmq::python_package: 'python2'
 rabbitmq::rabbitmq_home: '/var/db/rabbitmq'
 rabbitmq::config_path: '/usr/local/etc/rabbitmq/rabbitmq.config'
-rabbitmq::env_config_path: '/usr/loca/etc/rabbitmq/rabbitmq-env.conf'
+rabbitmq::env_config_path: '/usr/local/etc/rabbitmq/rabbitmq-env.conf'
 rabbitmq::inetrc_config_path: '/usr/local/etc/rabbitmq/inetrc'


### PR DESCRIPTION
#### Pull Request (PR) description
When provisioning on FreeBSD the following error was occurring:

```
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /usr/loca/etc/rabbitmq/rabbitmq-env.conf20200114-5149-136fx0a.lock (file: /usr/local/etc/puppet/code/environments/feature_starling_vagrant/modules/rabbitmq/manifests/config.pp, line: 170)
Error: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /usr/loca/etc/rabbitmq/rabbitmq-env.conf20200114-5149-136fx0a.lock (file: /usr/local/etc/puppet/code/environments/feature_starling_vagrant/modules/rabbitmq/manifests/config.pp, line: 170)
Wrapped exception:
No such file or directory @ dir_s_mkdir - /usr/loca/etc/rabbitmq/rabbitmq-env.conf20200114-5149-136fx0a.lock
Error: /Stage[main]/Rabbitmq::Config/File[rabbitmq-env.config]/ensure: change from 'absent' to 'file' failed: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /usr/loca/etc/rabbitmq/rabbitmq-env.conf20200114-5149-136fx0a.lock (file: /usr/local/etc/puppet/code/environments/feature
_starling_vagrant/modules/rabbitmq/manifests/config.pp, line: 170) (corrective)
```

This is due to the env_config_path value being incorrect, instead of `/usr/loca/etc` it should be `/usr/local/etc`. This PR corrects the path.

#### This Pull Request (PR) fixes the following issues
n/a
