### PR TITLE
Treat `initial-cluster-size` option in policy as an integer

### DIFF
--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -120,9 +120,13 @@ Puppet::Type.newtype(:rabbitmq_policy) do
       ha_sync_batch_size_val = definition['ha-sync-batch-size']
       raise ArgumentError, "Invalid ha-sync-batch-size value '#{ha_sync_batch_size_val}'" unless ha_sync_batch_size_val.to_i.to_s == ha_sync_batch_size_val
     end
-    if definition.key? 'delivery-limit' # rubocop:disable Style/GuardClause
+    if definition.key? 'delivery-limit'
       delivery_limit_val = definition['delivery-limit']
       raise ArgumentError, "Invalid delivery-limit value '#{delivery_limit_val}'" unless delivery_limit_val.to_i.to_s == delivery_limit_val
+    end
+    if definition.key? 'initial-cluster-size' # rubocop:disable Style/GuardClause
+      initial_cluster_size_val = definition['initial-cluster-size']
+      raise ArgumentError, "Invalid initial-cluster-size value '#{initial_cluster_size_val}'" unless initial_cluster_size_val.to_i.to_s == initial_cluster_size_val
     end
   end
 
@@ -135,6 +139,7 @@ Puppet::Type.newtype(:rabbitmq_policy) do
     definition['shards-per-node'] = definition['shards-per-node'].to_i if definition.key? 'shards-per-node'
     definition['ha-sync-batch-size'] = definition['ha-sync-batch-size'].to_i if definition.key? 'ha-sync-batch-size'
     definition['delivery-limit'] = definition['delivery-limit'].to_i if definition.key? 'delivery-limit'
+    definition['initial-cluster-size'] = definition['initial-cluster-size'].to_i if definition.key? 'initial-cluster-size'
     definition
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_policy_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_policy_spec.rb
@@ -195,6 +195,19 @@ describe Puppet::Type.type(:rabbitmq_policy) do
     end.to raise_error(Puppet::Error, %r{Invalid delivery-limit value.*future})
   end
 
+  it 'accepts and converts the initial-cluster-size value' do
+    definition = { 'initial-cluster-size' => '3' }
+    policy[:definition] = definition
+    expect(policy[:definition]['initial-cluster-size']).to eq(3)
+  end
+
+  it 'does not accept non-numeric initial-cluster-size value' do
+    definition = { 'initial-cluster-size' => 'impressive' }
+    expect do
+      policy[:definition] = definition
+    end.to raise_error(Puppet::Error, %r{Invalid initial-cluster-size value 'impressive})
+  end
+
   context 'accepts list value in ha-params when ha-mode = nodes' do
     before do
       policy[:definition] = definition


### PR DESCRIPTION
#### Pull Request (PR) description

Similiar to https://github.com/voxpupuli/puppet-rabbitmq/pull/628, the policy setting `initial-cluster-size` needs to be parsed into an integer before being passed to RMQ. 

Fixes this:

```
Error:
Validation failed

<<"3">> is not a valid cluster size

```