### PR TITLE
Fix undef comparison in rabbitmq-env.conf template

### DIFF
--- a/templates/rabbitmq-env.conf.epp
+++ b/templates/rabbitmq-env.conf.epp
@@ -1,5 +1,5 @@
 <% $rabbitmq::config::environment_variables.keys.sort.each |$k| { -%>
-  <%- unless $rabbitmq::config::environment_variables[$k] == Undef {-%>
+  <%- unless $rabbitmq::config::environment_variables[$k] =~ Undef {-%>
 <%= $k %>=<%= $rabbitmq::config::environment_variables[$k] %>
   <%-} -%>
 <% } -%>


### PR DESCRIPTION
#### Pull Request (PR) description

Conversion from erb to epp introduced a logic error, comparing the value of the environment variable to the `Undef` Type, rather than comparing either the type of the value against the `Undef` type, or the value against the literal `undef`.

This change fixes the issue that `environment_variables` with undefined values were being added to `rabbitmq-env.config` unintentionally, including implicit environment variables injected by `$default_ssl_env_variables`.

Before:

```

#### This Pull Request (PR) fixes the following issues
