### PR TITLE
require puppet/systemd >= 6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 4.0.0 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
With the changes made in https://github.com/voxpupuli/puppet-rabbitmq/pull/982, this module needs `puppet-systemd` >= 6.0.0, as this is the first release with the `Limits` moved to the `Systemd::Unit::Service` data type. Otherwise, it's not possible to set limits, as validation will fail

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
