### PR TITLE
Convert `queue-version` to integer

### DIFF
--- a/lib/puppet/type/rabbitmq_policy.rb
+++ b/lib/puppet/type/rabbitmq_policy.rb
@@ -11,6 +11,7 @@ CONVERT_TO_INT_VARS = %w[
   max-length
   max-length-bytes
   message-ttl
+  queue-version
   shards-per-node
 ].freeze
 

--- a/spec/unit/puppet/type/rabbitmq_policy_spec.rb
+++ b/spec/unit/puppet/type/rabbitmq_policy_spec.rb
@@ -221,6 +221,19 @@ describe Puppet::Type.type(:rabbitmq_policy) do
     end.to raise_error(Puppet::Error, %r{Invalid initial-cluster-size value 'impressive})
   end
 
+  it 'accepts and converts the queue-version value' do
+    definition = { 'queue-version' => '2' }
+    policy[:definition] = definition
+    expect(policy[:definition]['queue-version']).to eq(2)
+  end
+
+  it 'does not accept non-numeric queue-version value' do
+    definition = { 'queue-version' => 'oogabooga' }
+    expect do
+      policy[:definition] = definition
+    end.to raise_error(Puppet::Error, %r{Invalid queue-version value.*oogabooga})
+  end
+
   context 'accepts list value in ha-params when ha-mode = nodes' do
     before do
       policy[:definition] = definition


### PR DESCRIPTION
#### Pull Request (PR) description
Add `queue-version` to the list of items that should be converted from string to integer before being passed to RabbitMQ

#### This Pull Request (PR) fixes the following issues
Fixes #1017