### PR TITLE
Enable usage of custom list of plugins when using static config file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,7 @@ class rabbitmq::config {
   $admin_enable                        = $rabbitmq::admin_enable
   $management_enable                   = $rabbitmq::management_enable
   $use_config_file_for_plugins         = $rabbitmq::use_config_file_for_plugins
+  $plugins                             = $rabbitmq::plugins
   $cluster_node_type                   = $rabbitmq::cluster_node_type
   $cluster_nodes                       = $rabbitmq::cluster_nodes
   $config                              = $rabbitmq::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,6 +116,8 @@
 # @param use_config_file_for_plugins
 #   If enabled the /etc/rabbitmq/enabled_plugins config file is created,
 #   replacing the use of the rabbitmqplugins provider to enable plugins.
+# @param plugins
+#   Additional list of plugins to start, or to add to /etc/rabbitmq/enabled_plugins, if use_config_file_for_plugins is enabled.
 # @param auth_backends
 #   An array specifying authorization/authentication backend to use. Single quotes should be placed around array entries,
 #   ex. `['{foo, baz}', 'baz']` Defaults to [rabbit_auth_backend_internal], and if using LDAP defaults to [rabbit_auth_backend_internal,
@@ -345,6 +347,7 @@ class rabbitmq (
   Boolean $admin_enable                                                                            = true,
   Boolean $management_enable                                                                       = false,
   Boolean $use_config_file_for_plugins                                                             = false,
+  Array $plugins                                                                                   = [],
   Hash $cluster                                                                                    = $rabbitmq::cluster,
   Enum['ram', 'disc'] $cluster_node_type                                                           = 'disc',
   Array $cluster_nodes                                                                             = [],
@@ -548,6 +551,14 @@ class rabbitmq (
           notify   => Class['rabbitmq::service'],
           provider => 'rabbitmqplugins',
         }
+      }
+    }
+    # Start anything else listed on the plugins array, if it was not started already by the other booleans
+    $plugins.each | $plugin | {
+      rabbitmq_plugin { $plugin:
+        ensure   => present,
+        notify   => Class['rabbitmq::service'],
+        provider => 'rabbitmqplugins',
       }
     }
   }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -682,7 +682,7 @@ describe 'rabbitmq' do
       end
 
       context 'use config file for plugins' do
-        describe 'config_plugins_file: true' do
+        describe 'config_plugins_file: true and default list of enabled plugins' do
           let :params do
             { use_config_file_for_plugins: true }
           end
@@ -697,6 +697,26 @@ describe 'rabbitmq' do
 
           it 'configures enabled_plugins' do
             is_expected.to contain_file('enabled_plugins').with_content(%r{\[rabbitmq_management\]\.})
+          end
+        end
+
+        describe 'config_plugins_file: true and custom list of enabled plugins' do
+          let :params do
+            {
+              use_config_file_for_plugins: true,
+              admin_enable: false,
+              plugins: %w[rabbitmq_stomp rabbitmq_shovel rabbitmq_prometheus]
+            }
+          end
+
+          it 'does not use rabbitmqplugin provider' do
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_stomp')
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_shovel')
+            is_expected.not_to contain_rabbitmq_plugin('rabbitmq_prometheus')
+          end
+
+          it 'configures enabled_plugins' do
+            is_expected.to contain_file('enabled_plugins').with_content(%r{\[rabbitmq_stomp,rabbitmq_shovel,rabbitmq_prometheus\]\.})
           end
         end
 

--- a/templates/enabled_plugins.erb
+++ b/templates/enabled_plugins.erb
@@ -1,6 +1,6 @@
 % This file managed by Puppet
 % Template Path: <%= @module_name %>/templates/enabled_plugins
-<%- @_plugins = [] -%>
+<%- @_plugins = @plugins -%>
 <%- if @admin_enable or @management_enable -%>
   <%- @_plugins << 'rabbitmq_management' -%>
 <%- end -%>
@@ -16,4 +16,4 @@
     <%- @_plugins << 'rabbitmq_shovel_management' -%>
   <%- end -%>
 <%- end -%>
-[<%= @_plugins.join(',')%>].
+[<%= (@_plugins.uniq).join(',')%>].


### PR DESCRIPTION
This PR enables usage of a custom list of plugins when using a plugins config file, as reported on #916