### PR TITLE
Fix rabbit version discovery with newer RabbitMQ

### DIFF
--- a/lib/puppet/provider/rabbitmq_cli.rb
+++ b/lib/puppet/provider/rabbitmq_cli.rb
@@ -38,7 +38,7 @@ class Puppet::Provider::RabbitmqCli < Puppet::Provider
     return @rabbitmq_version if defined? @rabbitmq_version
 
     output = rabbitmqctl('-q', 'status')
-    version = output.match(%r{RabbitMQ.*?([\d\.]+)})
+    version = output.match(%r{(?:\{rabbit,"RabbitMQ","|RabbitMQ version: )([\d\.]+)})
     @rabbitmq_version = version[1] if version
   end
 


### PR DESCRIPTION
The output of "rabbitmqctl -q status" has changed, and the version
detection is now broken in this module. As a consequence, the puppet
providers are all broken because they aren't using the much needed
--no-table-headers option for rabbitmqctl.

This patch fix this problem. It's been tested in Debian unstable
and Bullseye, which includes rabbitmq-server 3.8.9.
