### PR TITLE
Escape double quotes in password during comparison

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -69,7 +69,7 @@ Puppet::Type.type(:rabbitmq_user).provide(
     check_access_control = [
       'rabbit_access_control:check_user_pass_login(',
       %[list_to_binary("#{@resource[:name]}"), ],
-      %[list_to_binary("#{password}")).]
+      %[list_to_binary("#{password.to_s.gsub('"', '\\"')}")).]
     ]
 
     response = rabbitmqctl('eval', check_access_control.join)


### PR DESCRIPTION
#### Pull Request (PR) description
Escape double quotes during password comparison to fix bash unterminated string error

#### This Pull Request (PR) fixes the following issues
Fixes #850 