### PR TITLE
Add new parameter autoconvert for rabbitmq_parameter

### DIFF
--- a/lib/puppet/type/rabbitmq_parameter.rb
+++ b/lib/puppet/type/rabbitmq_parameter.rb
@@ -19,6 +19,18 @@ Type for managing rabbitmq parameters
          'expires' => '360000',
      },
    }
+   rabbitmq_parameter { 'documentumShovelNoMunging@/':
+     component_name => '',
+     value          => {
+         'src-uri'    => 'amqp://',
+         'src-exchange'  => 'my-exchange',
+         'src-exchange-key' => '6',
+         'src-queue'  => 'my-queue',
+         'dest-uri'   => 'amqp://remote-server',
+         'dest-exchange' => 'another-exchange',
+     },
+     autoconvert   => false,
+   }
 DESC
 
   ensurable do
@@ -50,6 +62,12 @@ DESC
     end
   end
 
+  newparam(:autoconvert) do
+    desc 'whether numeric strings from `value` should be converted to int automatically'
+    newvalues(:true, :false)
+    defaultto(:true)
+  end
+
   newproperty(:value) do
     desc 'A hash of values to use with the component name you are setting'
     validate do |value|
@@ -78,6 +96,7 @@ DESC
   end
 
   def munge_value(value)
+    return value if self[:autoconvert] == :false
     value.each do |k, v|
       value[k] = v.to_i if v =~ %r{\A[-+]?[0-9]+\z}
     end

--- a/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
@@ -82,4 +82,12 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
     parameter[:value] = value
     expect(parameter[:value]['myparameter']).to eq(1_800_000)
   end
+
+  it 'does not convert numeric string to integer when autoconvert is set to false' do
+    parameter[:autoconvert] = false
+    value = { 'myparameter' => '1800000' }
+    parameter[:value] = value
+    expect(parameter[:value]['myparameter']).to eq('1800000')
+    expect(parameter[:value]['myparameter']).to be_kind_of(String)
+  end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Add a new parameter `autoconvert` for `rabbitmq_parameter` to allow users to disable auto type conversion from numeric strings to integers if needed.

#### This Pull Request (PR) fixes the following issues
We have several `x-content-hash` exchanges which use a numeric string as the routing key. Due to the `munge_value` [implementation](https://github.com/voxpupuli/puppet-rabbitmq/blob/2bcfb0e/lib/puppet/type/rabbitmq_parameter.rb#L82), the routing key would be converted to an integer. 

As a result, a valid payload to create a shovel as below
```json
{
  "component": "shovel",
  "vhost": "foo",
  "name": "test",
  "value": {
    "src-uri": "amqps://user:[redacted]@rabbit.service.consul:5671/foo",
    "src-exchange-key": "5",
    "dest-uri": "amqps://user:[redacted]@rabbit.service.consul:5671/bar",
    "dest-exchange-key": "5",
    "ack-mode": "on-confirm",
    "src-protocol": "amqp091",
    "dest-protocol": "amqp091",
    "src-exchange": "indexer_document_requests",
    "src-delete-after": "never",
    "dest-exchange": "indexer_document_requests",
    "dest-add-forward-headers": false
  }
}
```
will be converted to 
```json
{
  "component": "shovel",
  "vhost": "foo",
  "name": "test",
  "value": {
    "src-uri": "amqps://user:[redacted]@rabbit.service.consul:5671/foo",
    "src-exchange-key": 5,
    "dest-uri": "amqps://user:[redacted]@rabbit.service.consul:5671/bar",
    "dest-exchange-key": 5,
    "ack-mode": "on-confirm",
    "src-protocol": "amqp091",
    "dest-protocol": "amqp091",
    "src-exchange": "indexer_document_requests",
    "src-delete-after": "never",
    "dest-exchange": "indexer_document_requests",
    "dest-add-forward-headers": false
  }
}
```
Because RabbitMQ doesn't accept exchange keys to be integers, it'll throw out validation errors:
```
Error:
Validation failed
dest-exchange-key should be binary, actually was 5
src-exchange-key should be binary, actually was 5
```

This PR would allow the auto type conversion to be disabled and therefore numeric strings to be included in the RabbitMQ parameter payload if needed. The users would be responsible to ensure the right date types are used if `autoconvert` is set to `false`.