### PR TITLE
Use a more expressive method of rewriting values

### DIFF
--- a/lib/puppet/type/rabbitmq_parameter.rb
+++ b/lib/puppet/type/rabbitmq_parameter.rb
@@ -106,9 +106,12 @@ Puppet::Type.newtype(:rabbitmq_parameter) do
   def munge_value(value)
     return value if value(:autoconvert) == :false
 
-    value.each do |k, v|
-      value[k] = v.to_i if v =~ %r{\A[-+]?[0-9]+\z}
+    value.transform_values do |v|
+      if v.is_a?(String) && v.match?(%r{\A[-+]?[0-9]+\z})
+        v.to_i
+      else
+        v
+      end
     end
-    value
   end
 end

--- a/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_parameter_spec.rb
@@ -44,9 +44,8 @@ describe Puppet::Type.type(:rabbitmq_parameter) do
   end
 
   it 'accepts a valid hash for value' do
-    value = { 'message-ttl' => '1800000' }
-    parameter[:value] = value
-    expect(parameter[:value]).to eq(value)
+    parameter[:value] = { 'message-ttl' => '1800000' }
+    expect(parameter[:value]).to eq({ 'message-ttl' => 1_800_000 })
   end
 
   it 'does not accept an empty string for definition' do


### PR DESCRIPTION
This achieves almost the same, except that this version doesn't change the original value. If that's really desired, `transform_values!` can be used. It makes it clearer what's going on.