### PR TITLE
Minor fix to resolve a linting check

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -128,7 +128,7 @@ class rabbitmq::config {
       $proto_dist = 'inet6_tcp'
       $ssl_path = ''
     }
-    $ipv6_or_tls_env = ['SERVER_ADDITIONAL', 'CTL'].reduce( {}) |$memo, $item| {
+    $ipv6_or_tls_env = ['SERVER_ADDITIONAL', 'CTL'].reduce({}) |$memo, $item| {
       $orig = $_environment_variables["RABBITMQ_${item}_ERL_ARGS"]
       $munged = $orig ? {
         # already quoted, keep quoting


### PR DESCRIPTION
This resolves the current error when the sintax test runs:
```
$ bundle exec rake lint
manifests/config.pp:131:manifest_whitespace_opening_brace_before:ERROR:there should be a single space before an opening brace
```