### PR TITLE
Release 10.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
-## [v10.2.0](https://github.com/voxpupuli/puppet-rabbitmq/tree/v10.2.0) (2020-10-12)
+## [v10.3.0](https://github.com/voxpupuli/puppet-rabbitmq/tree/v10.3.0) (2020-12-01)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-rabbitmq/compare/v10.2.0...v10.3.0)
+
+**Implemented enhancements:**
+
+- Add new parameter autoconvert for rabbitmq\_parameter [\#865](https://github.com/voxpupuli/puppet-rabbitmq/pull/865) ([joec4i](https://github.com/joec4i))
+
+**Fixed bugs:**
+
+- Ensure :autoconvert is initialized before :value for rabbitmq\_parameter [\#867](https://github.com/voxpupuli/puppet-rabbitmq/pull/867) ([joec4i](https://github.com/joec4i))
+
+## [v10.2.0](https://github.com/voxpupuli/puppet-rabbitmq/tree/v10.2.0) (2020-10-13)
 
 [Full Changelog](https://github.com/voxpupuli/puppet-rabbitmq/compare/v10.1.2...v10.2.0)
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1289,6 +1289,18 @@ rabbitmq_parameter { 'documentumFed@/':
       'expires' => '360000',
   },
 }
+rabbitmq_parameter { 'documentumShovelNoMunging@/':
+  component_name => '',
+  value          => {
+      'src-uri'    => 'amqp://',
+      'src-exchange'  => 'my-exchange',
+      'src-exchange-key' => '6',
+      'src-queue'  => 'my-queue',
+      'dest-uri'   => 'amqp://remote-server',
+      'dest-exchange' => 'another-exchange',
+  },
+  autoconvert   => false,
+}
 ```
 
 #### Properties
@@ -1322,6 +1334,14 @@ Valid values: %r{^\S+@\S+$}
 namevar
 
 combination of name@vhost to set parameter for
+
+##### `autoconvert`
+
+Valid values: `true`, `false`
+
+whether numeric strings from `value` should be converted to int automatically
+
+Default value: `true`
 
 ### rabbitmq_plugin
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-rabbitmq",
-  "version": "10.2.1-rc0",
+  "version": "10.3.0",
   "author": "voxpupuli",
   "summary": "Installs, configures, and manages RabbitMQ.",
   "license": "Apache-2.0",


### PR DESCRIPTION
#### Pull Request (PR) description
Release 10.3.0:

* Add new parameter autoconvert for rabbitmq_parameter (@joec4i) (#865)
* Ensure :autoconvert is initialized before :value for rabbitmq_parameter (@joec4i) (#867)
* modulesync 3.1.0 (@bastelfreak) (#864)
* modulesync 4.0.0 (@bastelfreak) (#866)
