### PR TITLE
Harden codebase and add documentation stubs

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,3 +1,1 @@
 --fail-on-warnings
---no-parameter_documentation-check
---no-parameter_types-check

--- a/.sync.yml
+++ b/.sync.yml
@@ -2,3 +2,7 @@
 spec/spec_helper.rb:
   spec_overrides: "require 'spec_helper_local'"
   mock_with: ':mocha'
+.puppet-lint.rc:
+  enabled_lint_checks:
+    - parameter_documentation
+    - parameter_types

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -247,6 +247,8 @@ The following parameters are available in the `rabbitmq` class:
 * [`package_apt_pin`](#-rabbitmq--package_apt_pin)
 * [`package_ensure`](#-rabbitmq--package_ensure)
 * [`package_gpg_key`](#-rabbitmq--package_gpg_key)
+* [`package_source`](#-rabbitmq--package_source)
+* [`package_provider`](#-rabbitmq--package_provider)
 * [`repo_gpg_key`](#-rabbitmq--repo_gpg_key)
 * [`package_name`](#-rabbitmq--package_name)
 * [`port`](#-rabbitmq--port)
@@ -271,6 +273,7 @@ The following parameters are available in the `rabbitmq` class:
 * [`ssl_management_cacert`](#-rabbitmq--ssl_management_cacert)
 * [`ssl_management_cert`](#-rabbitmq--ssl_management_cert)
 * [`ssl_management_key`](#-rabbitmq--ssl_management_key)
+* [`ssl_management_fail_if_no_peer_cert`](#-rabbitmq--ssl_management_fail_if_no_peer_cert)
 * [`ssl_port`](#-rabbitmq--ssl_port)
 * [`ssl_reuse_sessions`](#-rabbitmq--ssl_reuse_sessions)
 * [`ssl_secure_renegotiate`](#-rabbitmq--ssl_secure_renegotiate)
@@ -297,9 +300,6 @@ The following parameters are available in the `rabbitmq` class:
 * [`rabbitmqadmin_package`](#-rabbitmq--rabbitmqadmin_package)
 * [`archive_options`](#-rabbitmq--archive_options)
 * [`loopback_users`](#-rabbitmq--loopback_users)
-* [`package_source`](#-rabbitmq--package_source)
-* [`package_provider`](#-rabbitmq--package_provider)
-* [`ssl_management_fail_if_no_peer_cert`](#-rabbitmq--ssl_management_fail_if_no_peer_cert)
 
 ##### <a name="-rabbitmq--admin_enable"></a>`admin_enable`
 
@@ -739,6 +739,22 @@ for Debian/RedHat OS Family by default.
 
 Default value: `undef`
 
+##### <a name="-rabbitmq--package_source"></a>`package_source`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
+
+##### <a name="-rabbitmq--package_provider"></a>`package_provider`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
+
 ##### <a name="-rabbitmq--repo_gpg_key"></a>`repo_gpg_key`
 
 Data type: `Optional[String]`
@@ -936,6 +952,14 @@ Data type: `Optional[Stdlib::Absolutepath]`
 SSL management key. If unset set to ssl_key for backwards compatibility.
 
 Default value: `$ssl_key`
+
+##### <a name="-rabbitmq--ssl_management_fail_if_no_peer_cert"></a>`ssl_management_fail_if_no_peer_cert`
+
+Data type: `Boolean`
+
+
+
+Default value: `false`
 
 ##### <a name="-rabbitmq--ssl_port"></a>`ssl_port`
 
@@ -1154,30 +1178,6 @@ Data type: `Array`
 This option configures a list of users to allow access via the loopback interfaces
 
 Default value: `['guest']`
-
-##### <a name="-rabbitmq--package_source"></a>`package_source`
-
-Data type: `Optional[String]`
-
-
-
-Default value: `undef`
-
-##### <a name="-rabbitmq--package_provider"></a>`package_provider`
-
-Data type: `Optional[String]`
-
-
-
-Default value: `undef`
-
-##### <a name="-rabbitmq--ssl_management_fail_if_no_peer_cert"></a>`ssl_management_fail_if_no_peer_cert`
-
-Data type: `Boolean`
-
-
-
-Default value: `false`
 
 ## Resource types
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1260,7 +1260,7 @@ Default value: `queue`
 
 Valid values: `present`, `absent`
 
-The basic property that the resource should be in.
+Whether the resource should be present or absent
 
 Default value: `present`
 
@@ -1358,7 +1358,7 @@ The following properties are available in the `rabbitmq_cluster` type.
 
 Valid values: `present`, `absent`
 
-The basic property that the resource should be in.
+Whether the resource should be present or absent
 
 Default value: `present`
 
@@ -1439,11 +1439,13 @@ The following parameters are available in the `rabbitmq_erlang_cookie` type.
 
 Valid values: `true`, `false`
 
+Force parameter
 
 Default value: `false`
 
 ##### <a name="-rabbitmq_erlang_cookie--path"></a>`path`
 
+Path of the erlang cookie
 
 ##### <a name="-rabbitmq_erlang_cookie--provider"></a>`provider`
 
@@ -1452,16 +1454,19 @@ will usually discover the appropriate provider for your platform.
 
 ##### <a name="-rabbitmq_erlang_cookie--rabbitmq_group"></a>`rabbitmq_group`
 
+Rabbitmq Group
 
 Default value: `rabbitmq`
 
 ##### <a name="-rabbitmq_erlang_cookie--rabbitmq_home"></a>`rabbitmq_home`
 
+Path to the rabbitmq home directory
 
 Default value: `/var/lib/rabbitmq`
 
 ##### <a name="-rabbitmq_erlang_cookie--rabbitmq_user"></a>`rabbitmq_user`
 
+Rabbitmq User
 
 Default value: `rabbitmq`
 
@@ -1469,6 +1474,7 @@ Default value: `rabbitmq`
 
 Valid values: `%r{^\S+$}`
 
+Name of the service
 
 ### <a name="rabbitmq_exchange"></a>`rabbitmq_exchange`
 
@@ -1501,7 +1507,7 @@ The following properties are available in the `rabbitmq_exchange` type.
 
 Valid values: `present`, `absent`
 
-The basic property that the resource should be in.
+Whether the resource should be present or absent
 
 Default value: `present`
 
@@ -1635,7 +1641,7 @@ The component_name to use when setting parameter, eg: shovel or federation
 
 Valid values: `present`, `absent`
 
-The basic property that the resource should be in.
+Whether the resource should be present or absent
 
 Default value: `present`
 
@@ -1709,7 +1715,7 @@ The following properties are available in the `rabbitmq_plugin` type.
 
 Valid values: `present`, `absent`
 
-The basic property that the resource should be in.
+Whether the resource should be present or absent
 
 Default value: `present`
 
@@ -1789,7 +1795,7 @@ policy definition
 
 Valid values: `present`, `absent`
 
-The basic property that the resource should be in.
+Whether the resource should be present or absent
 
 Default value: `present`
 
@@ -1855,7 +1861,7 @@ The following properties are available in the `rabbitmq_queue` type.
 
 Valid values: `present`, `absent`
 
-The basic property that the resource should be in.
+Whether the resource should be present or absent
 
 Default value: `present`
 
@@ -1970,7 +1976,7 @@ Default value: `false`
 
 Valid values: `present`, `absent`
 
-The basic property that the resource should be in.
+Whether the resource should be present or absent
 
 Default value: `present`
 
@@ -2032,7 +2038,7 @@ regexp representing configuration permissions
 
 Valid values: `present`, `absent`
 
-The basic property that the resource should be in.
+Whether the resource should be present or absent
 
 Default value: `present`
 
@@ -2105,7 +2111,7 @@ A description of the vhost
 
 Valid values: `present`, `absent`
 
-The basic property that the resource should be in.
+Whether the resource should be present or absent
 
 Default value: `present`
 

--- a/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_binding/rabbitmqadmin.rb
@@ -6,6 +6,7 @@ require 'digest'
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
 Puppet::Type.type(:rabbitmq_binding).provide(:rabbitmqadmin, parent: Puppet::Provider::RabbitmqCli) do
+  desc 'Rabbitmqadmin provider for rabbitmq binding'
   confine feature: :posix
 
   # Without this, the composite namevar stuff doesn't work properly.

--- a/lib/puppet/provider/rabbitmq_cluster/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_cluster/rabbitmqctl.rb
@@ -5,6 +5,7 @@ Puppet::Type.type(:rabbitmq_cluster).provide(
   :rabbitmqctl,
   parent: Puppet::Provider::RabbitmqCli
 ) do
+  desc 'Rabbitmqctl provider for rabbitmq cluster'
   confine feature: :posix
 
   def exists?

--- a/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
+++ b/lib/puppet/provider/rabbitmq_erlang_cookie/ruby.rb
@@ -3,6 +3,7 @@
 require 'puppet'
 require 'set'
 Puppet::Type.type(:rabbitmq_erlang_cookie).provide(:ruby) do
+  desc 'Ruby provider for rabbitmq erlang cookie'
   confine feature: :posix
 
   def exists?

--- a/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_exchange/rabbitmqadmin.rb
@@ -3,6 +3,7 @@
 require 'puppet'
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
 Puppet::Type.type(:rabbitmq_exchange).provide(:rabbitmqadmin, parent: Puppet::Provider::RabbitmqCli) do
+  desc 'Rabbitmqadmin provider for rabbitmq exchange'
   confine feature: :posix
 
   def should_vhost

--- a/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_parameter/rabbitmqctl.rb
@@ -5,6 +5,7 @@ require 'puppet/util/package'
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
 Puppet::Type.type(:rabbitmq_parameter).provide(:rabbitmqctl, parent: Puppet::Provider::RabbitmqCli) do
+  desc 'Rabbitmqctl provider for rabbitmq parameter'
   confine feature: :posix
 
   mk_resource_methods

--- a/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
+++ b/lib/puppet/provider/rabbitmq_plugin/rabbitmqplugins.rb
@@ -4,6 +4,7 @@ require 'puppet/util/package'
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
 Puppet::Type.type(:rabbitmq_plugin).provide(:rabbitmqplugins, parent: Puppet::Provider::RabbitmqCli) do
+  desc 'Rabbitmqplugins provider for rabbitmq plugin'
   confine feature: :posix
 
   def self.plugin_list

--- a/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_policy/rabbitmqctl.rb
@@ -5,6 +5,7 @@ require 'puppet/util/package'
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
 Puppet::Type.type(:rabbitmq_policy).provide(:rabbitmqctl, parent: Puppet::Provider::RabbitmqCli) do
+  desc 'Rabbitmqctl provider for rabbitmq policy'
   confine feature: :posix
 
   # cache policies

--- a/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
+++ b/lib/puppet/provider/rabbitmq_queue/rabbitmqadmin.rb
@@ -5,6 +5,7 @@ require 'puppet'
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
 Puppet::Type.type(:rabbitmq_queue).provide(:rabbitmqadmin, parent: Puppet::Provider::RabbitmqCli) do
+  desc 'Rabbitmqadmin provider for rabbitmq queue'
   confine feature: :posix
 
   def should_vhost

--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -5,6 +5,7 @@ Puppet::Type.type(:rabbitmq_user).provide(
   :rabbitmqctl,
   parent: Puppet::Provider::RabbitmqCli
 ) do
+  desc 'Rabbitmqctl provider for rabbitmq user'
   confine feature: :posix
 
   def initialize(value = {})

--- a/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user_permissions/rabbitmqctl.rb
@@ -2,6 +2,7 @@
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rabbitmq_cli'))
 Puppet::Type.type(:rabbitmq_user_permissions).provide(:rabbitmqctl, parent: Puppet::Provider::RabbitmqCli) do
+  desc 'Rabbitmqctl provider for rabbitmq user permissions'
   confine feature: :posix
 
   # cache users permissions

--- a/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_vhost/rabbitmqctl.rb
@@ -5,6 +5,7 @@ Puppet::Type.type(:rabbitmq_vhost).provide(
   :rabbitmqctl,
   parent: Puppet::Provider::RabbitmqCli
 ) do
+  desc 'Rabbitmqctl provider for rabbitmq vhost'
   confine feature: :posix
 
   def self.prefetch(resources)

--- a/lib/puppet/type/rabbitmq_binding.rb
+++ b/lib/puppet/type/rabbitmq_binding.rb
@@ -41,6 +41,7 @@ Puppet::Type.newtype(:rabbitmq_binding) do
   DESC
 
   ensurable do
+    desc 'Whether the resource should be present or absent'
     defaultto(:present)
     newvalue(:present) do
       provider.create

--- a/lib/puppet/type/rabbitmq_cluster.rb
+++ b/lib/puppet/type/rabbitmq_cluster.rb
@@ -18,6 +18,7 @@ Puppet::Type.newtype(:rabbitmq_cluster) do
   DESC
 
   ensurable do
+    desc 'Whether the resource should be present or absent'
     defaultto(:present)
     newvalue(:present) do
       provider.create

--- a/lib/puppet/type/rabbitmq_erlang_cookie.rb
+++ b/lib/puppet/type/rabbitmq_erlang_cookie.rb
@@ -13,7 +13,9 @@ Puppet::Type.newtype(:rabbitmq_erlang_cookie) do
     this type directly.
   DESC
 
-  newparam(:path, namevar: true)
+  newparam(:path, namevar: true) do
+    desc 'Path of the erlang cookie'
+  end
 
   newproperty(:content) do
     desc 'Content of cookie'
@@ -33,23 +35,28 @@ Puppet::Type.newtype(:rabbitmq_erlang_cookie) do
   end
 
   newparam(:force) do
+    desc 'Force parameter'
     defaultto(:false)
     newvalues(:true, :false)
   end
 
   newparam(:rabbitmq_user) do
+    desc 'Rabbitmq User'
     defaultto('rabbitmq')
   end
 
   newparam(:rabbitmq_group) do
+    desc 'Rabbitmq Group'
     defaultto('rabbitmq')
   end
 
   newparam(:rabbitmq_home) do
+    desc 'Path to the rabbitmq home directory'
     defaultto('/var/lib/rabbitmq')
   end
 
   newparam(:service_name) do
+    desc 'Name of the service'
     newvalues(%r{^\S+$})
   end
 end

--- a/lib/puppet/type/rabbitmq_exchange.rb
+++ b/lib/puppet/type/rabbitmq_exchange.rb
@@ -20,6 +20,7 @@ Puppet::Type.newtype(:rabbitmq_exchange) do
   DESC
 
   ensurable do
+    desc 'Whether the resource should be present or absent'
     defaultto(:present)
     newvalue(:present) do
       provider.create

--- a/lib/puppet/type/rabbitmq_parameter.rb
+++ b/lib/puppet/type/rabbitmq_parameter.rb
@@ -36,6 +36,7 @@ Puppet::Type.newtype(:rabbitmq_parameter) do
   DESC
 
   ensurable do
+    desc 'Whether the resource should be present or absent'
     defaultto(:present)
     newvalue(:present) do
       provider.create

--- a/lib/puppet/type/rabbitmq_plugin.rb
+++ b/lib/puppet/type/rabbitmq_plugin.rb
@@ -20,6 +20,7 @@ Puppet::Type.newtype(:rabbitmq_plugin) do
   DESC
 
   ensurable do
+    desc 'Whether the resource should be present or absent'
     defaultto(:present)
     newvalue(:present) do
       provider.create

--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -17,6 +17,7 @@ Puppet::Type.newtype(:rabbitmq_policy) do
   DESC
 
   ensurable do
+    desc 'Whether the resource should be present or absent'
     defaultto(:present)
     newvalue(:present) do
       provider.create

--- a/lib/puppet/type/rabbitmq_queue.rb
+++ b/lib/puppet/type/rabbitmq_queue.rb
@@ -19,6 +19,7 @@ Puppet::Type.newtype(:rabbitmq_queue) do
   DESC
 
   ensurable do
+    desc 'Whether the resource should be present or absent'
     defaultto(:present)
     newvalue(:present) do
       provider.create

--- a/lib/puppet/type/rabbitmq_user.rb
+++ b/lib/puppet/type/rabbitmq_user.rb
@@ -23,6 +23,7 @@ Puppet::Type.newtype(:rabbitmq_user) do
   DESC
 
   ensurable do
+    desc 'Whether the resource should be present or absent'
     defaultto(:present)
     newvalue(:present) do
       provider.create

--- a/lib/puppet/type/rabbitmq_user_permissions.rb
+++ b/lib/puppet/type/rabbitmq_user_permissions.rb
@@ -13,6 +13,7 @@ Puppet::Type.newtype(:rabbitmq_user_permissions) do
   DESC
 
   ensurable do
+    desc 'Whether the resource should be present or absent'
     defaultto(:present)
     newvalue(:present) do
       provider.create

--- a/lib/puppet/type/rabbitmq_vhost.rb
+++ b/lib/puppet/type/rabbitmq_vhost.rb
@@ -17,6 +17,7 @@ Puppet::Type.newtype(:rabbitmq_vhost) do
   DESC
 
   ensurable do
+    desc 'Whether the resource should be present or absent'
     defaultto(:present)
     newvalue(:present) do
       provider.create

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -226,6 +226,8 @@
 #   RPM package GPG key to import. Uses source method. Should be a URL for Debian/RedHat OS family, or a file name for
 #   RedHat OS family. Set to https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
 #   for Debian/RedHat OS Family by default.
+# @param package_source
+# @param package_provider
 # @param repo_gpg_key
 #   RPM package GPG key to import. Uses source method. Should be a URL for Debian/RedHat OS family, or a file name for
 #   RedHat OS family. Set to https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey for Debian/RedHat OS Family by
@@ -280,6 +282,7 @@
 #   SSL management cert. If unset set to ssl_cert for backwards compatibility.
 # @param ssl_management_key
 #   SSL management key. If unset set to ssl_key for backwards compatibility.
+# @param ssl_management_fail_if_no_peer_cert
 # @param ssl_port
 #   SSL port for RabbitMQ
 # @param ssl_reuse_sessions

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -3,14 +3,23 @@
 #   puppetlabs-stdlib
 #
 # @api private
+#
+# @param location
+# @param repos
+# @param include_src
+# @param key
+# @param key_source
+# @param key_content
+# @param architecture
+#
 class rabbitmq::repo::apt (
-  String $location               = 'https://packagecloud.io/rabbitmq/rabbitmq-server',
-  String $repos                  = 'main',
+  String[1] $location            = 'https://packagecloud.io/rabbitmq/rabbitmq-server',
+  String[1] $repos               = 'main',
   Boolean $include_src           = false,
-  String $key                    = '8C695B0219AFDEB04A058ED8F4E789204D206F89',
-  String $key_source             = $rabbitmq::package_gpg_key,
-  Optional[String] $key_content  = $rabbitmq::key_content,
-  Optional[String] $architecture = undef,
+  String[1] $key                 = '8C695B0219AFDEB04A058ED8F4E789204D206F89',
+  String[1] $key_source          = $rabbitmq::package_gpg_key,
+  Optional[String[1]] $key_content  = $rabbitmq::key_content,
+  Optional[String[1]] $architecture = undef,
 ) {
   $osname = downcase($facts['os']['name'])
   $pin    = $rabbitmq::package_apt_pin

--- a/manifests/repo/rhel.pp
+++ b/manifests/repo/rhel.pp
@@ -1,10 +1,15 @@
 # Makes sure that the Packagecloud repo is installed
 #
 # @api private
+#
+# @param location
+# @param repo_key_source
+# @param package_key_source
+#
 class rabbitmq::repo::rhel (
-  $location                  = "https://packagecloud.io/rabbitmq/rabbitmq-server/el/${facts['os'][release][major]}/\$basearch",
-  String $repo_key_source    = $rabbitmq::repo_gpg_key,
-  String $package_key_source = $rabbitmq::package_gpg_key,
+  String[1] $location                  = "https://packagecloud.io/rabbitmq/rabbitmq-server/el/${facts['os'][release][major]}/\$basearch",
+  String[1] $repo_key_source    = $rabbitmq::repo_gpg_key,
+  String[1] $package_key_source = $rabbitmq::package_gpg_key,
 ) {
   # Import package key from rabbitmq to be able to
   # sign the package and the repo.

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,10 +1,15 @@
 # This class manages the rabbitmq server service itself.
 #
 # @api private
+#
+# @param service_ensure
+# @param service_manage
+# @param service_name
+#
 class rabbitmq::service (
-  Enum['running', 'stopped'] $service_ensure  = $rabbitmq::service_ensure,
-  Boolean $service_manage                     = $rabbitmq::service_manage,
-  $service_name                               = $rabbitmq::service_name,
+  Enum['running', 'stopped'] $service_ensure = $rabbitmq::service_ensure,
+  Boolean $service_manage                    = $rabbitmq::service_manage,
+  String[1] $service_name                    = $rabbitmq::service_name,
 ) inherits rabbitmq {
   if ($service_manage) {
     if $service_ensure == 'running' {


### PR DESCRIPTION
Might be backwards incompatible due to codebase hardening. Hardening occurs in:
- repo::apt
- repo::rhel
- service
All of those are either changing String to String[1] (disallowing empty Strings) or add a String datatype to variables already having a default String value