### PR TITLE
Adjust docu for RabbitMQ log level #894

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,7 +37,20 @@
 #     config_variables => {
 #       'hipe_compile' => true,
 #       'frame_max'    => 131072,
-#       'log_levels'   => "[{connection, info}]"
+#     }
+#   }
+#
+# @example Change RabbitMQ log level in rabbitmq.config for RabbitMQ version < 3.7.x :
+#   class { 'rabbitmq':
+#     config_variables => {
+#       'log_levels'   => "[{queue, info}]"
+#     }
+#   }
+#
+# @example Change RabbitMQ log level in rabbitmq.config for RabbitMQ version since 3.7.x :
+#   class { 'rabbitmq':
+#     config_variables => {
+#       'log'          => "[{file, [{level,debug}]},{categories, [{queue, [{level,info},{file,'queue.log'}]}]}]"
 #     }
 #   }
 #


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Since RabbitMQ version 3.7.0, log level configuration has changed. Key "log_levels" has been replaced by categories.

> Log Message Categories
> RabbitMQ has several categories of messages, which can be logged with different levels or to different files.
>
> The categories replace the rabbit.log_levels configuration setting in versions earlier than 3.7.0.

#### This Pull Request (PR) fixes the following issues
Fixes #894 'Reference for log_levels does not apply'