### PR TITLE
Use mocked facts in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :test do
-  gem 'voxpupuli-test', '~> 2.1',  :require => false
+  gem 'voxpupuli-test', '~> 2.2',  :require => false
   gem 'coveralls',                 :require => false
   gem 'simplecov-console',         :require => false
 end

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -3,8 +3,6 @@ require 'spec_helper'
 describe 'rabbitmq' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
-      systemd_facts = os_specific_facts(facts)
-      facts = facts.merge(systemd_facts)
       let :facts do
         facts
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../../lib', __FILE__))
 
 require 'voxpupuli/test/spec_helper'
 
+add_mocked_facts!
+
 if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
   facts = YAML.safe_load(File.read(File.join(__dir__, 'default_module_facts.yml')))
   if facts

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,27 +1,2 @@
 add_custom_fact :rabbitmq_version, '3.6.1'                              # puppet-rabbitmq
 add_custom_fact :erl_ssl_path, '/usr/lib64/erlang/lib/ssl-7.3.3.1/ebin' # puppet-rabbitmq
-
-def os_specific_facts(facts)
-  case facts[:os]['family']
-  when 'Archlinux'
-    { service_provider: 'systemd', systemd: true }
-  when 'Debian'
-    case facts[:os]['release']['major']
-    when '7'
-      { service_provider: 'sysv', systemd: false }
-    when '14.04'
-      { service_provider: 'upstart', systemd: false }
-    else
-      { service_provider: 'systemd', systemd: true }
-    end
-  when 'RedHat'
-    case facts[:os]['release']['major']
-    when '6'
-      { service_provider: 'sysv', systemd: false }
-    else
-      { service_provider: 'systemd', systemd: true }
-    end
-  else
-    { service_provider: 'systemd', systemd: true }
-  end
-end


### PR DESCRIPTION
This uses the add_mocked_facts! from voxpupuli-test 2.2.0 rather than a local override.

A result of what https://github.com/voxpupuli/modulesync_config/pull/693 would do.