### PR TITLE
Change repos_ensure default from false to true

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -29,7 +29,7 @@ rabbitmq::package_gpg_key: ~
 rabbitmq::package_name: 'rabbitmq'
 rabbitmq::package_source: ~
 rabbitmq::package_provider: ~
-rabbitmq::repos_ensure: false
+rabbitmq::repos_ensure: true
 rabbitmq::manage_python: true
 rabbitmq::python_package: 'python'
 rabbitmq::rabbitmq_user: 'rabbitmq'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -202,7 +202,7 @@
 #   Name of the package required by rabbitmqadmin.
 # @param repos_ensure
 #   Ensure that a repo with the official (and newer) RabbitMQ package is configured, along with its signing key.
-#   Defaults to false (use system packages). This does not ensure that soft dependencies (like EPEL on RHEL systems) are present.
+#   Defaults to true (use RabbitMQ repos). This does not ensure that soft dependencies (like EPEL on RHEL systems) are present.
 #   It also does not solve the erlang dependency.  See https://www.rabbitmq.com/which-erlang.html for a good breakdown of the
 #   different ways of handling the erlang deps.  See also https://github.com/voxpupuli/puppet-rabbitmq/issues/788
 # @param service_ensure
@@ -329,7 +329,7 @@ class rabbitmq(
   Variant[String, Array] $package_name                                                             = 'rabbitmq',
   Optional[String] $package_source                                                                 = undef,
   Optional[String] $package_provider                                                               = undef,
-  Boolean $repos_ensure                                                                            = false,
+  Boolean $repos_ensure                                                                            = true,
   Boolean $manage_python                                                                           = true,
   String $python_package                                                                           = 'python',
   String $rabbitmq_user                                                                            = 'rabbitmq',

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -27,21 +27,6 @@ describe 'rabbitmq' do
       end
 
       context 'with default params' do
-        it { is_expected.not_to contain_class('rabbitmq::repo::apt') }
-        it { is_expected.not_to contain_apt__source('rabbitmq') }
-        it { is_expected.not_to contain_class('rabbitmq::repo::rhel') }
-        it { is_expected.not_to contain_yumrepo('rabbitmq') }
-      end
-
-      context 'with service_restart => false' do
-        let(:params) { { service_restart: false } }
-
-        it { is_expected.not_to contain_class('rabbitmq::config').that_notifies('Class[rabbitmq::service]') }
-      end
-
-      context 'with repos_ensure => true' do
-        let(:params) { { repos_ensure: true } }
-
         if facts[:os]['family'] == 'Debian'
           it 'includes rabbitmq::repo::apt' do
             is_expected.to contain_class('rabbitmq::repo::apt').
@@ -74,6 +59,21 @@ describe 'rabbitmq' do
           it { is_expected.not_to contain_class('rabbitmq::repo::rhel') }
           it { is_expected.not_to contain_yumrepo('rabbitmq') }
         end
+      end
+
+      context 'with service_restart => false' do
+        let(:params) { { service_restart: false } }
+
+        it { is_expected.not_to contain_class('rabbitmq::config').that_notifies('Class[rabbitmq::service]') }
+      end
+
+      context 'with repos_ensure => false' do
+        let(:params) { { repos_ensure: false } }
+
+        it { is_expected.not_to contain_class('rabbitmq::repo::apt') }
+        it { is_expected.not_to contain_apt__source('rabbitmq') }
+        it { is_expected.not_to contain_class('rabbitmq::repo::rhel') }
+        it { is_expected.not_to contain_yumrepo('rabbitmq') }
       end
 
       context 'with no pin', if: facts[:os]['family'] == 'Debian' do


### PR DESCRIPTION
#### Pull Request (PR) description
As part of the work i was doing to enable CentOS/RHEL 8 support in #842 i ran into an issue where EPEL no longer ships RabbitMQ packages. In that PR i had made some hacky fixes to enable the RabbitMQ repos, via the `repos_ensure` parameter, by default on that OS. After some discussions it was decided that we should instead, simply change the default value of `repos_ensure` to `true` on all OSes.

**Note: This is a breaking change!**