### PR TITLE
fix purge rabbitmq_parameter

### DIFF
--- a/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
@@ -69,9 +69,9 @@ Puppet::Type.type(:rabbitmq_parameter).provide(:rabbitmqctl, parent: Puppet::Pro
     key = resource[:name].rpartition('@').first
 
     if @property_flush[:ensure] == :absent
-      rabbitmqctl('clear_parameter', '-p', vhost, resource[:component_name], key)
+      rabbitmqctl('clear_parameter', '-p', vhost, component_name, key)
     else
-      rabbitmqctl('set_parameter', '-p', vhost, resource[:component_name], key, resource[:value].to_json)
+      rabbitmqctl('set_parameter', '-p', vhost, component_name, key, resource[:value].to_json)
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
purging shovels was not working since #832.

I don't know why, but `resource[:component_name]` is an empty string when calling `clear_parameter`. Using the instance variable `component name` works.

I don't know why the `resource object` is used to get instance variable in an instance function.

I just change component name to discuss about this bug, but for consistency, other variables in this function should be changed:
- `resource[:name]` -> `name`
- `resource[:value]` -> `value`