### PR TITLE
Add require_epel parameter, defaulting to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ These are now documented via [Puppet Strings](https://github.com/puppetlabs/pupp
 
 You can view example usage in [REFERENCE](REFERENCE.md).
 
-**[puppet/epel](https://forge.puppet.com/modules/puppet/epel) is a soft dependency. The module requires it if you're on CentOS 7**
+**[puppet/epel](https://forge.puppet.com/modules/puppet/epel) is a soft dependency. If you're on CentOS 7 and don't want to require it, set `$require_epel` to `false`**
 
 Version v13.2.0 and older also added an erlang repository on CentOS 7. That isn't used and can be safely removed.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -254,6 +254,7 @@ The following parameters are available in the `rabbitmq` class:
 * [`port`](#-rabbitmq--port)
 * [`python_package`](#-rabbitmq--python_package)
 * [`repos_ensure`](#-rabbitmq--repos_ensure)
+* [`require_epel`](#-rabbitmq--require_epel)
 * [`service_ensure`](#-rabbitmq--service_ensure)
 * [`service_manage`](#-rabbitmq--service_manage)
 * [`service_name`](#-rabbitmq--service_name)
@@ -799,6 +800,14 @@ It also does not solve the erlang dependency.  See https://www.rabbitmq.com/whic
 different ways of handling the erlang deps.  See also https://github.com/voxpupuli/puppet-rabbitmq/issues/788
 
 Default value: `false`
+
+##### <a name="-rabbitmq--require_epel"></a>`require_epel`
+
+Data type: `Boolean`
+
+If this parameter is set, On CentOS / RHEL 7 systems, require the "puppet/epel" module
+
+Default value: `true`
 
 ##### <a name="-rabbitmq--service_ensure"></a>`service_ensure`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -243,6 +243,8 @@
 #   Defaults to false (use system packages). This does not ensure that soft dependencies (like EPEL on RHEL systems) are present.
 #   It also does not solve the erlang dependency.  See https://www.rabbitmq.com/which-erlang.html for a good breakdown of the
 #   different ways of handling the erlang deps.  See also https://github.com/voxpupuli/puppet-rabbitmq/issues/788
+# @param require_epel
+#   If this parameter is set, On CentOS / RHEL 7 systems, require the "puppet/epel" module
 # @param service_ensure
 #   The state of the service.
 # @param service_manage
@@ -453,6 +455,7 @@ class rabbitmq (
   Array $archive_options                                                                           = [],
   Array $loopback_users                                                                            = ['guest'],
   Boolean $service_restart                                                                         = true,
+  Boolean $require_epel                                                                            = true,
 ) {
   if $ssl_only and ! $ssl {
     fail('$ssl_only => true requires that $ssl => true')
@@ -507,7 +510,12 @@ class rabbitmq (
       default: {
       }
     }
-  } elsif ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7') {
+  } elsif ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7') and $require_epel {
+    # On later CentOS / RHEL systems, this is not useful since EPEL doesn't
+    # have the rabbitmq-server package anyway.
+    #
+    # Once support for 7 is dropped, we should remove this code and the
+    # parameter
     require epel
   }
 


### PR DESCRIPTION
#### Pull Request (PR) description
Allow an option to restore epel as a true soft dependency. Defaulting to `true` so that the tests will work with default behavior.

IMO, the safer / better / not technically breaking behavior would be to default this to `false`, however I don't think it's possible / trivial to do this while keeping the default class inclusion test in 
https://github.com/voxpupuli/puppet-rabbitmq/blob/137edeedf1f15e04d239a026e119c114eb2021ba/spec/acceptance/class_spec.rb#L18
as-is? If we want to try instantiating it differently there, I can rework this or open a new one.

Since there wasn't already a unit test for this, I didn't add one here, but can do so if needed depending on which option we go with.

#### This Pull Request (PR) fixes the following issues
Fixes #995
Closes #998