### PR TITLE
remove invalid cluster_node_type 'disk'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -302,7 +302,7 @@ class rabbitmq (
   Boolean $admin_enable                                                                            = true,
   Boolean $management_enable                                                                       = false,
   Boolean $use_config_file_for_plugins                                                             = false,
-  Enum['ram', 'disk', 'disc'] $cluster_node_type                                                   = 'disc',
+  Enum['ram', 'disc'] $cluster_node_type                                                           = 'disc',
   Array $cluster_nodes                                                                             = [],
   String $config                                                                                   = 'rabbitmq/rabbitmq.config.erb',
   Boolean $config_cluster                                                                          = false,


### PR DESCRIPTION
#### Pull Request (PR) description

Hi,

I would like to propose this little change, as to what I was able to find out is not a valid option, and i'm not sure if it ever was.

The `disk` option was added in module version `5.0.0 (2014-12-22)`
See commit: https://github.com/voxpupuli/puppet-rabbitmq/commit/6c67f33d08f68e2cda898d0161f5820cd9f32c0e
and Puppetlabs ticket: https://tickets.puppetlabs.com/browse/MODULES-1186

The part on the clustering page referenced there is probably this:
https://www.rabbitmq.com/clustering.html#cluster-node-types

```
A node can be a disk node or a RAM node. (Note: disk and disc are used interchangeably).
RAM nodes store internal database tables in RAM only. This does not include messages, 
message store indices, queue indices and other node state.
```
Though it doesn't mention that the **parameters** can be used interchangeably. And from what i've seen in the rest of the rabbitmq documentation and source code, i don't think this was ever a valid option.

##### Results of my research
* rabbitmqctl man page says valid options are `disc` and `ram`
  * https://www.rabbitmq.com/rabbitmqctl.8.html#change_cluster_node_type
* No change in the last 4 years there.
  * https://github.com/rabbitmq/rabbitmq-server/blame/master/docs/rabbitmqctl.8#L289
* erlang spec saying only valid options are `disc` and `ram`
  * https://github.com/rabbitmq/rabbitmq-server/blob/master/src/rabbit_mnesia.erl#L1077
  * No change in the last 6 years there.

Reason I found this out was that i just spent 2 days debugging why the cluster wouldn't form until i realized that i had set the cluster_node_type to `disk`. Though the first node starts correctly, probably because the node type is ignored as in any cluster must exist at least one `disc` node. So the first node was running fine, but none of the other nodes were able to join.

#### This Pull Request (PR) fixes the following issues
cluster_node_type 'disk' is not a valid option.
