### PR TITLE
Don't use RABBITMQ_SERVER_ERL_ARGS

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -125,7 +125,7 @@ class rabbitmq::config {
       $proto_dist = 'inet6_tcp'
       $ssl_path = ''
     }
-    $ipv6_or_tls_env = ['SERVER', 'CTL'].reduce({}) |$memo, $item| {
+    $ipv6_or_tls_env = ['SERVER_ADDITIONAL', 'CTL'].reduce({}) |$memo, $item| {
       $orig = $_environment_variables["RABBITMQ_${item}_ERL_ARGS"]
       $munged = $orig ? {
         # already quoted, keep quoting

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1326,7 +1326,7 @@ describe 'rabbitmq' do
         context 'without other erl args' do
           it 'enables inet6 distribution' do
             is_expected.to contain_file('rabbitmq-env.config'). \
-              with_content(%r{^RABBITMQ_SERVER_ERL_ARGS="-proto_dist inet6_tcp"$}). \
+              with_content(%r{^RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="-proto_dist inet6_tcp"$}). \
               with_content(%r{^RABBITMQ_CTL_ERL_ARGS="-proto_dist inet6_tcp"$})
           end
         end
@@ -1334,13 +1334,13 @@ describe 'rabbitmq' do
         context 'with other quoted erl args' do
           let(:params) do
             { ipv6: true,
-              environment_variables: { 'RABBITMQ_SERVER_ERL_ARGS' => '"some quoted args"',
+              environment_variables: { 'RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS' => '"some quoted args"',
                                        'RABBITMQ_CTL_ERL_ARGS'    => '"other quoted args"' } }
           end
 
           it 'enables inet6 distribution and quote properly' do
             is_expected.to contain_file('rabbitmq-env.config'). \
-              with_content(%r{^RABBITMQ_SERVER_ERL_ARGS="some quoted args -proto_dist inet6_tcp"$}). \
+              with_content(%r{^RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="some quoted args -proto_dist inet6_tcp"$}). \
               with_content(%r{^RABBITMQ_CTL_ERL_ARGS="other quoted args -proto_dist inet6_tcp"$})
           end
         end
@@ -1348,13 +1348,13 @@ describe 'rabbitmq' do
         context 'with other unquoted erl args' do
           let(:params) do
             { ipv6: true,
-              environment_variables: { 'RABBITMQ_SERVER_ERL_ARGS' => 'foo',
+              environment_variables: { 'RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS' => 'foo',
                                        'RABBITMQ_CTL_ERL_ARGS'    => 'bar' } }
           end
 
           it 'enables inet6 distribution and quote properly' do
             is_expected.to contain_file('rabbitmq-env.config'). \
-              with_content(%r{^RABBITMQ_SERVER_ERL_ARGS="foo -proto_dist inet6_tcp"$}). \
+              with_content(%r{^RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="foo -proto_dist inet6_tcp"$}). \
               with_content(%r{^RABBITMQ_CTL_ERL_ARGS="bar -proto_dist inet6_tcp"$})
           end
         end
@@ -1367,7 +1367,7 @@ describe 'rabbitmq' do
 
           it 'enables inet6 distribution' do
             is_expected.to contain_file('rabbitmq-env.config'). \
-              with_content(%r{^RABBITMQ_SERVER_ERL_ARGS=" -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin -proto_dist inet6_tls"$}). \
+              with_content(%r{^RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=" -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin -proto_dist inet6_tls"$}). \
               with_content(%r{^RABBITMQ_CTL_ERL_ARGS=" -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin -proto_dist inet6_tls"$})
           end
         end
@@ -1376,13 +1376,13 @@ describe 'rabbitmq' do
           let(:params) do
             { ipv6: true,
               ssl_erl_dist: true,
-              environment_variables: { 'RABBITMQ_SERVER_ERL_ARGS' => '"some quoted args"',
+              environment_variables: { 'RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS' => '"some quoted args"',
                                        'RABBITMQ_CTL_ERL_ARGS'    => '"other quoted args"' } }
           end
 
           it 'enables inet6 distribution and quote properly' do
             is_expected.to contain_file('rabbitmq-env.config'). \
-              with_content(%r{^RABBITMQ_SERVER_ERL_ARGS="some quoted args -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin  -proto_dist inet6_tls"$}). \
+              with_content(%r{^RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="some quoted args -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin  -proto_dist inet6_tls"$}). \
               with_content(%r{^RABBITMQ_CTL_ERL_ARGS="other quoted args -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin  -proto_dist inet6_tls"$})
           end
         end
@@ -1391,13 +1391,13 @@ describe 'rabbitmq' do
           let(:params) do
             { ipv6: true,
               ssl_erl_dist: true,
-              environment_variables: { 'RABBITMQ_SERVER_ERL_ARGS' => 'foo',
+              environment_variables: { 'RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS' => 'foo',
                                        'RABBITMQ_CTL_ERL_ARGS'    => 'bar' } }
           end
 
           it 'enables inet6 distribution and quote properly' do
             is_expected.to contain_file('rabbitmq-env.config'). \
-              with_content(%r{^RABBITMQ_SERVER_ERL_ARGS="foo -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin  -proto_dist inet6_tls"$}). \
+              with_content(%r{^RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS="foo -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin  -proto_dist inet6_tls"$}). \
               with_content(%r{^RABBITMQ_CTL_ERL_ARGS="bar -pa /usr/lib64/erlang/lib/ssl-7.3.3.1/ebin  -proto_dist inet6_tls"$})
           end
         end


### PR DESCRIPTION
Instead, use RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS

Quoted from https://www.rabbitmq.com/configure.html#supported-environment-variables:

"
RABBITMQ_SERVER_ERL_ARGS - Standard parameters for the erl command
used when invoking the RabbitMQ Server. This should be overridden for
debugging purposes only. Overriding this variable replaces the default
value.
"

The default value of RABBITMQ_SERVER_ERL_ARGS on *nix is:

+P 1048576 +t 5000000 +stbt db +zdbbl 128000

So currently, if ipv6/tls is enabled, and the caller does not provide
its own default value of RABBITMQ_SERVER_ERL_ARGS, it will end up
overwriting those server defaults.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
