### PR TITLE
Add official support for CentOS 8

### DIFF
--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -1,4 +1,5 @@
 ---
+rabbitmq::python_package: 'python3'
 rabbitmq::package_name: 'rabbitmq-server'
 rabbitmq::service_name: 'rabbitmq-server'
 rabbitmq::package_gpg_key: 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'

--- a/metadata.json
+++ b/metadata.json
@@ -11,13 +11,15 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -12,12 +12,16 @@ describe 'rabbitmq class:' do
     service_name = 'rabbitmq'
   end
 
+  repos_ensure = (fact('os.family') == 'RedHat')
+
   context 'default class inclusion' do
     let(:pp) do
       <<-EOS
-      class { 'rabbitmq': }
+      class { 'rabbitmq':
+        repos_ensure => #{repos_ensure},
+      }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': repo_source => 'packagecloud' }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS
@@ -52,10 +56,11 @@ describe 'rabbitmq class:' do
     let(:pp) do
       <<-EOS
         class { 'rabbitmq':
+          repos_ensure   => #{repos_ensure},
           service_ensure => 'stopped',
         }
         if $facts['os']['family'] == 'RedHat' {
-          class { 'erlang': epel_enable => true}
+          class { 'erlang': repo_source => 'packagecloud' }
           Class['erlang'] -> Class['rabbitmq']
         }
       EOS
@@ -72,20 +77,23 @@ describe 'rabbitmq class:' do
   context 'service is unmanaged' do
     it 'runs successfully' do
       pp_pre = <<-EOS
-        class { 'rabbitmq': }
+        class { 'rabbitmq':
+          repos_ensure => #{repos_ensure},
+        }
         if $facts['os']['family'] == 'RedHat' {
-          class { 'erlang': epel_enable => true}
+          class { 'erlang': repo_source => 'packagecloud' }
           Class['erlang'] -> Class['rabbitmq']
         }
       EOS
 
       pp = <<-EOS
         class { 'rabbitmq':
+          repos_ensure   => #{repos_ensure},
           service_manage => false,
-          service_ensure  => 'stopped',
+          service_ensure => 'stopped',
         }
         if $facts['os']['family'] == 'RedHat' {
-          class { 'erlang': epel_enable => true}
+          class { 'erlang': repo_source => 'packagecloud' }
           Class['erlang'] -> Class['rabbitmq']
         }
       EOS
@@ -104,6 +112,7 @@ describe 'rabbitmq class:' do
     let(:pp) do
       <<-EOS
       class { 'rabbitmq':
+        repos_ensure      => #{repos_ensure},
         service_manage    => true,
         port              => 5672,
         admin_enable      => true,
@@ -137,6 +146,7 @@ describe 'rabbitmq class:' do
     let(:pp) do
       <<-EOS
         class { 'rabbitmq':
+          repos_ensure      => #{repos_ensure},
           service_manage    => true,
           port              => 5672,
           admin_enable      => true,
@@ -172,6 +182,7 @@ describe 'rabbitmq class:' do
     let(:pp) do
       <<-EOS
         class { 'rabbitmq':
+          repos_ensure    => #{repos_ensure},
           service_manage  => true,
           admin_enable    => true,
           node_ip_address => '0.0.0.0',
@@ -203,6 +214,7 @@ describe 'rabbitmq class:' do
     let(:pp) do
       <<-EOS
         class { 'rabbitmq':
+          repos_ensure          => #{repos_ensure},
           service_manage        => true,
           port                  => 5672,
           admin_enable          => true,

--- a/spec/acceptance/clustering_spec.rb
+++ b/spec/acceptance/clustering_spec.rb
@@ -3,10 +3,13 @@
 require 'spec_helper_acceptance'
 
 describe 'rabbitmq clustering' do
+  repos_ensure = (fact('os.family') == 'RedHat')
+
   context 'rabbitmq::wipe_db_on_cookie_change => false' do
     it 'runs successfully' do
       pp = <<-EOS
       class { 'rabbitmq':
+        repos_ensure             => #{repos_ensure},
         cluster                  => { 'name' => 'rabbit_cluster', 'init_node' => $facts['fqdn'] },
         config_cluster           => true,
         cluster_nodes            => ['rabbit1', 'rabbit2'],
@@ -16,7 +19,7 @@ describe 'rabbitmq clustering' do
         wipe_db_on_cookie_change => false,
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': repo_source => 'packagecloud' }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS
@@ -33,6 +36,7 @@ describe 'rabbitmq clustering' do
     it 'runs successfully' do
       pp = <<-EOS
       class { 'rabbitmq':
+        repos_ensure             => #{repos_ensure},
         cluster                  => { 'name' => 'rabbit_cluster', 'init_node' => $facts['fqdn'] },
         config_cluster           => true,
         cluster_nodes            => ['rabbit1', 'rabbit2'],
@@ -42,7 +46,7 @@ describe 'rabbitmq clustering' do
         wipe_db_on_cookie_change => true,
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': repo_source => 'packagecloud' }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS

--- a/spec/acceptance/delete_guest_user_spec.rb
+++ b/spec/acceptance/delete_guest_user_spec.rb
@@ -3,15 +3,18 @@
 require 'spec_helper_acceptance'
 
 describe 'rabbitmq with delete_guest_user' do
+  repos_ensure = (fact('os.family') == 'RedHat')
+
   context 'delete_guest_user' do
     it 'runs successfully' do
       pp = <<-EOS
       class { 'rabbitmq':
+        repos_ensure      => #{repos_ensure},
         port              => 5672,
         delete_guest_user => true,
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': repo_source => 'packagecloud' }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS

--- a/spec/acceptance/parameter_spec.rb
+++ b/spec/acceptance/parameter_spec.rb
@@ -3,14 +3,13 @@
 require 'spec_helper_acceptance'
 
 describe 'rabbitmq parameter on a vhost:' do
+  repos_ensure = (fact('os.family') == 'RedHat')
+
   context 'create parameter resource' do
     it 'runs successfully' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
-        Class['erlang'] -> Class['rabbitmq']
-      }
       class { 'rabbitmq':
+        repos_ensure      => #{repos_ensure},
         service_manage    => true,
         port              => 5672,
         delete_guest_user => true,

--- a/spec/acceptance/parameter_spec.rb
+++ b/spec/acceptance/parameter_spec.rb
@@ -16,7 +16,7 @@ describe 'rabbitmq parameter on a vhost:' do
         admin_enable      => true,
       }
 
-      rabbitmq_plugin { [ 'rabbitmq_federation_management', 'rabbitmq_federation' ]:
+      rabbitmq_plugin { [ 'rabbitmq_federation', 'rabbitmq_federation_management' ]:
         ensure => present
       } ~> Service['rabbitmq-server']
 

--- a/spec/acceptance/policy_spec.rb
+++ b/spec/acceptance/policy_spec.rb
@@ -3,14 +3,17 @@
 require 'spec_helper_acceptance'
 
 describe 'rabbitmq policy on a vhost:' do
+  repos_ensure = (fact('os.family') == 'RedHat')
+
   context 'create policy resource' do
     it 'runs successfully' do
       pp = <<-EOS
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
+        class { 'erlang': repo_source => 'packagecloud' }
         Class['erlang'] -> Class['rabbitmq']
       }
       class { 'rabbitmq':
+        repos_ensure      => #{repos_ensure},
         service_manage    => true,
         port              => 5672,
         delete_guest_user => true,

--- a/spec/acceptance/queue_spec.rb
+++ b/spec/acceptance/queue_spec.rb
@@ -3,14 +3,17 @@
 require 'spec_helper_acceptance'
 
 describe 'rabbitmq binding:' do
+  repos_ensure = (fact('os.family') == 'RedHat')
+
   context 'create binding and queue resources when using default management port' do
     it 'runs successfully' do
       pp = <<-EOS
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
+        class { 'erlang': repo_source => 'packagecloud' }
         Class['erlang'] -> Class['rabbitmq']
       }
       class { 'rabbitmq':
+        repos_ensure      => #{repos_ensure},
         service_manage    => true,
         port              => 5672,
         delete_guest_user => true,
@@ -81,10 +84,11 @@ describe 'rabbitmq binding:' do
     it 'runs successfully' do
       pp = <<-EOS
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
+        class { 'erlang': repo_source => 'packagecloud' }
         Class['erlang'] -> Class['rabbitmq']
       }
       class { 'rabbitmq':
+        repos_ensure      => #{repos_ensure},
         service_manage    => true,
         port              => 5672,
         delete_guest_user => true,
@@ -168,11 +172,8 @@ describe 'rabbitmq binding:' do
   context 'create binding and queue resources when using a non-default management port' do
     it 'runs successfully' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
-        Class['erlang'] -> Class['rabbitmq']
-      }
       class { 'rabbitmq':
+        repos_ensure      => #{repos_ensure},
         service_manage    => true,
         port              => 5672,
         management_port   => 11111,

--- a/spec/acceptance/rabbitmqadmin_spec.rb
+++ b/spec/acceptance/rabbitmqadmin_spec.rb
@@ -3,15 +3,18 @@
 require 'spec_helper_acceptance'
 
 describe 'rabbitmq::install::rabbitmqadmin class' do
+  repos_ensure = (fact('os.family') == 'RedHat')
+
   context 'downloads the cli tools' do
     it 'runs successfully' do
       pp = <<-EOS
       class { 'rabbitmq':
+        repos_ensure   => #{repos_ensure},
         admin_enable   => true,
         service_manage => true,
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': repo_source => 'packagecloud' }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS
@@ -28,11 +31,12 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
     it 'runs successfully' do
       pp = <<-EOS
       class { 'rabbitmq':
+        repos_ensure   => #{repos_ensure},
         admin_enable   => true,
         service_manage => false,
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': repo_source => 'packagecloud' }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS
@@ -51,25 +55,27 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
       # make sure credential change takes effect before admin_enable
       pp_pre = <<-EOS
       class { 'rabbitmq':
+        repos_ensure   => #{repos_ensure},
         service_manage => true,
         default_user   => 'foobar',
         default_pass   => 'bazblam',
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': repo_source => 'packagecloud' }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS
 
       pp = <<-EOS
       class { 'rabbitmq':
+        repos_ensure   => #{repos_ensure},
         admin_enable   => true,
         service_manage => true,
         default_user   => 'foobar',
         default_pass   => 'bazblam',
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': repo_source => 'packagecloud' }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -3,14 +3,17 @@
 require 'spec_helper_acceptance'
 
 describe 'rabbitmq user:' do
+  repos_ensure = (fact('os.family') == 'RedHat')
+
   context 'create user resource' do
     it 'runs successfully' do
       pp = <<-EOS
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
+        class { 'erlang': repo_source => 'packagecloud' }
         Class['erlang'] -> Class['rabbitmq']
       }
       class { 'rabbitmq':
+        repos_ensure      => #{repos_ensure},
         service_manage    => true,
         port              => 5672,
         delete_guest_user => true,
@@ -38,6 +41,10 @@ describe 'rabbitmq user:' do
   context 'destroy user resource' do
     it 'runs successfully' do
       pp = <<-EOS
+      if $facts['os']['family'] == 'RedHat' {
+        class { 'erlang': repo_source => 'packagecloud' }
+        Class['erlang'] -> Class['rabbitmq']
+      }
       rabbitmq_user { 'dan':
         ensure => absent,
       }

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -41,10 +41,6 @@ describe 'rabbitmq user:' do
   context 'destroy user resource' do
     it 'runs successfully' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': repo_source => 'packagecloud' }
-        Class['erlang'] -> Class['rabbitmq']
-      }
       rabbitmq_user { 'dan':
         ensure => absent,
       }

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -3,14 +3,13 @@
 require 'spec_helper_acceptance'
 
 describe 'rabbitmq vhost:' do
+  repos_ensure = (fact('os.family') == 'RedHat')
+
   context 'create vhost resource' do
     it 'runs successfully' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
-        Class['erlang'] -> Class['rabbitmq']
-      }
       class { 'rabbitmq':
+        repos_ensure      => #{repos_ensure},
         service_manage    => true,
         port              => 5672,
         delete_guest_user => true,

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -12,7 +12,7 @@ describe 'rabbitmq' do
         facts
       end
 
-      name = case facts[:osfamily]
+      name = case facts[:os]['family']
              when 'Archlinux', 'OpenBSD', 'FreeBSD'
                'rabbitmq'
              else
@@ -239,8 +239,9 @@ describe 'rabbitmq' do
             is_expected.to contain_archive('rabbitmqadmin').with_source('http://1.1.1.1:15672/cli/rabbitmqadmin')
           end
 
-          it { is_expected.to contain_package('python') } if %w[RedHat Debian SUSE Archlinux].include?(facts[:os]['family'])
+          it { is_expected.to contain_package('python') } if %w[Debian SUSE Archlinux].include?(facts[:os]['family'])
           it { is_expected.to contain_package('python2') } if %w[FreeBSD OpenBSD].include?(facts[:os]['family'])
+          it { is_expected.to contain_package('python3') } if %w[RedHat].include?(facts[:os]['family'])
         end
 
         context 'with manage_python false' do
@@ -250,6 +251,7 @@ describe 'rabbitmq' do
             is_expected.to contain_class('rabbitmq::install::rabbitmqadmin')
             is_expected.not_to contain_package('python')
             is_expected.not_to contain_package('python2')
+            is_expected.not_to contain_package('python3')
           end
         end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,7 +7,7 @@ configure_beaker do |host|
   when 'Debian'
     install_module_from_forge_on(host, 'puppetlabs-apt', '>= 4.1.0 < 9.0.0')
   when 'RedHat'
-    install_module_from_forge_on(host, 'garethr-erlang', '>= 0.3.0 < 1.0.0')
+    install_module_from_forge_on(host, 'puppet-erlang', '>= 1.0.0 < 2.0.0')
     if fact_on(host, 'os.selinux.enabled')
       # Make sure selinux is disabled so the tests work.
       on host, puppet('resource', 'exec', 'setenforce 0', 'path=/bin:/sbin:/usr/bin:/usr/sbin', 'onlyif=which setenforce && getenforce | grep Enforcing')


### PR DESCRIPTION
#### Pull Request (PR) description

This change adds official support for CentOS 8. The current logic is
almost compatible except for the package name of Python 2, which is
python2 in CentOS 8 while python in CentOS 7.


#### This Pull Request (PR) fixes the following issues

N/A
