### PR TITLE
Fix indentation for cluster_nodes

### DIFF
--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -408,7 +408,7 @@ describe 'rabbitmq' do
           end
 
           it 'for cluster_nodes' do
-            is_expected.to contain_file('rabbitmq.config').with('content' => %r{cluster_nodes.*\['rabbit@hare-1', 'rabbit@hare-2'\], ram})
+            is_expected.to contain_file('rabbitmq.config').with('content' => %r{^ {4}\{cluster_nodes, \{\['rabbit@hare-1', 'rabbit@hare-2'\], ram})
           end
         end
 
@@ -423,7 +423,7 @@ describe 'rabbitmq' do
           end
 
           it 'for cluster_nodes' do
-            is_expected.to contain_file('rabbitmq.config').with('content' => %r{cluster_nodes.*\[\], ram})
+            is_expected.to contain_file('rabbitmq.config').with('content' => %r{^ {4}\{cluster_nodes, \{\[\], ram})
           end
         end
       end

--- a/templates/rabbitmq.config.epp
+++ b/templates/rabbitmq.config.epp
@@ -19,11 +19,11 @@
     {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_ldap]},
 <% } -%>
 <% if $rabbitmq::config::config_cluster {-%>
-    <% if !$rabbitmq::config::cluster_nodes.empty {-%>
+    <%- if !$rabbitmq::config::cluster_nodes.empty {-%>
     {cluster_nodes, {['rabbit@<%= $rabbitmq::config::cluster_nodes.join("', 'rabbit@") %>'], <%= $rabbitmq::config::cluster_node_type %>}},
-    <% } else {%>
+    <%- } else {-%>
     {cluster_nodes, {[], <%= $rabbitmq::config::cluster_node_type %>}},
-    <% } %>
+    <%- } -%>
     {cluster_partition_handling, <%= $rabbitmq::config::cluster_partition_handling %>},
 <% } -%>
     {tcp_listen_options, [


### PR DESCRIPTION
#### Pull Request (PR) description
Fix indentation of `cluster_nodes` in `rabbitmq.config`. 

_This is just realigning things after upgrading recently and noticed the change from erb to epp templates, and subsequent conditional added [here](https://github.com/voxpupuli/puppet-rabbitmq/commit/aaa46bea9465934f0da2b170253c8e20e293142d) changed the alignment_

#### This Pull Request (PR) fixes the following issues
Correctly aligns `cluster_nodes` when empty...
```
--- /etc/rabbitmq/rabbitmq.config	2024-05-29 20:04:23.109445139 +0000
+++ /tmp/puppet-file20240529-12718-1ikruem	2024-05-29 20:16:08.230884643 +0000
@@ -5,8 +5,7 @@
   {rabbit, [
     {loopback_users, []},
     {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_oauth2]},
-        {cluster_nodes, {[], disc}},
-
+    {cluster_nodes, {[], disc}},
     {cluster_partition_handling, pause_minority},
     {tcp_listen_options, [
          {backlog,       128},
```

Correctly aligns `cluster_nodes` when not empty...
```
--- /etc/rabbitmq/rabbitmq.config	2024-05-29 20:04:23.109445139 +0000
+++ /tmp/puppet-file20240529-14820-1u3363v	2024-05-29 20:17:16.176505986 +0000
@@ -5,8 +5,7 @@
   {rabbit, [
     {loopback_users, []},
     {auth_backends, [rabbit_auth_backend_internal, rabbit_auth_backend_oauth2]},
-        {cluster_nodes, {['rabbit@samplenodeq01.example.com', 'rabbit@samplenodeq02.example.com', 'rabbit@samplenodeq03.example.com'], disc}},
-
+    {cluster_nodes, {['rabbit@samplenodeq01.example.com', 'rabbit@samplenodeq02.example.com', 'rabbit@samplenodeq03.example.com'], disc}},
     {cluster_partition_handling, pause_minority},
     {tcp_listen_options, [
          {backlog,       128},
```



