### PR TITLE
Add support for cowboy_opts config in rabbitmq.config

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -207,6 +207,7 @@ The following parameters are available in the `rabbitmq` class:
 * [`config`](#-rabbitmq--config)
 * [`config_additional_variables`](#-rabbitmq--config_additional_variables)
 * [`config_cluster`](#-rabbitmq--config_cluster)
+* [`config_cowboy_opts`](#-rabbitmq--config_cowboy_opts)
 * [`config_kernel_variables`](#-rabbitmq--config_kernel_variables)
 * [`config_path`](#-rabbitmq--config_path)
 * [`config_ranch`](#-rabbitmq--config_ranch)
@@ -410,6 +411,14 @@ Data type: `Boolean`
 Enable or disable clustering support.
 
 Default value: `false`
+
+##### <a name="-rabbitmq--config_cowboy_opts"></a>`config_cowboy_opts`
+
+Data type: `Hash`
+
+Hash of additional configs (key / value) for `cowboy_opts` in rabbitmq.config.
+
+Default value: `{}`
 
 ##### <a name="-rabbitmq--config_kernel_variables"></a>`config_kernel_variables`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,7 @@ class rabbitmq::config {
   $cluster_node_type                   = $rabbitmq::cluster_node_type
   $cluster_nodes                       = $rabbitmq::cluster_nodes
   $config                              = $rabbitmq::config
+  $config_cowboy_opts                  = $rabbitmq::config_cowboy_opts
   $config_cluster                      = $rabbitmq::config_cluster
   $config_path                         = $rabbitmq::config_path
   $config_ranch                        = $rabbitmq::config_ranch

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,8 +10,8 @@ class rabbitmq::config {
   $cluster_node_type                   = $rabbitmq::cluster_node_type
   $cluster_nodes                       = $rabbitmq::cluster_nodes
   $config                              = $rabbitmq::config
-  $config_cowboy_opts                  = $rabbitmq::config_cowboy_opts
   $config_cluster                      = $rabbitmq::config_cluster
+  $config_cowboy_opts                  = $rabbitmq::config_cowboy_opts
   $config_path                         = $rabbitmq::config_path
   $config_ranch                        = $rabbitmq::config_ranch
   $config_stomp                        = $rabbitmq::config_stomp

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,6 +137,8 @@
 #   Additional config variables in rabbitmq.config
 # @param config_cluster
 #   Enable or disable clustering support.
+# @param config_cowboy_opts
+#   Additional config variables for cowboy_opts in rabbitmq.config.
 # @param config_kernel_variables
 #   Hash of Erlang kernel configuration variables to set (see [Variables Configurable in rabbitmq.config](#variables-configurable-in-rabbitmq.config)).
 # @param config_path
@@ -356,7 +358,8 @@ class rabbitmq (
   Hash $cluster                                                                                    = $rabbitmq::cluster,
   Enum['ram', 'disc'] $cluster_node_type                                                           = 'disc',
   Array $cluster_nodes                                                                             = [],
-  String $config                                                                                   = 'rabbitmq/rabbitmq.config.epp',
+  String $config   
+  Hash $config_cowboy_opts                                                                         = {},                                                                                = 'rabbitmq/rabbitmq.config.epp',
   Boolean $config_cluster                                                                          = false,
   Stdlib::Absolutepath $config_path                                                                = '/etc/rabbitmq/rabbitmq.config',
   Boolean $config_ranch                                                                            = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,7 +138,7 @@
 # @param config_cluster
 #   Enable or disable clustering support.
 # @param config_cowboy_opts
-#   Additional config variables for cowboy_opts in rabbitmq.config.
+#   Hash of additional configs (key / value) for `cowboy_opts` in rabbitmq.config.
 # @param config_kernel_variables
 #   Hash of Erlang kernel configuration variables to set (see [Variables Configurable in rabbitmq.config](#variables-configurable-in-rabbitmq.config)).
 # @param config_path

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -358,8 +358,8 @@ class rabbitmq (
   Hash $cluster                                                                                    = $rabbitmq::cluster,
   Enum['ram', 'disc'] $cluster_node_type                                                           = 'disc',
   Array $cluster_nodes                                                                             = [],
-  String $config   
-  Hash $config_cowboy_opts                                                                         = {},                                                                                = 'rabbitmq/rabbitmq.config.epp',
+  String $config                                                                                   = 'rabbitmq/rabbitmq.config.epp',
+  Hash $config_cowboy_opts                                                                         = {},
   Boolean $config_cluster                                                                          = false,
   Stdlib::Absolutepath $config_path                                                                = '/etc/rabbitmq/rabbitmq.config',
   Boolean $config_ranch                                                                            = true,

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -429,6 +429,50 @@ describe 'rabbitmq' do
         end
       end
 
+      describe 'with config_cowboy_opts' do
+        context 'without SSL' do
+          let(:params) do
+            {
+              config_cowboy_opts: {
+                'max_request_line_length' => 16_000,
+                'max_keepalive' => 1000,
+              },
+            }
+          end
+
+          it 'sets expected cowboy config variables' do
+            is_expected.to contain_file('rabbitmq.config'). \
+              with_content(
+                %r{\{cowboy_opts, \[\n\s+\{max_keepalive, 1000\},\n\s+\{max_request_line_length, 16000\}}
+              )
+          end
+        end
+
+        context 'withSSL' do
+          let(:params) do
+            {
+              config_cowboy_opts: {
+                'max_request_line_length' => 16_003,
+                'max_keepalive' => 1002,
+              },
+              ssl: true,
+              ssl_port: 3141,
+              ssl_cacert: '/path/to/cacert',
+              ssl_cert: '/path/to/cert',
+              ssl_key: '/path/to/key',
+              ssl_versions: ['tlsv1.2', 'tlsv1.1'],
+            }
+          end
+
+          it 'sets expected cowboy config variables' do
+            is_expected.to contain_file('rabbitmq.config'). \
+              with_content(
+                %r{\{cowboy_opts, \[\n\s+\{max_keepalive, 1002\},\n\s+\{max_request_line_length, 16003\}}
+              )
+          end
+        end
+      end
+
       describe 'rabbitmq-env configuration' do
         context 'with default params' do
           it 'sets environment variables' do

--- a/templates/rabbitmq.config.epp
+++ b/templates/rabbitmq.config.epp
@@ -136,6 +136,13 @@
       {ip, "<%= $rabbitmq::config::management_ip_address %>"},
   <%- } -%>
       {port, <%= $rabbitmq::config::ssl_management_port %>},
+      <%- if !$rabbitmq::config::config_cowboy_opts.empty {-%>
+      {cowboy_opts, [
+      <%- $rabbitmq::config::config_cowboy_opts.keys.sort.each |$k| { -%>
+        {<%= $k %>, <%= $rabbitmq::config::config_cowboy_opts[$k] %>}<% if $k != $rabbitmq::config::config_cowboy_opts.keys.sort[-1] { %>,<%- } %>
+      <%- } -%>
+      ]},
+      <%- } -%>
       {ssl, true},
       {ssl_opts, [
                   <%- if $rabbitmq::config::ssl_management_cacert {-%>
@@ -164,7 +171,10 @@
   <%- if $rabbitmq::config::management_ip_address {-%>
       {ip, "<%= $rabbitmq::config::management_ip_address %>"},
   <%- } -%>
-      {port, <%= $rabbitmq::config::management_port %>}
+      {port, <%= $rabbitmq::config::management_port %>}<% if !$rabbitmq::config::config_cowboy_opts.empty {%>,
+      {cowboy_opts, [<%- $rabbitmq::config::config_cowboy_opts.keys.sort.each |$k| { %>
+        {<%= $k %>, <%= $rabbitmq::config::config_cowboy_opts[$k] %>}<% if $k != $rabbitmq::config::config_cowboy_opts.keys.sort[-1] { %>,<%- }} %>
+      ]}<%- } %>
 <%- } -%>
     ]}
 <%- } -%>


### PR DESCRIPTION
Adds the possibility  to use cowboy_opts configuration in the rabbitmq.config.

Unfortunately, i can't test the ssl/cowboy_opts part on my side.