### PR TITLE
Use ensure_packages from stdlib

### DIFF
--- a/manifests/install/rabbitmqadmin.pp
+++ b/manifests/install/rabbitmqadmin.pp
@@ -11,7 +11,7 @@ class rabbitmq::install::rabbitmqadmin {
     $python_package = $rabbitmq::python_package
     # Some systems (e.g., Ubuntu 16.04) don't ship Python 2 by default
     if $rabbitmq::manage_python {
-      ensure_packages([$python_package])
+      stdlib::ensure_packages([$python_package])
       $rabbitmqadmin_require = [Archive['rabbitmqadmin'], Package[$python_package]]
     } else {
       $rabbitmqadmin_require = Archive['rabbitmqadmin']


### PR DESCRIPTION
#### Pull Request (PR) description
Resolve deprecation errors by using `ensure_packages()` from stdlib vs. from Puppet

```
  Warning: This function is deprecated, please use stdlib::ensure_packages instead. at ["/etc/puppetlabs/code/environments/production/modules/rabbitmq/manifests/install/rabbitmqadmin.pp", 14]:["/etc/puppetlabs/code/environments/production/modules/rabbitmq/manifests/init.pp", 574]
```

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
