### PR TITLE
[fix] ownership and permissions on conf files

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -146,23 +146,23 @@ class rabbitmq::config {
 
   file { '/etc/rabbitmq':
     ensure => directory,
-    owner  => '0',
-    group  => '0',
-    mode   => '0755',
+    owner  => $rabbitmq_user,
+    group  => $rabbitmq_group,
+    mode   => '2755',
   }
 
   file { '/etc/rabbitmq/ssl':
     ensure => directory,
-    owner  => '0',
-    group  => '0',
-    mode   => '0755',
+    owner  => $rabbitmq_user,
+    group  => $rabbitmq_group,
+    mode   => '2750',
   }
 
   file { 'rabbitmq.config':
     ensure  => file,
     path    => $config_path,
     content => template($config),
-    owner   => '0',
+    owner   => $rabbitmq_user,
     group   => $rabbitmq_group,
     mode    => '0640',
   }
@@ -171,7 +171,7 @@ class rabbitmq::config {
     ensure  => file,
     path    => $env_config_path,
     content => template($env_config),
-    owner   => '0',
+    owner   => $rabbitmq_user,
     group   => $rabbitmq_group,
     mode    => '0640',
   }
@@ -180,7 +180,7 @@ class rabbitmq::config {
     ensure  => file,
     path    => $inetrc_config_path,
     content => template($inetrc_config),
-    owner   => '0',
+    owner   => $rabbitmq_user,
     group   => $rabbitmq_group,
     mode    => '0640',
   }
@@ -190,7 +190,7 @@ class rabbitmq::config {
       ensure  => file,
       path    => '/etc/rabbitmq/enabled_plugins',
       content => template('rabbitmq/enabled_plugins.erb'),
-      owner   => '0',
+      owner   => $rabbitmq_user,
       group   => $rabbitmq_group,
       mode    => '0640',
       require => File['/etc/rabbitmq'],
@@ -202,7 +202,7 @@ class rabbitmq::config {
       ensure  => file,
       path    => '/etc/rabbitmq/rabbitmqadmin.conf',
       content => template('rabbitmq/rabbitmqadmin.conf.erb'),
-      owner   => '0',
+      owner   => $rabbitmq_user,
       group   => $rabbitmq_group,
       mode    => '0640',
       require => File['/etc/rabbitmq'],

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -37,6 +37,19 @@ describe 'rabbitmq class:' do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
+
+    describe file('/etc/rabbitmq') do
+      it { is_expected.to be_directory }
+      it { is_expected.to be_owned_by 'rabbitmq' }
+      it { is_expected.to be_grouped_into 'rabbitmq' }
+    end
+
+    describe file('/etc/rabbitmq/ssl') do
+      it { is_expected.to be_directory }
+      it { is_expected.to be_owned_by 'rabbitmq' }
+      it { is_expected.to be_grouped_into 'rabbitmq' }
+      it { is_expected.not_to be_readable.by('others') }
+    end
   end
 
   context 'disable and stop service' do

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -310,7 +310,9 @@ describe 'rabbitmq' do
         it {
           is_expected.to contain_file('/etc/rabbitmq').with(
             'ensure' => 'directory',
-            'mode'   => '0755'
+            'owner'  => 'rabbitmq',
+            'group'  => 'rabbitmq',
+            'mode'   => '2755'
           )
         }
       end
@@ -318,9 +320,20 @@ describe 'rabbitmq' do
       describe 'manages configuration file correctly' do
         it {
           is_expected.to contain_file('rabbitmq.config').with(
-            'owner' => '0',
+            'owner' => 'rabbitmq',
             'group' => 'rabbitmq',
             'mode'  => '0640'
+          )
+        }
+      end
+
+      describe 'manages SSL directory correctly' do
+        it {
+          is_expected.to contain_file('/etc/rabbitmq/ssl').with(
+            'ensure' => 'directory',
+            'owner'  => 'rabbitmq',
+            'group'  => 'rabbitmq',
+            'mode'   => '2750'
           )
         }
       end


### PR DESCRIPTION
#### Pull Request (PR) description
* Set owner of config directories to rabbitmq user rather than root
* Set group of config directories explicitly to rabbitmq, and set setgid bit
* Set more restrictive permissions on the SSL directory
* Update expectations, and test file permissions in acceptance tests

This is a narrower version of #796 (@dhoppe)
This does have some security implications, since when the file is owned by root, if the application is compromised, the rabbitmq user still may not be able to modify configuration files; with these changes, it would.

I _believe_ that changing the ownership this way should be safe even on older RabbitMQ versions. However, would appreciate some eyes and / or actual testing of this, as I'm not in a good position to do extensive validations beyond the acceptance tests.

#### This Pull Request (PR) fixes the following issues
Fixes #703
Closes #796
Fixes #813