### PR TITLE
Handle rabbitmq.config when cluster_nodes is empty

### DIFF
--- a/templates/rabbitmq.config.epp
+++ b/templates/rabbitmq.config.epp
@@ -19,7 +19,11 @@
     {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_ldap]},
 <% } -%>
 <% if $rabbitmq::config::config_cluster {-%>
+    <% if !$rabbitmq::config::cluster_nodes.empty {-%>
     {cluster_nodes, {['rabbit@<%= $rabbitmq::config::cluster_nodes.join("', 'rabbit@") %>'], <%= $rabbitmq::config::cluster_node_type %>}},
+    <% } else {%>
+    {cluster_nodes, {[], <%= $rabbitmq::config::cluster_node_type %>}},
+    <% } %>
     {cluster_partition_handling, <%= $rabbitmq::config::cluster_partition_handling %>},
 <% } -%>
     {tcp_listen_options, [


### PR DESCRIPTION
#### Pull Request (PR) description
Fix cluster config when `cluster_nodes` is empty

Followup to #978 