### PR TITLE
Remove deprecated `Stdlib::Compat`

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -39,7 +39,7 @@ class rabbitmq::install::rabbitmqadmin {
     if !($management_ip_address) {
       # Pull from localhost if we don't have an explicit bind address
       $sanitized_ip = '127.0.0.1'
-    } elsif $management_ip_address =~ Stdlib::Compat::Ipv6 {
+    } elsif $management_ip_address =~ Stdlib::IP::Address::V6::Nosubnet {
       $sanitized_ip = join(enclose_ipv6(any2array($management_ip_address)), ',')
     } else {
       $sanitized_ip = $management_ip_address

--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 9.0.0"
+      "version_requirement": ">= 4.25.0 < 9.0.0"
     },
     {
       "name": "puppet/archive",


### PR DESCRIPTION
#### Pull Request (PR) description
- Increase minimum stdlib to 4.25.0
- Remove `Stdlib::Compat` for `Stdlib::IP::Address::V6::Nosubnet`

https://forge.puppet.com/modules/puppetlabs/stdlib/readme

Resolves test failures with latest stdlib

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
