### PR TITLE
Add support for Debian 11

### DIFF
--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -1,4 +1,5 @@
 ---
+rabbitmq::python_package: 'python3'
 rabbitmq::package_name: 'rabbitmq-server'
 rabbitmq::service_name: 'rabbitmq-server'
 rabbitmq::package_gpg_key: 'https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey'

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -190,7 +190,8 @@ describe 'rabbitmq' do
             is_expected.to contain_archive('rabbitmqadmin').with_source('http://1.1.1.1:15672/cli/rabbitmqadmin')
           end
 
-          it { is_expected.to contain_package('python') } if %w[RedHat Debian SUSE Archlinux].include?(os_facts[:os]['family'])
+          it { is_expected.to contain_package('python') } if %w[RedHat SUSE Archlinux].include?(os_facts[:os]['family'])
+          it { is_expected.to contain_package('python3') } if %w[Debian].include?(os_facts[:os]['family'])
           it { is_expected.to contain_package('python38') } if %w[FreeBSD].include?(os_facts[:os]['family'])
         end
 


### PR DESCRIPTION
#### Pull Request (PR) description
Add metadata support for Debian 11, and use the "python3" package for the entire Debian family. This appears to be valid for both currently supported versions

#### This Pull Request (PR) fixes the following issues
Closes #1008