### PR TITLE
Hide user password

### DIFF
--- a/lib/puppet/type/rabbitmq_user.rb
+++ b/lib/puppet/type/rabbitmq_user.rb
@@ -46,6 +46,16 @@ DESC
     def change_to_s(_current, _desired)
       'password has been changed'
     end
+
+    # rubocop:disable Style/PredicateName
+    def is_to_s(_value)
+      '[old password redacted]'
+    end
+    # rubocop:enable Style/PredicateName
+
+    def should_to_s(_value)
+      '[new password redacted]'
+    end
   end
 
   newproperty(:admin) do


### PR DESCRIPTION
Override the is_to_s and should_to_s
methods in the puppet property to make
sure it's not shown in outputs.

Closes: #839