### PR TITLE
Drop support for Debian 10, Ubuntu 18, and FreeBSD 12

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,14 +23,12 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
         "22.04"
       ]
@@ -44,7 +42,6 @@
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "12",
         "13",
         "14"
       ]

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -5,7 +5,7 @@ require 'voxpupuli/acceptance/spec_helper_acceptance'
 configure_beaker do |host|
   case fact_on(host, 'os.family')
   when 'Debian'
-    install_puppet_module_via_pmt_on(host, 'puppetlabs-apt', '>= 4.1.0 < 10.0.0')
+    install_puppet_module_via_pmt_on(host, 'puppetlabs-apt', '>= 9.0.0 < 10.0.0')
   when 'RedHat'
     install_puppet_module_via_pmt_on(host, 'puppet-epel', '>= 5.0.0 < 6.0.0')
     if fact_on(host, 'os.selinux.enabled')
@@ -13,8 +13,6 @@ configure_beaker do |host|
       on host, puppet('resource', 'exec', 'setenforce 0', 'path=/bin:/sbin:/usr/bin:/usr/sbin', 'onlyif=which setenforce && getenforce | grep Enforcing')
     end
   end
-
-  install_package(host, 'iproute2') if fact('os.release.major').to_i == 18 || fact('os.release.major') == 'buster/sid'
 
   # Fake certs
   on host, 'echo "-----BEGIN RSA PRIVATE KEY-----


### PR DESCRIPTION
#### Pull Request (PR) description
Drop metadata support for EOL OSes

- Drop support for Debian 10
- Drop support for Ubuntu 18.04
- Drop support for FreeBSD 12
- Remove some workarounds / hacks specific to older Debian-based systems.

~Note: we could / should theoretically drop support for CentOS / RHEL 7, but tests still don't function on 8 or 9.~ See #1027 for RHEL changes

#### This Pull Request (PR) fixes the following issue