### PR TITLE
CentOS7: default to EPEL7 as source

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,9 @@
+---
 fixtures:
   repositories:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
     apt: 'https://github.com/puppetlabs/puppetlabs-apt'
     archive: 'https://github.com/voxpupuli/puppet-archive'
-    erlang: 'https://github.com/garethr/garethr-erlang'
+    epel: 'https://github.com/voxpupuli/puppet-epel'
     systemd: 'https://github.com/voxpupuli/puppet-systemd'
     yumrepo_core: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core'

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ These are now documented via [Puppet Strings](https://github.com/puppetlabs/pupp
 
 You can view example usage in [REFERENCE](REFERENCE.md).
 
+**[puppet/epel](https://forge.puppet.com/modules/puppet/epel) is a soft dependency. The module requires it if you're on CentOS 7**
+
+Version v13.2.0 and older also added an erlang repository on CentOS 7. That isn't used and can be safely removed.
+
 ## Reference
 
 See [REFERENCE](REFERENCE.md).

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -492,6 +492,8 @@ class rabbitmq (
     }
   }
 
+  # when repos_ensure is true, we configure externel repos
+  # CentOS 7 doesn't contain rabbitmq. It's only in EPEL.
   if $repos_ensure {
     case $facts['os']['family'] {
       'RedHat': {
@@ -505,6 +507,8 @@ class rabbitmq (
       default: {
       }
     }
+  } elsif ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7') {
+    require epel
   }
 
   contain rabbitmq::install

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -15,11 +15,7 @@ describe 'rabbitmq class:' do
   context 'default class inclusion' do
     let(:pp) do
       <<-EOS
-      class { 'rabbitmq': }
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
-        Class['erlang'] -> Class['rabbitmq']
-      }
+      include rabbitmq
       EOS
     end
 
@@ -54,10 +50,6 @@ describe 'rabbitmq class:' do
         class { 'rabbitmq':
           service_ensure => 'stopped',
         }
-        if $facts['os']['family'] == 'RedHat' {
-          class { 'erlang': epel_enable => true}
-          Class['erlang'] -> Class['rabbitmq']
-        }
       EOS
     end
 
@@ -72,21 +64,13 @@ describe 'rabbitmq class:' do
   context 'service is unmanaged' do
     it 'runs successfully' do
       pp_pre = <<-EOS
-        class { 'rabbitmq': }
-        if $facts['os']['family'] == 'RedHat' {
-          class { 'erlang': epel_enable => true}
-          Class['erlang'] -> Class['rabbitmq']
-        }
+        include rabbitmq
       EOS
 
       pp = <<-EOS
         class { 'rabbitmq':
           service_manage => false,
           service_ensure  => 'stopped',
-        }
-        if $facts['os']['family'] == 'RedHat' {
-          class { 'erlang': epel_enable => true}
-          Class['erlang'] -> Class['rabbitmq']
         }
       EOS
 

--- a/spec/acceptance/clustering_spec.rb
+++ b/spec/acceptance/clustering_spec.rb
@@ -14,10 +14,6 @@ describe 'rabbitmq clustering' do
         erlang_cookie            => 'TESTCOOKIE',
         wipe_db_on_cookie_change => false,
       }
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
-        Class['erlang'] -> Class['rabbitmq']
-      }
       EOS
 
       apply_manifest(pp, expect_failures: true)
@@ -38,10 +34,6 @@ describe 'rabbitmq clustering' do
         cluster_node_type        => 'ram',
         erlang_cookie            => 'TESTCOOKIE',
         wipe_db_on_cookie_change => true,
-      }
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
-        Class['erlang'] -> Class['rabbitmq']
       }
       EOS
 
@@ -83,10 +75,6 @@ describe 'rabbitmq clustering' do
         cluster_node_type        => 'ram',
         environment_variables    => { 'NODENAME' => 'rabbit@foobar' },
         erlang_cookie            => 'TESTCOOKIE',
-      }
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
-        Class['erlang'] -> Class['rabbitmq']
       }
       EOS
 

--- a/spec/acceptance/delete_guest_user_spec.rb
+++ b/spec/acceptance/delete_guest_user_spec.rb
@@ -10,10 +10,6 @@ describe 'rabbitmq with delete_guest_user' do
         port              => 5672,
         delete_guest_user => true,
       }
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
-        Class['erlang'] -> Class['rabbitmq']
-      }
       EOS
 
       apply_manifest(pp, catch_failures: true)

--- a/spec/acceptance/parameter_spec.rb
+++ b/spec/acceptance/parameter_spec.rb
@@ -6,10 +6,6 @@ describe 'rabbitmq parameter on a vhost:' do
   context 'create parameter resource' do
     it 'runs successfully' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
-        Class['erlang'] -> Class['rabbitmq']
-      }
       class { 'rabbitmq':
         service_manage    => true,
         port              => 5672,

--- a/spec/acceptance/policy_spec.rb
+++ b/spec/acceptance/policy_spec.rb
@@ -6,10 +6,6 @@ describe 'rabbitmq policy on a vhost:' do
   context 'create policy resource' do
     it 'runs successfully' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
-        Class['erlang'] -> Class['rabbitmq']
-      }
       class { 'rabbitmq':
         service_manage    => true,
         port              => 5672,

--- a/spec/acceptance/queue_spec.rb
+++ b/spec/acceptance/queue_spec.rb
@@ -6,10 +6,6 @@ describe 'rabbitmq binding:' do
   context 'create binding and queue resources when using default management port' do
     it 'runs successfully' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
-        Class['erlang'] -> Class['rabbitmq']
-      }
       class { 'rabbitmq':
         service_manage    => true,
         port              => 5672,
@@ -80,10 +76,6 @@ describe 'rabbitmq binding:' do
   context 'create multiple bindings when same source / destination / vhost but different routing keys' do
     it 'runs successfully' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
-        Class['erlang'] -> Class['rabbitmq']
-      }
       class { 'rabbitmq':
         service_manage    => true,
         port              => 5672,
@@ -168,10 +160,6 @@ describe 'rabbitmq binding:' do
   context 'create binding and queue resources when using a non-default management port' do
     it 'runs successfully' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
-        Class['erlang'] -> Class['rabbitmq']
-      }
       class { 'rabbitmq':
         service_manage    => true,
         port              => 5672,

--- a/spec/acceptance/rabbitmqadmin_spec.rb
+++ b/spec/acceptance/rabbitmqadmin_spec.rb
@@ -10,10 +10,6 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
         admin_enable   => true,
         service_manage => true,
       }
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
-        Class['erlang'] -> Class['rabbitmq']
-      }
       EOS
 
       apply_manifest(pp, catch_failures: true)
@@ -30,10 +26,6 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
       class { 'rabbitmq':
         admin_enable   => true,
         service_manage => false,
-      }
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
-        Class['erlang'] -> Class['rabbitmq']
       }
       EOS
 
@@ -55,10 +47,6 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
         default_user   => 'foobar',
         default_pass   => 'bazblam',
       }
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
-        Class['erlang'] -> Class['rabbitmq']
-      }
       EOS
 
       pp = <<-EOS
@@ -67,10 +55,6 @@ describe 'rabbitmq::install::rabbitmqadmin class' do
         service_manage => true,
         default_user   => 'foobar',
         default_pass   => 'bazblam',
-      }
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true}
-        Class['erlang'] -> Class['rabbitmq']
       }
       EOS
 

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -6,10 +6,6 @@ describe 'rabbitmq user:' do
   context 'create user resource' do
     it 'runs successfully' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
-        Class['erlang'] -> Class['rabbitmq']
-      }
       class { 'rabbitmq':
         service_manage    => true,
         port              => 5672,

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -6,18 +6,14 @@ describe 'rabbitmq vhost:' do
   context 'create vhost resource' do
     it 'runs successfully' do
       pp = <<-EOS
-      if $facts['os']['family'] == 'RedHat' {
-        class { 'erlang': epel_enable => true }
-        Class['erlang'] -> Class['rabbitmq']
-      }
       class { 'rabbitmq':
         service_manage    => true,
         port              => 5672,
         delete_guest_user => true,
         admin_enable      => true,
-      } ->
+      }
 
-      rabbitmq_vhost { 'myhost':
+      -> rabbitmq_vhost { 'myhost':
         ensure => present,
       }
       EOS

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,7 +7,7 @@ configure_beaker do |host|
   when 'Debian'
     install_puppet_module_via_pmt_on(host, 'puppetlabs-apt', '>= 4.1.0 < 9.0.0')
   when 'RedHat'
-    install_puppet_module_via_pmt_on(host, 'garethr-erlang', '>= 0.3.0 < 1.0.0')
+    install_puppet_module_via_pmt_on(host, 'puppet-epel', '>= 5.0.0 < 6.0.0')
     if fact_on(host, 'os.selinux.enabled')
       # Make sure selinux is disabled so the tests work.
       on host, puppet('resource', 'exec', 'setenforce 0', 'path=/bin:/sbin:/usr/bin:/usr/sbin', 'onlyif=which setenforce && getenforce | grep Enforcing')


### PR DESCRIPTION
Historically we used the garethr/erlang module as soft dependency on CentOS 7. This also configured the EPEL7 repository. I always always a bit unsure where the actual rabbitmq packages come from. I assumed somehow from the erlang repo. My impression is that the erlan repo isn't used at all. rabbitmq packages where always pulled from EPEL7. The problem with the garethr/erlang is that it depends on the deprecated `stahnma/epel` (which is now puppet/epel) and uses topscope facts and
variables. The module doesn't work anymore with Puppet 8.

This PR replaces the unused garethr/erlang directly with the EPEL module.