### PR TITLE
Use default install method on Archlinux

### DIFF
--- a/data/family/Archlinux.yaml
+++ b/data/family/Archlinux.yaml
@@ -1,3 +1,2 @@
 ---
-rabbitmq::python_package: 'python2'
-rabbitmq::rabbitmqadmin_package: 'rabbitmqadmin'
+rabbitmq::python_package: 'python'

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -231,20 +231,15 @@ describe 'rabbitmq' do
             end
           end
 
-          if facts[:os]['family'] == 'Archlinux'
-            it 'installs a package called rabbitmqadmin' do
-              is_expected.to contain_package('rabbitmqadmin').with_name('rabbitmqadmin')
-            end
-          else
-            it 'we enable the admin interface by default' do
-              is_expected.to contain_class('rabbitmq::install::rabbitmqadmin')
-              is_expected.to contain_rabbitmq_plugin('rabbitmq_management').with(
-                notify: 'Class[Rabbitmq::Service]'
-              )
-              is_expected.to contain_archive('rabbitmqadmin').with_source('http://1.1.1.1:15672/cli/rabbitmqadmin')
-            end
+          it 'we enable the admin interface by default' do
+            is_expected.to contain_class('rabbitmq::install::rabbitmqadmin')
+            is_expected.to contain_rabbitmq_plugin('rabbitmq_management').with(
+              notify: 'Class[Rabbitmq::Service]'
+            )
+            is_expected.to contain_archive('rabbitmqadmin').with_source('http://1.1.1.1:15672/cli/rabbitmqadmin')
           end
-          it { is_expected.to contain_package('python') } if %w[RedHat Debian SUSE].include?(facts[:os]['family'])
+
+          it { is_expected.to contain_package('python') } if %w[RedHat Debian SUSE Archlinux].include?(facts[:os]['family'])
           it { is_expected.to contain_package('python2') } if %w[FreeBSD OpenBSD].include?(facts[:os]['family'])
         end
 


### PR DESCRIPTION
#### Pull Request (PR) description
Update Python package name to python instead of python2, and use file install vs. package install by default

Partially rolls back #654, though continues to allow the user to set the package via `$rabbitmqadmin_package`

This gets acceptance tests (partially) working again for Arch

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
