### PR TITLE
Remove facter rabbitmq_nodename error message

### DIFF
--- a/lib/facter/rabbitmq_nodename.rb
+++ b/lib/facter/rabbitmq_nodename.rb
@@ -2,7 +2,11 @@ Facter.add(:rabbitmq_nodename) do
   setcode do
     if Facter::Util::Resolution.which('rabbitmqctl')
       rabbitmq_nodename = Facter::Core::Execution.execute('rabbitmqctl status 2>&1')
-      %r{^Status of node '?([\w\.\-]+@[\w\.\-]+)'?}.match(rabbitmq_nodename)[1]
+      begin
+        %r{^Status of node '?([\w\.\-]+@[\w\.\-]+)'?}.match(rabbitmq_nodename)[1]
+      rescue
+        Facter.debug("Error: rabbitmq_nodename facter failed. Output was #{rabbitmq_nodename}")
+      end
     end
   end
 end


### PR DESCRIPTION
Currently when facter checks for rabbitmq_nodename and rabbitmq
is not available due to a number of reasons. We get the following
facter error displayed:
Error: Facter: error while resolving custom fact "rabbitmq_nodename": undefined method `[]' for nil:NilClass

Since facter errors are non fatal anyway let's be a little friendlier.

Before this change:
$ puppet apply foo.pp
Error: Facter: error while resolving custom fact "rabbitmq_nodename": undefined method `[]' for nil:NilClass
Notice: Compiled catalog for messaging-0.redhat.local in environment production in 0.02 seconds
Notice: foo
Notice: /Stage[main]/Main/Notify[foo]/message: defined 'message' as 'foo'

After this change:
$ puppet apply foo.pp
Notice: Compiled catalog for messaging-0.redhat.local in environment production in 0.02 seconds
Notice: foo
Notice: /Stage[main]/Main/Notify[foo]/message: defined 'message' as 'foo'

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
