### PR TITLE
Disallow empty string in `package_apt_pin`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -725,7 +725,7 @@ Default value: `undef`
 
 ##### <a name="-rabbitmq--package_apt_pin"></a>`package_apt_pin`
 
-Data type: `Optional[Variant[Numeric, String]]`
+Data type: `Optional[Variant[Numeric, String[1]]]`
 
 Whether to pin the package to a particular source
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -378,7 +378,7 @@ class rabbitmq (
   Boolean $management_ssl                                                                          = true,
   Optional[String] $management_hostname                                                            = undef,
   Optional[String] $node_ip_address                                                                = undef,
-  Optional[Variant[Numeric, String]] $package_apt_pin                                              = undef,
+  Optional[Variant[Numeric, String[1]]] $package_apt_pin                                           = undef,
   String $package_ensure                                                                           = 'installed',
   Optional[String] $package_gpg_key                                                                = undef,
   Optional[String] $repo_gpg_key                                                                   = undef,

--- a/spec/acceptance/clustering_spec.rb
+++ b/spec/acceptance/clustering_spec.rb
@@ -68,6 +68,10 @@ describe 'rabbitmq clustering' do
   context 'rabbitmq::cluster[:local_node] = foobar' do
     it 'runs successfully' do
       pp = <<-EOS
+      # Needed to avoid nxdomain error
+      host { 'foobar':
+        ip => '127.0.0.1',
+      }
       class { 'rabbitmq':
         cluster                  => { 'name' => 'rabbit_cluster', 'init_node' => 'foobar', 'local_node' => 'foobar' },
         config_cluster           => true,
@@ -78,7 +82,7 @@ describe 'rabbitmq clustering' do
       }
       EOS
 
-      apply_manifest(pp, expect_failures: true)
+      apply_manifest(pp, catch_failures: true)
     end
   end
 end

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -83,7 +83,7 @@ describe 'rabbitmq' do
       end
 
       context 'with no pin', if: os_facts['os']['family'] == 'Debian' do
-        let(:params) { { repos_ensure: true, package_apt_pin: '' } }
+        let(:params) { { repos_ensure: true, package_apt_pin: nil } }
 
         describe 'it sets up an apt::source' do
           it {


### PR DESCRIPTION
* Require package_apt_pin to be a non-empty string or number
* Use `nil` instead of empty string in test for empty pin

Resolves a test failure that seems to have cropped up since the last time tests ran (probably a new version of the apt module).

This is technically breaking in a minor way, though guessing we don't need to cut a major for it. Alternately, I could continue to be less strict in the module's validation, and just update the test case 🤷 

```
  3) rabbitmq on ubuntu-20.04-x86_64 with no pin it sets up an apt::source is expected to contain Apt::Source[rabbitmq] with location => "https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu", repos => "main" and key => "{\"id\"=>\"8C695B0219AFDEB04A058ED8F4E789204D206F89\", \"source\"=>\"https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey\", \"content\"=>nil}"
     Failure/Error:
       is_expected.to contain_apt__source('rabbitmq').with(
         'location' => "https://packagecloud.io/rabbitmq/rabbitmq-server/#{os_facts['os']['name'].downcase}",
         'repos' => 'main',
         'key' => '{"id"=>"8C695B0219AFDEB04A058ED8F4E789204D206F89", "source"=>"https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey", "content"=>nil}'
       )
     
     Puppet::PreformattedError:
       Evaluation Error: Error while evaluating a Resource Statement, Apt::Pin[rabbitmq]: parameter 'priority' expects a value of type Integer or String[1], got String (file: /Users/wby/git/puppet-rabbitmq/spec/fixtures/modules/rabbitmq/manifests/repo/apt.pp, line: 41) on node xxxx
```