### PR TITLE
Make rabbitmq_plugin resource functional on RabbitMQ 3.10.x

### DIFF
--- a/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
+++ b/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
@@ -12,6 +12,7 @@ Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins, parent: Puppet::Pr
     end
 
     plugin_list.split(%r{\n}).map do |line|
+      next if line.start_with?('Listing plugins')
       raise Puppet::Error, "Cannot parse invalid plugins line: #{line}" unless line =~ %r{^(\S+)$}
 
       new(name: Regexp.last_match(1))

--- a/spec/unit/puppet/provider/rabbitmq_plugin/rabbitmqctl_spec.rb
+++ b/spec/unit/puppet/provider/rabbitmq_plugin/rabbitmqctl_spec.rb
@@ -22,6 +22,16 @@ describe provider_class do
     provider.create
   end
 
+  context 'with RabbitMQ version >=3.10.0' do
+    it 'matches plugins' do
+      provider.expects(:rabbitmqplugins).with('list', '-E', '-m').returns <<~EOT
+        Listing plugins with pattern ".*" ...
+        foo
+      EOT
+      expect(provider.exists?).to eq(true)
+    end
+  end
+
   context 'with RabbitMQ version >=3.4.0' do
     it 'calls rabbitmqplugins to enable' do
       provider.class.expects(:rabbitmq_version).returns '3.4.0'


### PR DESCRIPTION
The rabbitmq_plugin resource use the "rabbitmq-plugins"-command when
enumerating enabled plugins.  Starting with rabbitmq 3.10, this command
will output a informational message:
'Listing plugins with pattern ".*" ...' which can be hidden with the -s
or -q parameter.  However, this approach will break rabbitmq_plugin on
older versions of RabbitMQ.

This patch implements a workaround that simply ignores the outputted line
if it exists.

Fixes: #909

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
