### PR TITLE
Ensure :autoconvert is initialized before :value for rabbitmq_parameter

### DIFF
--- a/lib/puppet/type/rabbitmq_parameter.rb
+++ b/lib/puppet/type/rabbitmq_parameter.rb
@@ -82,6 +82,12 @@ DESC
     [self[:name].split('@')[1]]
   end
 
+  def set_parameters(hash) # rubocop:disable Style/AccessorMethodName
+    # Hack to ensure :autoconvert is initialized before :value
+    self[:autoconvert] = hash[:autoconvert] if hash.key?(:autoconvert)
+    super
+  end
+
   def validate_component_name(value)
     raise ArgumentError, 'component_name must be defined' if value.empty?
   end
@@ -96,7 +102,7 @@ DESC
   end
 
   def munge_value(value)
-    return value if self[:autoconvert] == :false
+    return value if value(:autoconvert) == :false
     value.each do |k, v|
       value[k] = v.to_i if v =~ %r{\A[-+]?[0-9]+\z}
     end

--- a/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
@@ -83,11 +83,19 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
     expect(parameter[:value]['myparameter']).to eq(1_800_000)
   end
 
-  it 'does not convert numeric string to integer when autoconvert is set to false' do
-    parameter[:autoconvert] = false
-    value = { 'myparameter' => '1800000' }
-    parameter[:value] = value
-    expect(parameter[:value]['myparameter']).to eq('1800000')
-    expect(parameter[:value]['myparameter']).to be_kind_of(String)
+  context 'autoconvert is set to false' do
+    let(:parameter) do
+      Puppet::Type.type(:rabbitmq_parameter).new(
+        name: 'documentumShovel@/',
+        component_name: 'shovel',
+        autoconvert: false,
+        value: { 'myparameter' => '1800000' }
+      )
+    end
+
+    it 'does not convert numeric string to integer' do
+      expect(parameter[:value]['myparameter']).to eq('1800000')
+      expect(parameter[:value]['myparameter']).to be_kind_of(String)
+    end
   end
 end


### PR DESCRIPTION
## Pull Request (PR) description

Make sure `:autoconvert` is set before `:value` for `rabbitmq_parameter` since `:value` depends on `:autoconvert`.

This was done by overriding `set_parameters` for the type. It's hacky but there doesn't seem to be a better way to put put a parameter before a property since puppet lets `properties` take precedence over `parameters` -  https://github.com/puppetlabs/puppet/blob/7ef0811/lib/puppet/type.rb#L118-L124 . 

Note: my first attempt was to change `:autoconvert` to a property but that doesn't really fit. Because we don't store its value anywhere, having `:autoconvert` as a property will lead puppet to believe that there is always a change to the `:autoconvert`
```
  Notice: /Stage[main]/Main/Rabbitmq_parameter[documentumFed@fedhost]/autoconvert: defined 'autoconvert' as 'true'
```


#### This Pull Request (PR) fixes the following issues
My previous PR #865 has a test case where `parameter[:autoconvert] = false` is set explicitly before `value` , so it passes as expected. However, it fails to check the case where a `rabbitmq_parameter` is defined with a hash. e.g.

```puppet
rabbitmq_parameter { 'documentumShovel@/':
  component_name => 'shovel',
  autoconvert    => false,
  value          => { 'myparameter' => '1800000' },
}
```
Both cases are supported with this PR.

Please review. Thanks!
