### PR TITLE
Revert hard require on epel for CentOS 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ These are now documented via [Puppet Strings](https://github.com/puppetlabs/pupp
 
 You can view example usage in [REFERENCE](REFERENCE.md).
 
-**[puppet/epel](https://forge.puppet.com/modules/puppet/epel) is a soft dependency. The module requires it if you're on CentOS 7**
+**[puppet/epel](https://forge.puppet.com/modules/puppet/epel) is a soft dependency. On CentOS, with `$repos_ensure` set to `false` (current default), it may be required.
 
 Version v13.2.0 and older also added an erlang repository on CentOS 7. That isn't used and can be safely removed.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -507,8 +507,6 @@ class rabbitmq (
       default: {
       }
     }
-  } elsif ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7') {
-    require epel
   }
 
   contain rabbitmq::install


### PR DESCRIPTION
#### Pull Request (PR) description
This leaves some of the documentation about epel, and installs it for acceptance tests, but leaves it up to users on CentOS to include this separately if needed.

#### This Pull Request (PR) fixes the following issues
Fixes #995