### PR TITLE
(#1043) - Add support for any necessary systemd system parameters via hash input

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -136,6 +136,27 @@ class { 'rabbitmq':
 }
 ```
 
+##### Change RabbitMQ service startup timeout via SystemD to 20 minutes (1200 seconds) :
+
+```puppet
+class { 'rabbitmq':
+  systemd_additional_service_parameters => {
+    'TimeoutStartSec' => 1200,
+  }
+}
+```
+
+##### Change multiple RabbitMQ service startup parameters via SystemD:
+
+```puppet
+class { 'rabbitmq':
+  systemd_additional_service_parameters => {
+    'TimeoutStartSec' => 1200,
+    'TimeoutStopSec'  => 1200,
+  }
+}
+```
+
 ##### Change Erlang Kernel Config Variables in rabbitmq.config
 
 ```puppet
@@ -225,6 +246,7 @@ The following parameters are available in the `rabbitmq` class:
 * [`environment_variables`](#-rabbitmq--environment_variables)
 * [`erlang_cookie`](#-rabbitmq--erlang_cookie)
 * [`file_limit`](#-rabbitmq--file_limit)
+* [`systemd_additional_service_parameters`](#-rabbitmq--systemd_additional_service_parameters)
 * [`oom_score_adj`](#-rabbitmq--oom_score_adj)
 * [`heartbeat`](#-rabbitmq--heartbeat)
 * [`inetrc_config`](#-rabbitmq--inetrc_config)
@@ -564,6 +586,15 @@ Data type: `Variant[Integer[-1],Enum['unlimited'],Pattern[/^(infinity|\d+(:(infi
 Set rabbitmq file ulimit. Defaults to 16384. Only available on Linux
 
 Default value: `16384`
+
+##### <a name="-rabbitmq--systemd_additional_service_parameters"></a>`systemd_additional_service_parameters`
+
+Data type: `Hash`
+
+Hash of additional systemd service parameters which are appended to the dropin file. No validation is done, this is passed verbotem to the systemd dropin module.
+Defaults to {}. Only available on Linux
+
+Default value: `{}`
 
 ##### <a name="-rabbitmq--oom_score_adj"></a>`oom_score_adj`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,20 @@
 #     }
 #   }
 #
+# @example Change RabbitMQ service startup timeout via SystemD to 20 minutes (1200 seconds) :
+#   class { 'rabbitmq':
+#     systemd_additional_service_parameters => {
+#       'TimeoutStartSec' => 1200,
+#     }
+#   }
+# @example Change multiple RabbitMQ service startup parameters via SystemD:
+#   class { 'rabbitmq':
+#     systemd_additional_service_parameters => {
+#       'TimeoutStartSec' => 1200,
+#       'TimeoutStopSec'  => 1200,
+#     }
+#   }
+#
 # @example Change Erlang Kernel Config Variables in rabbitmq.config
 #   class { 'rabbitmq':
 #     port                    => '5672',
@@ -176,6 +190,9 @@
 #   to 'False' and set 'erlang_cookie'.
 # @param file_limit
 #   Set rabbitmq file ulimit. Defaults to 16384. Only available on Linux
+# @param systemd_additional_service_parameters
+#   Hash of additional systemd service parameters which are appended to the dropin file. No validation is done, this is passed verbotem to the systemd dropin module.
+#   Defaults to {}. Only available on Linux
 # @param oom_score_adj
 #   Set rabbitmq-server process OOM score. Defaults to 0.
 # @param heartbeat
@@ -470,6 +487,7 @@ class rabbitmq (
   Boolean $wipe_db_on_cookie_change                                                                = false,
   String $cluster_partition_handling                                                               = 'ignore',
   Variant[Integer[-1],Enum['unlimited'],Pattern[/^(infinity|\d+(:(infinity|\d+))?)$/]] $file_limit = 16384,
+  Hash $systemd_additional_service_parameters                                                      = {},
   Integer[-1000, 1000] $oom_score_adj                                                              = 0,
   Hash $environment_variables                                                                      = { 'LC_ALL' => 'en_US.UTF-8' },
   Hash $config_variables                                                                           = {},

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -182,7 +182,7 @@ describe 'rabbitmq' do
           end
         end
       end
-         
+
       { 'TimeoutStartSec' => 1200, 'TimeoutStopSec' => 1200, }.each do |key, value|
         context "with systemd_additional_service_parameters => '{ #{key} => #{value}'", if: os_facts['kernel'] == 'Linux' do
           let(:params) { { systemd_additional_service_parameters: { key => value } } }

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -182,6 +182,22 @@ describe 'rabbitmq' do
           end
         end
       end
+         
+      { 'TimeoutStartSec' => 1200, 'TimeoutStopSec' => 1200, }.each do |key, value|
+        context "with systemd_additional_service_parameters => '{ #{key} => #{value}'", if: os_facts['kernel'] == 'Linux' do
+          let(:params) { { systemd_additional_service_parameters: { key => value } } }
+
+          it { is_expected.to contain_systemd__manage_dropin('service-90-limits.conf').with_service_entry({ key => value, 'LimitNOFILE' => 16_384, 'OOMScoreAdjust' => 0 }) }
+        end
+      end
+
+      { 'TimeoutStartSec' => 600, 'TimeoutStopSec' => 2400, }.each do |key, value|
+        context "with systemd_additional_service_parameters => '{ #{key} => #{value}'", if: os_facts['kernel'] == 'Linux' do
+          let(:params) { { systemd_additional_service_parameters: { key => value } } }
+
+          it { is_expected.to contain_systemd__manage_dropin('service-90-limits.conf').with_service_entry({ key => value, 'LimitNOFILE' => 16_384, 'OOMScoreAdjust' => 0 }) }
+        end
+      end
 
       context 'on Linux', if: os_facts['kernel'] == 'Linux' do
         it { is_expected.to contain_systemd__manage_dropin('service-90-limits.conf') }


### PR DESCRIPTION
… hash input

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
- Add support for any "Service" Systemd Parameter via drop-in
- Do not conflict with the current two statically configured parameters oom score, and openfiles
- Takes a hash - remains flexible to allow "any" service parameter needed to be set in SystemD for RabbitMQ.

#### This Pull Request (PR) fixes the following issues
<!--
Fixes #1043 