### PR TITLE
change default python version for FreeBSD: 3.8

### DIFF
--- a/data/family/FreeBSD.yaml
+++ b/data/family/FreeBSD.yaml
@@ -1,5 +1,5 @@
 ---
-rabbitmq::python_package: 'python2'
+rabbitmq::python_package: 'python38'
 rabbitmq::rabbitmq_home: '/var/db/rabbitmq'
 rabbitmq::config_path: '/usr/local/etc/rabbitmq/rabbitmq.config'
 rabbitmq::env_config_path: '/usr/local/etc/rabbitmq/rabbitmq-env.conf'


### PR DESCRIPTION
Current python version for FreeBSD: 3.8
link: https://cgit.freebsd.org/ports/tree/Mk/bsd.default-versions.mk?h=2022Q1#n113

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
