### PR TITLE
Support RHEL and CentOS 8

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -507,7 +507,7 @@ class rabbitmq (
       default: {
       }
     }
-  } elsif ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7') {
+  } elsif ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] in ['7', '8']) {
     require epel
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -11,13 +11,15 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Add metadata support for RHEL / CentOS 8

Note: CentOS 8 has been EOL for a while, and RHEL 8 is EOL at the end of May, 2024. Thus, official support may be dropped again soon

#### This Pull Request (PR) fixes the following issues
Fixes #942
Closes #900
Fixes #816
