### PR TITLE
add a workaround for rabbitmq_vhost when running with --noop or --tags

### DIFF
--- a/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
@@ -19,6 +19,11 @@ Puppet::Type.type(:rabbitmq_vhost).provide(
   # we only deal with vhost metadata >= version 3.11.0
   def self.supports_metadata?
     Puppet::Util::Package.versioncmp(rabbitmq_version, '3.11') >= 0
+  rescue Puppet::MissingCommand
+    # See comment on the definition of rabbitmqctl_list in rabbitmqctl_cli.rb;
+    # the same rationale applies here.
+    Puppet.debug('supports_metadata?: rabbitmqctl command not found; assuming rabbitmq is not installed')
+    false
   end
 
   def supports_metadata?


### PR DESCRIPTION
#### Pull Request (PR) description

This fixes the error:
```
Error: Could not prefetch rabbitmq_vhost provider 'rabbitmqctl': Command rabbitmqctl is missing
```
The problem, and the workaround, are the same as that described in commit 8a3a27a0584666e71bf64b2eb49adf79133939c1, "add a workaround for running with --noop or --tags".

This is necessary because the original workaround is for `rabbitmqctl_list()`, whereas `rabbitmq_version()` calls `rabbitmqctl()` directly.

Other callers of `rabbitmq_version()` should not need this workaround, since they are not run in a state where rabbitmq itself is not yet installed.

#### This Pull Request (PR) fixes the following issues

Fixes #961