### PR TITLE
Support FreeBSD 12 and 13

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,11 @@
       ]
     },
     {
-      "operatingsystem": "FreeBSD"
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "12",
+        "13"
+      ]
     },
     {
       "operatingsystem": "OpenBSD"


### PR DESCRIPTION
#### Pull Request (PR) description
Update tests and metadata to support FreeBSD 12 and 13 This also helps us unit test the (otherwise untested) conditionals related to systems without systemd

We may still need to tweak the current python package name, but this is a start

Per @bastelfreak's suggestion, use `os_facts` to avoid confusion with 
`:facts`

#### This Pull Request (PR) fixes the following issues
