### PR TITLE
Remove superfluous daemon-reload code and raise minimum required puppet version to 6.1.0

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,9 +22,5 @@ class rabbitmq::service (
       hasrestart => true,
       name       => $service_name,
     }
-
-    if $facts['systemd'] {
-      Class['systemd::systemctl::daemon_reload'] -> Service['rabbitmq-server']
-    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -54,7 +54,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 8.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
#### Pull Request (PR) description
This removes the superfluous daemon-reload code in this module.

The upstream module (https://github.com/camptocamp/puppet-systemd) removed the support for puppet 4 and 5 that made this reload construct necessary.

They removed their code in this PR: https://github.com/camptocamp/puppet-systemd/pull/171

On the other hand, https://github.com/voxpupuli/puppet-rabbitmq/pull/884 doesn't go far enough, as it simply raises the possible version of the systemd module without taking into account the EOL of Puppet 4 and 5.

#### This Pull Request (PR) fixes the following issues

Fixes #875

Cheers
Thomas