### PR TITLE
Add optional variables to support SSL CRL check configuration

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -65,9 +65,6 @@ rabbitmq::ssl_reuse_sessions: true
 rabbitmq::ssl_honor_cipher_order: true
 rabbitmq::ssl_dhfile: ~
 rabbitmq::ssl_ciphers: []
-rabbitmq::ssl_crl_check: 'false'
-rabbitmq::ssl_crl_cache_hash_dir: ~
-rabbitmq::ssl_crl_cache_http_timeout: ~
 rabbitmq::stomp_ensure: false
 rabbitmq::ldap_auth: false
 rabbitmq::ldap_server: 'ldap'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -65,6 +65,9 @@ rabbitmq::ssl_reuse_sessions: true
 rabbitmq::ssl_honor_cipher_order: true
 rabbitmq::ssl_dhfile: ~
 rabbitmq::ssl_ciphers: []
+rabbitmq::ssl_crl_check: 'false'
+rabbitmq::ssl_crl_cache_hash_dir: ~
+rabbitmq::ssl_crl_cache_http_timeout: ~
 rabbitmq::stomp_ensure: false
 rabbitmq::ldap_auth: false
 rabbitmq::ldap_server: 'ldap'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -60,6 +60,9 @@ class rabbitmq::config {
   $ssl_dhfile                          = $rabbitmq::ssl_dhfile
   $ssl_versions                        = $rabbitmq::ssl_versions
   $ssl_ciphers                         = $rabbitmq::ssl_ciphers
+  $ssl_crl_check                       = $rabbitmq::ssl_crl_check
+  $ssl_crl_cache_hash_dir              = $rabbitmq::ssl_crl_cache_hash_dir
+  $ssl_crl_cache_http_timeout          = $rabbitmq::ssl_crl_cache_http_timeout
   $stomp_port                          = $rabbitmq::stomp_port
   $stomp_ssl_only                      = $rabbitmq::stomp_ssl_only
   $ldap_auth                           = $rabbitmq::ldap_auth

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -378,7 +378,7 @@ class rabbitmq (
   Optional[Stdlib::Absolutepath] $ssl_dhfile                                                       = undef,
   Array $ssl_ciphers                                                                               = [],
   Enum['true','false','peer','best_effort'] $ssl_crl_check                                         = 'false',
-  Optional[String] $ssl_crl_cache_hash_dir                                                         = undef,
+  Optional[Stdlib::Absolutepath] $ssl_crl_cache_hash_dir                                                         = undef,
   Optional[Integer] $ssl_crl_cache_http_timeout                                                    = undef,
   Boolean $stomp_ensure                                                                            = false,
   Boolean $ldap_auth                                                                               = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -269,6 +269,15 @@
 #   Functionality can be tested with cipherscan or similar tool: https://github.com/mozilla/cipherscan
 #   * Erlang style: `['ecdhe_rsa,aes_256_cbc,sha', 'dhe_rsa,aes_256_cbc,sha']`
 #   * OpenSSL style: `['ECDHE-RSA-AES256-SHA', 'DHE-RSA-AES256-SHA']`
+# @param ssl_crl_check
+#   Perform CRL (Certificate Revocation List) verification
+#   Please see the [Erlang SSL](https://erlang.org/doc/man/ssl.html#type-crl_check) module documentation for more information.
+# @param ssl_crl_cache_hash_dir
+#   This setting makes use of a directory where CRLs are stored in files named by the hash of the issuer name.
+#   Please see the [Erlang SSL](https://erlang.org/doc/man/ssl.html#type-crl_cache_opts) module documentation for more information.
+# @param ssl_crl_cache_http_timeout
+#   This setting enables use of internal CRLs cache and sets HTTP timeout interval on fetching CRLs from distributino URLs defined inside certificate.
+#   Please see the [Erlang SSL](https://erlang.org/doc/man/ssl.html#type-crl_cache_opts) module documentation for more information.
 # @param stomp_port
 #   The port to use for Stomp.
 # @param stomp_ssl_only
@@ -368,6 +377,9 @@ class rabbitmq (
   Boolean $ssl_honor_cipher_order                                                                  = true,
   Optional[Stdlib::Absolutepath] $ssl_dhfile                                                       = undef,
   Array $ssl_ciphers                                                                               = [],
+  Enum['true','false','peer','best_effort'] $ssl_crl_check                                         = 'false',
+  Optional[String] $ssl_crl_cache_hash_dir                                                         = undef,
+  Optional[Integer] $ssl_crl_cache_http_timeout                                                    = undef,
   Boolean $stomp_ensure                                                                            = false,
   Boolean $ldap_auth                                                                               = false,
   Variant[String[1],Array[String[1]]] $ldap_server                                                 = 'ldap',
@@ -410,6 +422,30 @@ class rabbitmq (
   if $ssl_versions {
     unless $ssl {
       fail('$ssl_versions requires that $ssl => true')
+    }
+  }
+
+  if $ssl_crl_check != "false" {
+    unless $ssl {
+      fail('$ssl_crl_check requires that $ssl => true')
+    }
+  }
+
+  if $ssl_crl_cache_hash_dir {
+    unless $ssl {
+      fail('$ssl_crl_cache_hash_dir requires that $ssl => true')
+    }
+    if $ssl_crl_check == "false" {
+      fail('$ssl_crl_cache_http_timeout requires that $ssl_crl_check => true|peer|best_effort')
+    }
+  }
+
+  if $ssl_crl_cache_http_timeout {
+    unless $ssl {
+      fail('$ssl_crl_cache_http_timeout requires that $ssl => true')
+    }
+    if $ssl_crl_check == "false" {
+      fail('$ssl_crl_cache_http_timeout requires that $ssl_crl_check => true|peer|best_effort')
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -425,7 +425,7 @@ class rabbitmq (
     }
   }
 
-  if $ssl_crl_check != "false" {
+  if $ssl_crl_check != 'false' {
     unless $ssl {
       fail('$ssl_crl_check requires that $ssl => true')
     }
@@ -435,7 +435,7 @@ class rabbitmq (
     unless $ssl {
       fail('$ssl_crl_cache_hash_dir requires that $ssl => true')
     }
-    if $ssl_crl_check == "false" {
+    if $ssl_crl_check == 'false' {
       fail('$ssl_crl_cache_http_timeout requires that $ssl_crl_check => true|peer|best_effort')
     }
   }
@@ -444,7 +444,7 @@ class rabbitmq (
     unless $ssl {
       fail('$ssl_crl_cache_http_timeout requires that $ssl => true')
     }
-    if $ssl_crl_check == "false" {
+    if $ssl_crl_check == 'false' {
       fail('$ssl_crl_cache_http_timeout requires that $ssl_crl_check => true|peer|best_effort')
     }
   }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1168,7 +1168,7 @@ describe 'rabbitmq' do
             ssl_cacert: '/path/to/cacert',
             ssl_cert: '/path/to/cert',
             ssl_key: '/path/to/key',
-            ssl_crl_check: 'true'
+            ssl_crl_check: 'true' }
         end
 
         it 'sets ssl crl check setting to specified value' do
@@ -1183,12 +1183,13 @@ describe 'rabbitmq' do
             ssl_cacert: '/path/to/cacert',
             ssl_cert: '/path/to/cert',
             ssl_key: '/path/to/key',
-            ssl_crl_cache_hash_dir: '/path/to/crl_cache/dir'
+            ssl_crl_check: 'true',
+            ssl_crl_cache_hash_dir: '/path/to/crl_cache/dir' }
         end
 
         it 'sets ssl crl check setting to specified value' do
           is_expected.to contain_file('rabbitmq.config').with_content(%r{crl_check,true})
-          is_expected.to contain_file('rabbitmq.config').with_content(%r{\[crl_cache,\s+{ssl_crl_hash_dir,\s+{internal,\s+[{dir, "/path/to/crl_cache/dir"}]}}\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{crl_cache,\s+{ssl_crl_hash_dir,\s+{internal,\s+\[{dir, "/path/to/crl_cache/dir"}\]}}})
         end
       end
 
@@ -1199,13 +1200,13 @@ describe 'rabbitmq' do
             ssl_cacert: '/path/to/cacert',
             ssl_cert: '/path/to/cert',
             ssl_key: '/path/to/key',
-            ssl_crl_check: 'true'
-            ssl_crl_cache_http_timeout: 5000
+            ssl_crl_check: 'true',
+            ssl_crl_cache_http_timeout: 5000 }
         end
 
         it 'sets ssl crl check setting to specified value' do
           is_expected.to contain_file('rabbitmq.config').with_content(%r{crl_check,true})
-          is_expected.to contain_file('rabbitmq.config').with_content(%r{\[crl_cache,\s+{ssl_crl_cache,\s+{internal,\s+[{http, 5000}]}}\]})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{crl_cache,\s+{ssl_crl_cache,\s+{internal,\s+\[{http, 5000}\]}}})
         end
       end
 
@@ -1216,7 +1217,7 @@ describe 'rabbitmq' do
             ssl_cacert: '/path/to/cacert',
             ssl_cert: '/path/to/cert',
             ssl_key: '/path/to/key',
-            ssl_crl_check: 'true'
+            ssl_crl_check: 'true' }
         end
 
         it 'fails' do
@@ -1232,11 +1233,11 @@ describe 'rabbitmq' do
             ssl_cert: '/path/to/cert',
             ssl_key: '/path/to/key',
             ssl_crl_check: 'false',
-            ssl_crl_cache_hash_dir: '/path/to/crl_cache/dir'
+            ssl_crl_cache_hash_dir: '/path/to/crl_cache/dir' }
         end
 
         it 'fails' do
-          expect { catalogue }.to raise_error(Puppet::Error, %r{\$$ssl_crl_cache_hash_dir requires that \$ssl_crl_check => true|peer|best_effort})
+          expect { catalogue }.to raise_error(Puppet::Error, %r{\$ssl_crl_cache_hash_dir requires that \$ssl_crl_check => true|peer|best_effort})
         end
       end
 
@@ -1248,11 +1249,11 @@ describe 'rabbitmq' do
             ssl_cert: '/path/to/cert',
             ssl_key: '/path/to/key',
             ssl_crl_check: 'false',
-            ssl_crl_cache_http_timeout: 5000,
+            ssl_crl_cache_http_timeout: 5000 }
         end
 
         it 'fails' do
-          expect { catalogue }.to raise_error(Puppet::Error,, %r{\$$ssl_crl_cache_http_timeout requires that \$ssl_crl_check => true|peer|best_effort})
+          expect { catalogue }.to raise_error(Puppet::Error, %r{\$ssl_crl_cache_http_timeout requires that \$ssl_crl_check => true|peer|best_effort})
         end
       end
 

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -1161,6 +1161,101 @@ describe 'rabbitmq' do
         end
       end
 
+      describe 'ssl options with ssl_crl_check enabled' do
+        let(:params) do
+          { ssl: true,
+            ssl_port: 3141,
+            ssl_cacert: '/path/to/cacert',
+            ssl_cert: '/path/to/cert',
+            ssl_key: '/path/to/key',
+            ssl_crl_check: 'true'
+        end
+
+        it 'sets ssl crl check setting to specified value' do
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{crl_check,true})
+        end
+      end
+
+      describe 'ssl options with ssl_crl_check and ssl_crl_hash_cache enabled' do
+        let(:params) do
+          { ssl: true,
+            ssl_port: 3141,
+            ssl_cacert: '/path/to/cacert',
+            ssl_cert: '/path/to/cert',
+            ssl_key: '/path/to/key',
+            ssl_crl_cache_hash_dir: '/path/to/crl_cache/dir'
+        end
+
+        it 'sets ssl crl check setting to specified value' do
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{crl_check,true})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{\[crl_cache,\s+{ssl_crl_hash_dir,\s+{internal,\s+[{dir, "/path/to/crl_cache/dir"}]}}\]})
+        end
+      end
+
+      describe 'ssl options with ssl_crl_check and http cache enabled' do
+        let(:params) do
+          { ssl: true,
+            ssl_port: 3141,
+            ssl_cacert: '/path/to/cacert',
+            ssl_cert: '/path/to/cert',
+            ssl_key: '/path/to/key',
+            ssl_crl_check: 'true'
+            ssl_crl_cache_http_timeout: 5000
+        end
+
+        it 'sets ssl crl check setting to specified value' do
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{crl_check,true})
+          is_expected.to contain_file('rabbitmq.config').with_content(%r{\[crl_cache,\s+{ssl_crl_cache,\s+{internal,\s+[{http, 5000}]}}\]})
+        end
+      end
+
+      describe 'ssl options with ssl_crl_check enabled and not ssl' do
+        let(:params) do
+          { ssl: false,
+            ssl_port: 3141,
+            ssl_cacert: '/path/to/cacert',
+            ssl_cert: '/path/to/cert',
+            ssl_key: '/path/to/key',
+            ssl_crl_check: 'true'
+        end
+
+        it 'fails' do
+          expect { catalogue }.to raise_error(Puppet::Error, %r{\$ssl_crl_check requires that \$ssl => true})
+        end
+      end
+
+      describe 'ssl options with ssl_crl_cache_hash_dir set and not ssl_crl_check' do
+        let(:params) do
+          { ssl: true,
+            ssl_port: 3141,
+            ssl_cacert: '/path/to/cacert',
+            ssl_cert: '/path/to/cert',
+            ssl_key: '/path/to/key',
+            ssl_crl_check: 'false',
+            ssl_crl_cache_hash_dir: '/path/to/crl_cache/dir'
+        end
+
+        it 'fails' do
+          expect { catalogue }.to raise_error(Puppet::Error, %r{\$$ssl_crl_cache_hash_dir requires that \$ssl_crl_check => true|peer|best_effort})
+        end
+      end
+
+      describe 'ssl options with ssl_crl_cache_http_timeout set and not ssl_crl_check' do
+        let(:params) do
+          { ssl: true,
+            ssl_port: 3141,
+            ssl_cacert: '/path/to/cacert',
+            ssl_cert: '/path/to/cert',
+            ssl_key: '/path/to/key',
+            ssl_crl_check: 'false',
+            ssl_crl_cache_http_timeout: 5000,
+        end
+
+        it 'fails' do
+          expect { catalogue }.to raise_error(Puppet::Error,, %r{\$$ssl_crl_cache_http_timeout requires that \$ssl_crl_check => true|peer|best_effort})
+        end
+      end
+
       describe 'ssl admin options with specific ssl versions' do
         let(:params) do
           { ssl: true,

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -95,7 +95,7 @@ end
                      <%= ssl_ciphers %>
                    ]}
                    <%- end -%>
-                   <%- if @ssl_crl_check != "false" -%>
+                   <%- if @ssl_crl_check != 'false' -%>
                    ,{crl_check,<%= @ssl_crl_check %>}
                    <%- end -%>
                    <%- if @ssl_crl_cache_hash_dir -%>

--- a/templates/rabbitmq.config.erb
+++ b/templates/rabbitmq.config.erb
@@ -95,6 +95,15 @@ end
                      <%= ssl_ciphers %>
                    ]}
                    <%- end -%>
+                   <%- if @ssl_crl_check != "false" -%>
+                   ,{crl_check,<%= @ssl_crl_check %>}
+                   <%- end -%>
+                   <%- if @ssl_crl_cache_hash_dir -%>
+                   ,{crl_cache, {ssl_crl_hash_dir, {internal, [{dir, "<%= @ssl_crl_cache_hash_dir %>"}]}}}
+                   <%- end -%>
+                   <%- if @ssl_crl_cache_http_timeout -%>
+                   ,{crl_cache, {ssl_crl_cache, {internal, [{http, <%= @ssl_crl_cache_http_timeout %>}]}}}
+                   <%- end -%>
                   ]},
 <%- end -%>
 <% if scope['rabbitmq::config_variables'] -%>


### PR DESCRIPTION
Add support for SSL CRL (Certificate Revocation List) check options.

This option is not documented in official documentation but RabbitMQ supports these options because they are implemented in underlying [OTP SSL module](https://erlang.org/doc/man/ssl.html#type-crl_cache_opts).

There are 3 main use cases:

* Enable CRL check in `best_effort` mode (if certificate revocation status cannot be determined it will be accepted as valid) and without any cache

In this case, result configuration should look like this:

```
[
  {rabbit, [
     {ssl_listeners, [5671]},
     {ssl_options, [{cacertfile,"/path/to/testca/cacert.pem"},
                    {certfile,"/path/to/server/cert.pem"},
                    {keyfile,"/path/to/server/key.pem"},
                    {verify,verify_peer},
                    {fail_if_no_peer_cert,false}]},
                    {crl_check, best_effort}
   ]}
].
```

* Enable CRL check in any of 3 modes and use internal CRL cache

```
[
  {rabbit, [
     {ssl_listeners, [5671]},
     {ssl_options, [{cacertfile,"/path/to/testca/cacert.pem"},
                    {certfile,"/path/to/server/cert.pem"},
                    {keyfile,"/path/to/server/key.pem"},
                    {verify,verify_peer},
                    {fail_if_no_peer_cert,false}]},
                    {crl_check, true},
                    {crl_cache, {ssl_crl_cache, {internal, [{http, 5000}]}}}
   ]}
].
```

* Do not perform any HTTP request and just use local directory to perform CRL check

_See [ssl_crl_hash_dir](https://erlang.org/doc/man/ssl.html#type-crl_cache_opts) implementation docs for more details._

```
[
  {rabbit, [
     {ssl_listeners, [5671]},
     {ssl_options, [{cacertfile,"/path/to/testca/cacert.pem"},
                    {certfile,"/path/to/server/cert.pem"},
                    {keyfile,"/path/to/server/key.pem"},
                    {verify,verify_peer},
                    {fail_if_no_peer_cert,false}]},
                    {crl_check, true},
                    {crl_cache, {ssl_crl_hash_dir, {internal, [{dir, "/path/to/crl/cache/"}]}}}
   ]}
].
```