### PR TITLE
Bugfix: Fix parsing issue for queue policies targeted at quorum queues

### DIFF
--- a/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:rabbitmq_policy).provide(:rabbitmqctl, parent: Puppet::Provid
       # / ha-all all .* {"ha-mode":"all","ha-sync-mode":"automatic"} 0 << This is for RabbitMQ v < 3.7.0
       # / ha-all .* all {"ha-mode":"all","ha-sync-mode":"automatic"} 0 << This is for RabbitMQ v >= 3.7.0
       if Puppet::Util::Package.versioncmp(rabbitmq_version, '3.7') >= 0
-        regex = %r{^(\S+)\s+(\S+)\s+(\S+)\s+(all|exchanges|queues)?\s+(\S+)\s+(\d+)$}
+        regex = %r{^(\S+)\s+(\S+)\s+(\S+)\s+(all|exchanges|(?:classic_|quorum_)?queues|streams)?\s+(\S+)\s+(\d+)$}
         applyto_index = 4
         pattern_index = 3
       else


### PR DESCRIPTION
Related to https://github.com/voxpupuli/puppet-rabbitmq/pull/948 - this allowed us to add policies targeted at classic_queues, quorum_queues, and streams. However after the policy is created and they are read out again in subsequent puppet runs, we get the following failure:
```
Could not evaluate: cannot parse line from list_policies
```

This modification fixes this parsing issue and adds a test which covers this change and also covers test parsing a set of alternative policy settings which aren't currently tested for (different pattern/definitions containing integer values).