### PR TITLE
Compatibility with camptocamp/systemd 3.x

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -23,8 +23,5 @@ class rabbitmq::service (
       name       => $service_name,
     }
 
-    if $facts['systemd'] {
-      Class['systemd::systemctl::daemon_reload'] -> Service['rabbitmq-server']
-    }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,6 +22,8 @@ class rabbitmq::service (
       hasrestart => true,
       name       => $service_name,
     }
-
+    if $facts['systemd'] and defined(Class['systemd::systemctl::daemon_reload']) {
+      Class['systemd::systemctl::daemon_reload'] -> Service['rabbitmq-server']
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.10.0 < 3.0.0"
+      "version_requirement": ">= 2.10.0 < 4.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
#### Pull Request (PR) description
Remove `systemd::systemctl::daemon_reload`

#### This Pull Request (PR) fixes the following issues
Fails with puppet-systemd >= 3.0.0
See https://github.com/camptocamp/puppet-systemd/compare/2.12.0...3.0.0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R224-R229
`systemd::systemctl::daemon_reload` was removed.


@ekohl 