### PR TITLE
Correctly handle rabbitmqctl list_users output

### DIFF
--- a/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
+++ b/lib/puppet/provider/rabbitmq_user/rabbitmqctl.rb
@@ -18,16 +18,20 @@ Puppet::Type.type(:rabbitmq_user).provide(
       rabbitmqctl_list('users')
     end
 
-    user_list.split(%r{\n}).map do |line|
-      raise Puppet::Error, "Cannot parse invalid user line: #{line}" unless line =~ %r{^(\S+)\s+\[(.*?)\]$}
+    if user_list.split(%r{\n}).size > 0
+      user_list.split(%r{\n}).map do |line|
+        raise Puppet::Error, "Cannot parse invalid user line: #{line}" unless line =~ %r{^(\S+)\s+\[(.*?)\]$}
 
-      user = Regexp.last_match(1)
-      tags = Regexp.last_match(2).split(%r{,\s*})
-      new(
-        ensure: :present,
-        name: user,
-        tags: tags
-      )
+        user = Regexp.last_match(1)
+        tags = Regexp.last_match(2).split(%r{,\s*})
+        new(
+          ensure: :present,
+          name: user,
+          tags: tags
+        )
+      end
+    else
+      user_list = []
     end
   end
 


### PR DESCRIPTION
The rabbitmq_user provider seemed broken to me, at least with a recent version of rabbitmq (I'm talking about 4.0.5 in Debian 13 aka Trixie).

This small patch fixes the provider.
