### PR TITLE
Update rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,4 @@
 ---
-inherit_from: .rubocop_todo.yml
-
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 


### PR DESCRIPTION
#### Pull Request (PR) description
The rubocop config introduced in #915 seems to have introduced a duplicate line above the modulesync version.

This creates the warning
```
.rubocop.yml:2: `inherit_from` is concealed by line 7
```
which is typically not fatal, but was causing me some issues.