### PR TITLE
Switch from garethr/erlang->puppet/erlang

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,6 @@ fixtures:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
     apt: 'https://github.com/puppetlabs/puppetlabs-apt'
     archive: 'https://github.com/voxpupuli/puppet-archive'
-    erlang: 'https://github.com/garethr/garethr-erlang'
+    erlang: 'https://github.com/voxpupuli/puppet-erlang'
     systemd: 'https://github.com/voxpupuli/puppet-systemd'
     yumrepo_core: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,4 +5,5 @@ fixtures:
     archive: 'https://github.com/voxpupuli/puppet-archive'
     erlang: 'https://github.com/voxpupuli/puppet-erlang'
     systemd: 'https://github.com/voxpupuli/puppet-systemd'
+    epel: 'https://github.com/voxpupuli/puppet-epel'
     yumrepo_core: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core'

--- a/examples/erlang_deps.pp
+++ b/examples/erlang_deps.pp
@@ -1,5 +1,4 @@
-# install first the garethr-erlang module. See README.md
+# install first the puppet/erlang module. See README.md
 include erlang
 
-class { 'erlang': epel_enable => true }
 Class['erlang'] -> Class['rabbitmq']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -492,6 +492,8 @@ class rabbitmq (
     }
   }
 
+  # when repos_ensure is true, we configure externel repos
+  # CentOS 7 doesn't contain rabbitmq. It's only in EPEL.
   if $repos_ensure {
     case $facts['os']['family'] {
       'RedHat': {
@@ -505,6 +507,8 @@ class rabbitmq (
       default: {
       }
     }
+  } elsif ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7') {
+    require epel
   }
 
   contain rabbitmq::install

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -17,7 +17,7 @@ describe 'rabbitmq class:' do
       <<-EOS
       class { 'rabbitmq': }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS
@@ -55,7 +55,7 @@ describe 'rabbitmq class:' do
           service_ensure => 'stopped',
         }
         if $facts['os']['family'] == 'RedHat' {
-          class { 'erlang': epel_enable => true}
+          class { 'erlang': }
           Class['erlang'] -> Class['rabbitmq']
         }
       EOS
@@ -74,7 +74,7 @@ describe 'rabbitmq class:' do
       pp_pre = <<-EOS
         class { 'rabbitmq': }
         if $facts['os']['family'] == 'RedHat' {
-          class { 'erlang': epel_enable => true}
+          class { 'erlang': }
           Class['erlang'] -> Class['rabbitmq']
         }
       EOS
@@ -85,7 +85,7 @@ describe 'rabbitmq class:' do
           service_ensure  => 'stopped',
         }
         if $facts['os']['family'] == 'RedHat' {
-          class { 'erlang': epel_enable => true}
+          class { 'erlang': }
           Class['erlang'] -> Class['rabbitmq']
         }
       EOS

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -15,11 +15,7 @@ describe 'rabbitmq class:' do
   context 'default class inclusion' do
     let(:pp) do
       <<-EOS
-      class { 'rabbitmq': }
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': }
-        Class['erlang'] -> Class['rabbitmq']
-      }
+      include rabbitmq
       EOS
     end
 
@@ -54,10 +50,6 @@ describe 'rabbitmq class:' do
         class { 'rabbitmq':
           service_ensure => 'stopped',
         }
-        if $facts['os']['family'] == 'RedHat' {
-          class { 'erlang': }
-          Class['erlang'] -> Class['rabbitmq']
-        }
       EOS
     end
 
@@ -73,20 +65,12 @@ describe 'rabbitmq class:' do
     it 'runs successfully' do
       pp_pre = <<-EOS
         class { 'rabbitmq': }
-        if $facts['os']['family'] == 'RedHat' {
-          class { 'erlang': }
-          Class['erlang'] -> Class['rabbitmq']
-        }
       EOS
 
       pp = <<-EOS
         class { 'rabbitmq':
           service_manage => false,
           service_ensure  => 'stopped',
-        }
-        if $facts['os']['family'] == 'RedHat' {
-          class { 'erlang': }
-          Class['erlang'] -> Class['rabbitmq']
         }
       EOS
 

--- a/spec/acceptance/clustering_spec.rb
+++ b/spec/acceptance/clustering_spec.rb
@@ -15,7 +15,7 @@ describe 'rabbitmq clustering' do
         wipe_db_on_cookie_change => false,
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS
@@ -40,7 +40,7 @@ describe 'rabbitmq clustering' do
         wipe_db_on_cookie_change => true,
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS
@@ -85,7 +85,7 @@ describe 'rabbitmq clustering' do
         erlang_cookie            => 'TESTCOOKIE',
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS

--- a/spec/acceptance/delete_guest_user_spec.rb
+++ b/spec/acceptance/delete_guest_user_spec.rb
@@ -11,7 +11,7 @@ describe 'rabbitmq with delete_guest_user' do
         delete_guest_user => true,
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS

--- a/spec/acceptance/parameter_spec.rb
+++ b/spec/acceptance/parameter_spec.rb
@@ -7,7 +7,7 @@ describe 'rabbitmq parameter on a vhost:' do
     it 'runs successfully' do
       pp = <<-EOS
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
+        class { 'erlang':  }
         Class['erlang'] -> Class['rabbitmq']
       }
       class { 'rabbitmq':

--- a/spec/acceptance/policy_spec.rb
+++ b/spec/acceptance/policy_spec.rb
@@ -7,7 +7,7 @@ describe 'rabbitmq policy on a vhost:' do
     it 'runs successfully' do
       pp = <<-EOS
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
+        class { 'erlang':  }
         Class['erlang'] -> Class['rabbitmq']
       }
       class { 'rabbitmq':

--- a/spec/acceptance/queue_spec.rb
+++ b/spec/acceptance/queue_spec.rb
@@ -7,7 +7,7 @@ describe 'rabbitmq binding:' do
     it 'runs successfully' do
       pp = <<-EOS
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
+        class { 'erlang':  }
         Class['erlang'] -> Class['rabbitmq']
       }
       class { 'rabbitmq':
@@ -81,7 +81,7 @@ describe 'rabbitmq binding:' do
     it 'runs successfully' do
       pp = <<-EOS
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
+        class { 'erlang':  }
         Class['erlang'] -> Class['rabbitmq']
       }
       class { 'rabbitmq':
@@ -169,7 +169,7 @@ describe 'rabbitmq binding:' do
     it 'runs successfully' do
       pp = <<-EOS
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
+        class { 'erlang':  }
         Class['erlang'] -> Class['rabbitmq']
       }
       class { 'rabbitmq':

--- a/spec/acceptance/rabbitmqadmin_spec.rb
+++ b/spec/acceptance/rabbitmqadmin_spec.rb
@@ -11,7 +11,7 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
         service_manage => true,
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS
@@ -32,7 +32,7 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
         service_manage => false,
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS
@@ -56,7 +56,7 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
         default_pass   => 'bazblam',
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS
@@ -69,7 +69,7 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
         default_pass   => 'bazblam',
       }
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
+        class { 'erlang': }
         Class['erlang'] -> Class['rabbitmq']
       }
       EOS

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -7,7 +7,7 @@ describe 'rabbitmq user:' do
     it 'runs successfully' do
       pp = <<-EOS
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
+        class { 'erlang':  }
         Class['erlang'] -> Class['rabbitmq']
       }
       class { 'rabbitmq':

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -7,7 +7,7 @@ describe 'rabbitmq vhost:' do
     it 'runs successfully' do
       pp = <<-EOS
       if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
+        class { 'erlang':  }
         Class['erlang'] -> Class['rabbitmq']
       }
       class { 'rabbitmq':

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -8,6 +8,7 @@ configure_beaker do |host|
     install_puppet_module_via_pmt_on(host, 'puppetlabs-apt', '>= 4.1.0 < 9.0.0')
   when 'RedHat'
     install_puppet_module_via_pmt_on(host, 'puppet-erlang', '>= 1.1.0 < 2.0.0')
+    install_puppet_module_via_pmt_on(host, 'puppet-epel', '>= 5.0.0 < 6.0.0')
     if fact_on(host, 'os.selinux.enabled')
       # Make sure selinux is disabled so the tests work.
       on host, puppet('resource', 'exec', 'setenforce 0', 'path=/bin:/sbin:/usr/bin:/usr/sbin', 'onlyif=which setenforce && getenforce | grep Enforcing')

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,7 +7,7 @@ configure_beaker do |host|
   when 'Debian'
     install_puppet_module_via_pmt_on(host, 'puppetlabs-apt', '>= 4.1.0 < 9.0.0')
   when 'RedHat'
-    install_puppet_module_via_pmt_on(host, 'garethr-erlang', '>= 0.3.0 < 1.0.0')
+    install_puppet_module_via_pmt_on(host, 'puppet-erlang', '>= 1.1.0 < 2.0.0')
     if fact_on(host, 'os.selinux.enabled')
       # Make sure selinux is disabled so the tests work.
       on host, puppet('resource', 'exec', 'setenforce 0', 'path=/bin:/sbin:/usr/bin:/usr/sbin', 'onlyif=which setenforce && getenforce | grep Enforcing')


### PR DESCRIPTION
@wyardley we cannot update the other modules because garether/erlang requires an old stdlib version. gareth doesn't maintain it anymore so we need to switch to another erlang module.