### PR TITLE
[WIP] Add CentOS/RHEL 8 Support

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,3 @@
+# Vox Pupuli Security Policy
+
+Our vulnerabilities reporting process is at https://voxpupuli.org/security/

--- a/.sync.yml
+++ b/.sync.yml
@@ -8,6 +8,8 @@
     - set: ubuntu1804-64
     - set: centos6-64
     - set: centos7-64
+    # RabbitMQ fails to start via systemd unless /sys/fs/cgroup is mounted through from to base host
+    - set: centos8-64{mount_folders={sysfscgroup={host_path=/sys/fs/cgroup\,container_path=/sys/fs/cgroup\,opts=ro}}}
 appveyor.yml:
   delete: true
 spec/spec_helper.rb:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+os: linux
 dist: bionic
 language: ruby
 cache: bundler
@@ -7,7 +8,7 @@ before_install:
   - bundle --version
 script:
   - 'bundle exec rake $CHECK'
-matrix:
+jobs:
   fast_finish: true
   include:
   - rvm: 2.4.4
@@ -70,6 +71,14 @@ matrix:
     bundler_args: --without development release
     env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=centos7-64 CHECK=beaker
     services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos8-64{mount_folders={sysfscgroup={host_path=/sys/fs/cgroup\,container_path=/sys/fs/cgroup\,opts=ro}}} CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=centos8-64{mount_folders={sysfscgroup={host_path=/sys/fs/cgroup\,container_path=/sys/fs/cgroup\,opts=ro}}} CHECK=beaker
+    services: docker
 branches:
   only:
   - master
@@ -84,7 +93,7 @@ notifications:
       - "chat.freenode.org#voxpupuli-notifications"
 deploy:
   provider: puppetforge
-  user: puppet
+  username: puppet
   password:
     secure: "Ojc0h2mbt9Y+eCyiKD+x1iYNONOP27Me63hjo9jo2v1bSs3aiM7djlcpz/sG+jRJ7JQoUyaGzHSn+gvxwWqdagFfFgDmipMKD0OXQinq7upRaG2hR+akKo0jllq9zLjJGBDoxurioKfOzPGlt2bX3UYY5KyeJ3AIM4dwCGVtSh4="
   on:

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'voxpupuli-test', '>= 1.0.0',  :require => false
+  gem 'voxpupuli-test', '>= 1.4.0',  :require => false
   gem 'coveralls',                   :require => false
   gem 'simplecov-console',           :require => false
 end

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 4. [Usage - Configuration options and additional functionality](#usage)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
 5. [Limitations - OS compatibility, etc.](#limitations)
-   * [RedHat module dependencies](#redhat-module-dependecies)
 6. [Development - Guide for contributing to the module](#development)
 
 ## Overview
@@ -53,6 +52,38 @@ You can view example usage in [REFERENCE](REFERENCE.md).
 ## Reference
 
 See [REFERENCE](REFERENCE.md).
+
+## Limitations
+
+If running CentOS/RHEL, ensure the `epel` repo, or another repo containing a
+suitable Erlang version, is present. On Debian systems, puppetlabs/apt
+(>=2.0.0 < 5.0.0) is a soft dependency.
+
+To have a suitable erlang version installed on RedHat and Debian systems,
+you have to install another puppet module from https://forge.puppetlabs.com/garethr/erlang with:
+
+    puppet module install garethr-erlang
+
+This module handles the packages for erlang.
+To use the module, add the following snippet to your site.pp or an appropriate profile class:
+
+For RedHat systems:
+```puppet
+include 'erlang'
+class { 'erlang':
+  epel_enable => true,
+}
+```
+
+For Debian systems:
+```puppet
+include 'erlang'
+package { 'erlang-base':
+  ensure => 'latest',
+}
+```
+
+This module also depends on voxpupuli/archive to install rabbitmqadmin.
 
 ## Development
 

--- a/metadata.json
+++ b/metadata.json
@@ -12,14 +12,16 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -185,6 +185,19 @@ describe 'rabbitmq' do
 
         context 'with service_manage set to true' do
           let(:params) { { admin_enable: true, management_ip_address: '1.1.1.1', service_manage: true } }
+          let(:python_package) do
+            if %w[Debian SUSE].include?(facts[:os]['family'])
+              'python'
+            elsif %w[FreeBSD OpenBSD].include?(facts[:os]['family'])
+              'python2'
+            elsif facts[:os]['family'] == 'RedHat'
+              if facts[:os]['release']['major'] == '8'
+                'python3'
+              else
+                'python'
+              end
+            end
+          end
 
           context 'with rabbitmqadmin_package set to blub' do
             let(:params) { { rabbitmqadmin_package: 'blub' } }
@@ -206,12 +219,7 @@ describe 'rabbitmq' do
               is_expected.to contain_archive('rabbitmqadmin').with_source('http://1.1.1.1:15672/cli/rabbitmqadmin')
             end
           end
-          if %w[RedHat Debian SUSE].include?(facts[:os]['family'])
-            it { is_expected.to contain_package('python') }
-          end
-          if %w[FreeBSD OpenBSD].include?(facts[:os]['family'])
-            it { is_expected.to contain_package('python2') }
-          end
+          it { is_expected.to contain_package(python_package) if python_package }
         end
         context 'with manage_python false' do
           let(:params) { { manage_python: false } }
@@ -220,6 +228,7 @@ describe 'rabbitmq' do
             is_expected.to contain_class('rabbitmq::install::rabbitmqadmin')
             is_expected.not_to contain_package('python')
             is_expected.not_to contain_package('python2')
+            is_expected.not_to contain_package('python3')
           end
         end
 


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds support for installing RabbitMQ on CentOS 8 / RHEL 8.
Also added back into the README information to the end-user about the need to use an external `erlang` module on RHEL systems.

#### This Pull Request (PR) fixes the following issues
Fixes #816 

Closes #826 
