### PR TITLE
Ignore SELinux defaults for systemd on RHEL based

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -231,9 +231,10 @@ class rabbitmq::config {
 
   if $facts['systemd'] { # systemd fact provided by systemd module
     systemd::service_limits { "${service_name}.service":
-      limits          => { 'LimitNOFILE' => $file_limit },
+      selinux_ignore_defaults => ($facts['os']['family'] == 'RedHat'),
+      limits                  => { 'LimitNOFILE' => $file_limit },
       # The service will be notified when config changes
-      restart_service => false,
+      restart_service         => false,
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -69,7 +69,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.1.0 < 3.0.0"
+      "version_requirement": ">= 2.10.0 < 3.0.0"
     }
   ],
   "tags": [

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -148,8 +148,11 @@ describe 'rabbitmq' do
           end
 
           if facts[:systemd]
+            selinux_ignore_defaults = facts[:os]['family'] == 'RedHat'
+
             it do
               is_expected.to contain_systemd__service_limits("#{name}.service").
+                with_selinux_ignore_defaults(selinux_ignore_defaults).
                 with_limits('LimitNOFILE' => value).
                 with_restart_service(false)
             end


### PR DESCRIPTION
It makes sure it's idempotent on RHEL based, needs an increase in systemd dependency to a minimum
versions of 2.10.0 to include the changes there.

Fixes: #836 
