### PR TITLE
RabbitMQ 3.8.2+ compatibility for rabbitmqctl list_users

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:rabbitmq_user).provide(
       rabbitmqctl_list('users')
     end
 
-    user_list.split(%r{\n}).map do |line|
+    user_list.split(%r{\n}).reject { |line| line.strip =~ %r{^user\s+tags$} }.map do |line|
       raise Puppet::Error, "Cannot parse invalid user line: #{line}" unless line =~ %r{^(\S+)\s+\[(.*?)\]$}
 
       user = Regexp.last_match(1)


### PR DESCRIPTION
rabbitmq-server's rabbitmqctl as of v3.7.8-4 (as shipped with Debian/buster) used to behave as follows:

```
| % sudo rabbitmqctl -q list_users
| foo        [bar]
```

As of rabbitmq-server v3.8.2-1+deb10u1 (as present in buster-security, see https://packages.qa.debian.org/r/rabbitmq-server/news/20230711T122021Z.html), it instead behaves as follows:

```
| % sudo rabbitmqctl -q list_users
| user    tags
| foo        [bar]
```

This results in:

```
| Error: Could not prefetch rabbitmq_user provider 'rabbitmqctl': Cannot parse invalid user line: user    tags
```

There's a new `--no-table-headers` option available in more recent versions of RabbitMQ (which would also be available for rabbitmq-server v3.8.2-1+deb10u1), also see https://github.com/rabbitmq/rabbitmq-cli/issues/273.

But since don't want to rely on having this option available (and therefore breaking compatibility with e.g. v3.7.8-4), let's instead skip lines matching this header output, to remaing both backwards as well as forwards compatible.

Related to https://github.com/voxpupuli/puppet-rabbitmq/issues/740

FTR: tested/verified with rabbitmq-server v3.7.8-4 + v3.8.2-1+deb10u1
