### PR TITLE
fix purge rabbitmq_parameter

### DIFF
--- a/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
@@ -69,7 +69,7 @@ Puppet::Type.type(:rabbitmq_parameter).provide(:rabbitmqctl, parent: Puppet::Pro
     key = resource[:name].rpartition('@').first
 
     if @property_flush[:ensure] == :absent
-      rabbitmqctl('clear_parameter', '-p', vhost, resource[:component_name], key)
+      rabbitmqctl('clear_parameter', '-p', vhost, resource[:component_name] || component_name, key)
     else
       rabbitmqctl('set_parameter', '-p', vhost, resource[:component_name], key, resource[:value].to_json)
     end

--- a/spec/acceptance/parameter_spec.rb
+++ b/spec/acceptance/parameter_spec.rb
@@ -45,4 +45,23 @@ describe 'rabbitmq parameter on a vhost:' do
       end
     end
   end
+
+  context 'destroy parameter resource' do
+    it 'runs successfully' do
+      pp = <<-EOS
+      rabbitmq_parameter { 'documentumFed@fedhost':
+        ensure => absent,
+      }
+      EOS
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    it 'does not have the parameter' do
+      shell('rabbitmqctl list_parameters -q') do |r|
+        expect(r.stdout).not_to match(%r{documentumFed\s+})
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
`resource[:component_name]` is set on creation (`ensure => present`) and deletion (`ensure => absent`) of the rabbitmq_parameter type but it is not set when it's removed from puppet-purge.

On the other hand,  `component_name` is set to absent on creation, is set on deletion and on purge.

```
             resource[:component_name]          component_name
creation          shovel                           :absent
deletion          shovel                           shovel
purge              nil                             shovel
```

When deleting a parameter, replace `resource[:component_name']` with `resource[:component_name] || component_name`.

this bug was introduced by #833 (for #832)