### PR TITLE
Add support for oom_score_adj

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -81,6 +81,7 @@ class rabbitmq::config {
   $auth_backends                       = $rabbitmq::auth_backends
   $cluster_partition_handling          = $rabbitmq::cluster_partition_handling
   $file_limit                          = $rabbitmq::file_limit
+  $oom_score_adj                       = $rabbitmq::oom_score_adj
   $collect_statistics_interval         = $rabbitmq::collect_statistics_interval
   $ipv6                                = $rabbitmq::ipv6
   $inetrc_config                       = $rabbitmq::inetrc_config
@@ -235,7 +236,10 @@ class rabbitmq::config {
   if $facts['systemd'] { # systemd fact provided by systemd module
     systemd::service_limits { "${service_name}.service":
       selinux_ignore_defaults => ($facts['os']['family'] == 'RedHat'),
-      limits                  => { 'LimitNOFILE' => $file_limit },
+      limits                  => {
+        'LimitNOFILE'    => $file_limit,
+        'OOMScoreAdjust' => $oom_score_adj,
+      },
       # The service will be notified when config changes
       restart_service         => false,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,6 +140,8 @@
 #   to 'False' and set 'erlang_cookie'.
 # @param file_limit
 #   Set rabbitmq file ulimit. Defaults to 16384. Only available on systems with `$::osfamily == 'Debian'` or `$::osfamily == 'RedHat'`.
+# @param oom_score_adj
+#   Set rabbitmq-server process OOM score. Defaults to 0.
 # @param heartbeat
 #   Set the heartbeat timeout interval, default is unset which uses the builtin server defaults of 60 seconds. Setting this
 # @param inetrc_config
@@ -394,6 +396,7 @@ class rabbitmq (
   Boolean $wipe_db_on_cookie_change                                                                = false,
   String $cluster_partition_handling                                                               = 'ignore',
   Variant[Integer[-1],Enum['unlimited'],Pattern[/^(infinity|\d+(:(infinity|\d+))?)$/]] $file_limit = 16384,
+  Integer[-1000, 1000] $oom_score_adj                                                              = 0,
   Hash $environment_variables                                                                      = { 'LC_ALL' => 'en_US.UTF-8' },
   Hash $config_variables                                                                           = {},
   Hash $config_kernel_variables                                                                    = {},

--- a/templates/default.erb
+++ b/templates/default.erb
@@ -8,3 +8,7 @@
 # to handle many simultaneous connections. Refer to the system
 # documentation for ulimit (in man bash) for more information.
 ulimit -n <%= @file_limit %>
+
+# OOM score. It sets the score of the init script, but as this value is
+# inherited, it also applies to the rabbitmq-server.
+echo <%= @oom_score_adj %> > /proc/$$/oom_score_adj


### PR DESCRIPTION
#### Pull Request (PR) description

Add support for OOM score in init script and systemd limits.
Default value is 0, acceptable values range from -1000 to +1000.

Documentation : Chapter 3.1 of https://www.kernel.org/doc/Documentation/filesystems/proc.txt