### PR TITLE
Add `enable_centos_release` parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -219,6 +219,7 @@ The following parameters are available in the `rabbitmq` class:
 * [`default_user`](#-rabbitmq--default_user)
 * [`default_pass`](#-rabbitmq--default_pass)
 * [`delete_guest_user`](#-rabbitmq--delete_guest_user)
+* [`enable_centos_release`](#-rabbitmq--enable_centos_release)
 * [`env_config`](#-rabbitmq--env_config)
 * [`env_config_path`](#-rabbitmq--env_config_path)
 * [`environment_variables`](#-rabbitmq--environment_variables)
@@ -505,6 +506,15 @@ Default value: `'guest'`
 Data type: `Boolean`
 
 Controls whether default guest user is deleted.
+
+Default value: `false`
+
+##### <a name="-rabbitmq--enable_centos_release"></a>`enable_centos_release`
+
+Data type: `Boolean`
+
+Enable the `centos-release-rabbitmq-38` if set to `true` and if the OS is in the
+RedHat family and `repos_ensure` is `false`. Defaults to true on CentOS.
 
 Default value: `false`
 

--- a/data/os/CentOS.yaml
+++ b/data/os/CentOS.yaml
@@ -1,0 +1,1 @@
+rabbitmq::enable_centos_release: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -161,6 +161,9 @@
 #   Password to set for the `default_user` in rabbitmq.config.
 # @param delete_guest_user
 #   Controls whether default guest user is deleted.
+# @param enable_centos_release
+#   Enable the `centos-release-rabbitmq-38` if set to `true` and if the OS is in the
+#   RedHat family and `repos_ensure` is `false`. Defaults to true on CentOS.
 # @param env_config
 #   The template file to use for rabbitmq_env.config.
 # @param env_config_path
@@ -369,6 +372,7 @@ class rabbitmq (
   String $default_user                                                                             = 'guest',
   String $default_pass                                                                             = 'guest',
   Boolean $delete_guest_user                                                                       = false,
+  Boolean $enable_centos_release                                                                   = false,
   String $env_config                                                                               = 'rabbitmq/rabbitmq-env.conf.epp',
   Stdlib::Absolutepath $env_config_path                                                            = '/etc/rabbitmq/rabbitmq-env.conf',
   Optional[String] $erlang_cookie                                                                  = undef,
@@ -513,7 +517,7 @@ class rabbitmq (
       default: {
       }
     }
-  } elsif $facts['os']['family'] == 'RedHat' {
+  } elsif $facts['os']['family'] == 'RedHat' and $enable_centos_release {
     package { 'centos-release-rabbitmq-38':
       ensure   => 'present',
     }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -39,13 +39,20 @@ describe 'rabbitmq' do
         it { is_expected.not_to contain_class('rabbitmq::repo::rhel') }
         it { is_expected.not_to contain_yumrepo('rabbitmq') }
 
-        it { is_expected.to contain_package('centos-release-rabbitmq-38') } if os_facts['os']['family'] == 'RedHat'
+        it { is_expected.to contain_package('centos-release-rabbitmq-38') } if os_facts['os']['name'] == 'CentOS'
+        it { is_expected.not_to contain_package('centos-release-rabbitmq-38') } if os_facts['os']['name'] == 'RedHat'
       end
 
       context 'with service_restart => false' do
         let(:params) { { service_restart: false } }
 
         it { is_expected.not_to contain_class('rabbitmq::config').that_notifies('Class[rabbitmq::service]') }
+      end
+
+      context 'with enable_centos_release set to false' do
+        let(:params) { { enable_centos_release: false } }
+
+        it { is_expected.not_to contain_package('centos-release-rabbitmq-38') } if os_facts['os']['family'] == 'RedHat'
       end
 
       context 'with repos_ensure => true' do


### PR DESCRIPTION
#### Pull Request (PR) description
Add an `enable_centos_release` parameter, defaulting to `false`, except on CentOS, where it defaults to `true`. If enabled on any OS in the RedHat family when `repos_ensure` is also disabled, it controls adding the `centos-release-rabbitmq` package (currently
`centos-release-rabbitmq-38`)

#### This Pull Request (PR) fixes the following issues
Fixes #1033
Closes #1032