### PR TITLE
Switch to string vs. symbols for facts in spec tests

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,7 +1,8 @@
 ---
 spec/spec_helper.rb:
-  spec_overrides: "require 'spec_helper_local'"
+  facterdb_string_keys: true
   mock_with: ':mocha'
+  spec_overrides: "require 'spec_helper_local'"
 .puppet-lint.rc:
   enabled_lint_checks:
     - parameter_documentation

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../lib', __dir__))
 require 'voxpupuli/test/spec_helper'
 
 RSpec.configure do |c|
-  c.facterdb_string_keys = false
+  c.facterdb_string_keys = true
   c.mock_with :mocha
 end
 


### PR DESCRIPTION
Set `facterdb_string_keys` to `true` and update to string versions of facts in our spec tests.

Update `.sync.yml` so that modulesync doesn't override this while the default is still `false`