### PR TITLE
Fixing Yum repo

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -27,6 +27,7 @@ rabbitmq::node_ip_address: ~
 rabbitmq::package_apt_pin: ~
 rabbitmq::package_ensure: 'installed'
 rabbitmq::package_gpg_key: ~
+rabbitmq::repo_gpg_key: ~
 rabbitmq::package_name: 'rabbitmq'
 rabbitmq::package_source: ~
 rabbitmq::package_provider: ~

--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -1,4 +1,5 @@
 ---
 rabbitmq::package_name: 'rabbitmq-server'
 rabbitmq::service_name: 'rabbitmq-server'
-rabbitmq::package_gpg_key: 'https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey'
+rabbitmq::package_gpg_key: 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'
+rabbitmq::repo_gpg_key: 'https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,17 @@
 #     package_gpg_key => 'http://www.some_site.some_domain/some_key.pub.key',
 #   }
 #
+# @example Offline installation from local mirror:
+#   class { 'rabbitmq':
+#     key_content     => template('openstack/rabbit.pub.key'),
+#     repo_gpg_key => '/tmp/rabbit.pub.key',
+#   }
+#
+# @example Use external package key source for any (apt/rpm) package provider:
+#   class { 'rabbitmq':
+#     repo_gpg_key => 'http://www.some_site.some_domain/some_key.pub.key',
+#   }
+#
 # @example To use RabbitMQ Environment Variables, use the parameters `environment_variables` e.g.:
 #   class { 'rabbitmq':
 #     port                  => '5672',
@@ -211,6 +222,10 @@
 #   Determines the ensure state of the package.  Set to installed by default, but could be changed to latest.
 # @param package_gpg_key
 #   RPM package GPG key to import. Uses source method. Should be a URL for Debian/RedHat OS family, or a file name for
+#   RedHat OS family. Set to https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
+#   for Debian/RedHat OS Family by default.
+# @param repo_gpg_key
+#   RPM package GPG key to import. Uses source method. Should be a URL for Debian/RedHat OS family, or a file name for
 #   RedHat OS family. Set to https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey for Debian/RedHat OS Family by
 #   default. Note, that `key_content`, if specified, would override this parameter for Debian OS family.
 # @param package_name
@@ -355,6 +370,7 @@ class rabbitmq (
   Optional[Variant[Numeric, String]] $package_apt_pin                                              = undef,
   String $package_ensure                                                                           = 'installed',
   Optional[String] $package_gpg_key                                                                = undef,
+  Optional[String] $repo_gpg_key                                                                   = undef,
   Variant[String, Array] $package_name                                                             = 'rabbitmq',
   Optional[String] $package_source                                                                 = undef,
   Optional[String] $package_provider                                                               = undef,

--- a/manifests/repo/rhel.pp
+++ b/manifests/repo/rhel.pp
@@ -2,22 +2,34 @@
 #
 # @api private
 class rabbitmq::repo::rhel (
-  $location          = "https://packagecloud.io/rabbitmq/rabbitmq-server/el/${facts['os'][release][major]}/\$basearch",
-  String $key_source = $rabbitmq::package_gpg_key,
+  $location                  = "https://packagecloud.io/rabbitmq/rabbitmq-server/el/${facts['os'][release][major]}/\$basearch",
+  String $repo_key_source    = $rabbitmq::repo_gpg_key,
+  String $package_key_source = $rabbitmq::package_gpg_key,
 ) {
+  # Import package key from rabbitmq to be able to
+  # sign the package and the repo.
+  # rabbitmq key is gpg-pubkey-6026dfca-573adfde
+  exec { "rpm --import ${package_key_source}":
+    path   => ['/bin','/usr/bin','/sbin','/usr/sbin'],
+    unless => 'rpm -q gpg-pubkey-6026dfca-573adfde 2>/dev/null',
+    before => YumRepo['rabbitmq'],
+  }
+
   yumrepo { 'rabbitmq':
-    ensure   => present,
-    name     => 'rabbitmq_rabbitmq-server',
-    baseurl  => $location,
-    gpgkey   => $key_source,
-    enabled  => 1,
-    gpgcheck => 1,
+    ensure        => present,
+    name          => 'rabbitmq_rabbitmq-server',
+    baseurl       => $location,
+    gpgkey        => $repo_key_source,
+    enabled       => 1,
+    gpgcheck      => 1,
+    repo_gpgcheck => 1,
   }
 
   # This may still be needed to prevent warnings
-  # packagecloud key is gpg-pubkey-d59097ab-52d46e88
-  exec { "rpm --import ${key_source}":
-    path   => ['/bin','/usr/bin','/sbin','/usr/sbin'],
-    unless => 'rpm -q gpg-pubkey-6026dfca-573adfde 2>/dev/null',
+  # packagecloud key is gpg-pubkey-4d206f89-5bbb8d59
+  exec { "rpm --import ${repo_key_source}":
+    path    => ['/bin','/usr/bin','/sbin','/usr/sbin'],
+    unless  => 'rpm -q gpg-pubkey-4d206f89-5bbb8d59 2>/dev/null',
+    require => YumRepo['rabbitmq'],
   }
 }


### PR DESCRIPTION
We have notice some errors coming up with this module and it seems as so packagecloud has change the way they want their repos set up. We have had to update other repos as well.
Package cloud documentation:
https://packagecloud.io/rabbitmq/rabbitmq-server/install#bash-rpm
https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/config_file.repo?os=rhel&dist=8&source=script

Error:
```
Notice: /Stage[main]/Rabbitmq::Repo::Rhel/Exec[rpm --import https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey]/returns: executed successfully
Error: Execution of '/usr/bin/dnf -d 0 -e 1 -y install rabbitmq-server' returned 1: Importing GPG key 0xDF309A0B:
 Userid     : "https://packagecloud.io/rabbitmq/erlang (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>"
 Fingerprint: 2EBD E413 D3CE 5D35 BCD1 5B7C 71C6 3471 DF30 9A0B
 From       : https://packagecloud.io/rabbitmq/erlang/gpgkey
The GPG keys listed for the "rabbitmq_rabbitmq-server" repository are already installed but they are not correct for this package.
Check that the correct key URLs are configured for this repository.. Failing package is: rabbitmq-server-3.9.15-1.el8.noarch
 GPG Keys are configured as: https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
Error: GPG check FAILED
Error: /Stage[main]/Rabbitmq::Install/Package[rabbitmq-server]/ensure: change from 'purged' to 'present' failed: Execution of '/usr/bin/dnf -d 0 -e 1 -y install rabbitmq-server' returned 1: Importing GPG key 0xDF309A0B:
 Userid     : "https://packagecloud.io/rabbitmq/erlang (https://packagecloud.io/docs#gpg_signing) <support@packagecloud.io>"
 Fingerprint: 2EBD E413 D3CE 5D35 BCD1 5B7C 71C6 3471 DF30 9A0B
 From       : https://packagecloud.io/rabbitmq/erlang/gpgkey
The GPG keys listed for the "rabbitmq_rabbitmq-server" repository are already installed but they are not correct for this package.
Check that the correct key URLs are configured for this repository.. Failing package is: rabbitmq-server-3.9.15-1.el8.noarch
 GPG Keys are configured as: https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey
Error: GPG check FAILED
```