### PR TITLE
Add support for CentOS / RHEL 9 and drop support for 7

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,5 @@ fixtures:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
     apt: 'https://github.com/puppetlabs/puppetlabs-apt'
     archive: 'https://github.com/voxpupuli/puppet-archive'
-    epel: 'https://github.com/voxpupuli/puppet-epel'
     systemd: 'https://github.com/voxpupuli/puppet-systemd'
     yumrepo_core: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core'

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -255,7 +255,6 @@ The following parameters are available in the `rabbitmq` class:
 * [`port`](#-rabbitmq--port)
 * [`python_package`](#-rabbitmq--python_package)
 * [`repos_ensure`](#-rabbitmq--repos_ensure)
-* [`require_epel`](#-rabbitmq--require_epel)
 * [`service_ensure`](#-rabbitmq--service_ensure)
 * [`service_manage`](#-rabbitmq--service_manage)
 * [`service_name`](#-rabbitmq--service_name)
@@ -805,19 +804,11 @@ Default value: `'python'`
 Data type: `Boolean`
 
 Ensure that a repo with the official (and newer) RabbitMQ package is configured, along with its signing key.
-Defaults to false (use system packages). This does not ensure that soft dependencies (like EPEL on RHEL systems) are present.
-It also does not solve the erlang dependency.  See https://www.rabbitmq.com/which-erlang.html for a good breakdown of the
-different ways of handling the erlang deps.  See also https://github.com/voxpupuli/puppet-rabbitmq/issues/788
+Defaults to false (use system packages). This does not ensure that soft dependencies are present.
+It also does not solve the erlang dependency. See https://www.rabbitmq.com/which-erlang.html for a good breakdown of the
+different ways of handling the erlang deps. See also https://github.com/voxpupuli/puppet-rabbitmq/issues/788
 
 Default value: `false`
-
-##### <a name="-rabbitmq--require_epel"></a>`require_epel`
-
-Data type: `Boolean`
-
-If this parameter is set, On CentOS / RHEL 7 systems, require the "puppet/epel" module
-
-Default value: `true`
 
 ##### <a name="-rabbitmq--service_ensure"></a>`service_ensure`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -242,11 +242,9 @@
 #   Name of the package required by rabbitmqadmin.
 # @param repos_ensure
 #   Ensure that a repo with the official (and newer) RabbitMQ package is configured, along with its signing key.
-#   Defaults to false (use system packages). This does not ensure that soft dependencies (like EPEL on RHEL systems) are present.
-#   It also does not solve the erlang dependency.  See https://www.rabbitmq.com/which-erlang.html for a good breakdown of the
-#   different ways of handling the erlang deps.  See also https://github.com/voxpupuli/puppet-rabbitmq/issues/788
-# @param require_epel
-#   If this parameter is set, On CentOS / RHEL 7 systems, require the "puppet/epel" module
+#   Defaults to false (use system packages). This does not ensure that soft dependencies are present.
+#   It also does not solve the erlang dependency. See https://www.rabbitmq.com/which-erlang.html for a good breakdown of the
+#   different ways of handling the erlang deps. See also https://github.com/voxpupuli/puppet-rabbitmq/issues/788
 # @param service_ensure
 #   The state of the service.
 # @param service_manage
@@ -461,7 +459,6 @@ class rabbitmq (
   Array $archive_options                                                                           = [],
   Array $loopback_users                                                                            = ['guest'],
   Boolean $service_restart                                                                         = true,
-  Boolean $require_epel                                                                            = true,
 ) {
   if $ssl_only and ! $ssl {
     fail('$ssl_only => true requires that $ssl => true')
@@ -516,13 +513,10 @@ class rabbitmq (
       default: {
       }
     }
-  } elsif ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7') and $require_epel {
-    # On later CentOS / RHEL systems, this is not useful since EPEL doesn't
-    # have the rabbitmq-server package anyway.
-    #
-    # Once support for 7 is dropped, we should remove this code and the
-    # parameter
-    require epel
+  } elsif $facts['os']['family'] == 'RedHat' {
+    package { 'centos-release-rabbitmq-38':
+      ensure   => 'present',
+    }
   }
 
   contain rabbitmq::install

--- a/metadata.json
+++ b/metadata.json
@@ -11,13 +11,13 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "9"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "9"
       ]
     },
     {

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,7 +7,6 @@ configure_beaker do |host|
   when 'Debian'
     install_puppet_module_via_pmt_on(host, 'puppetlabs-apt', '>= 9.0.0 < 10.0.0')
   when 'RedHat'
-    install_puppet_module_via_pmt_on(host, 'puppet-epel', '>= 5.0.0 < 6.0.0')
     if fact_on(host, 'os.selinux.enabled')
       # Make sure selinux is disabled so the tests work.
       on host, puppet('resource', 'exec', 'setenforce 0', 'path=/bin:/sbin:/usr/bin:/usr/sbin', 'onlyif=which setenforce && getenforce | grep Enforcing')


### PR DESCRIPTION
#### Pull Request (PR) description
- Remove support for CentOS / RHEL 7 (breaking change)
- Remove workarounds specific to EPEL and `require_epel` parameter (breaking change)
- Add support for CentOS / RHEL 9 in metadata
- Where `repos_ensure` is not set, install `centos-release-rabbitmq-38` to support installing RabbitMQ from semi-official source (this is especially critical until #926 or something like it comes, since our tests, and the module, won't function, without this).
- Add in some additional tests for coverage (followup to #1028) that were hard to test without a supported RedHat family OS in metadata

Fixes #816

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
