### PR TITLE
Fix detection of management_ip_address for rabbitmqadmin

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -27,8 +27,14 @@ class rabbitmq::install::rabbitmqadmin {
 
     $default_user = $rabbitmq::default_user
     $default_pass = $rabbitmq::default_pass
-    $management_ip_address = $rabbitmq::management_ip_address
     $archive_options = $rabbitmq::archive_options
+
+    # This should be consistent with rabbitmq::config
+    if $rabbitmq::management_ip_address {
+      $management_ip_address = $rabbitmq::management_ip_address
+    } else {
+      $management_ip_address = $rabbitmq::node_ip_address
+    }
 
     if !($management_ip_address) {
       # Pull from localhost if we don't have an explicit bind address


### PR DESCRIPTION
#### Pull Request (PR) description
This fixes inconsistent logic to determine management ip address if the rabbitmq::management_ip_address parameter is not set, and makes sure all logic tries to look up the rabbitmq::node_ip_address parameter.


#### This Pull Request (PR) fixes the following issues
N/A
