### PR TITLE
Use namespace function from stdlib

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -149,7 +149,7 @@ class rabbitmq::config {
         default           => "\"${orig}${ssl_path} -proto_dist ${proto_dist}\"",
       }
 
-      merge($memo, { "RABBITMQ_${item}_ERL_ARGS" => $munged })
+      stdlib::merge($memo, { "RABBITMQ_${item}_ERL_ARGS" => $munged })
     }
 
     $environment_variables = $_environment_variables + $ipv6_or_tls_env

--- a/metadata.json
+++ b/metadata.json
@@ -60,7 +60,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppet/archive",


### PR DESCRIPTION
#### Pull Request (PR) description
The existing functions were deprecated in favor of the stdlib namespace functions in puppetlabs-stdlib 9.0.0 .

This fixes the outdated lower bound of pupetlabs-stdlib, because the namespace has already been used since [1] was mereged.

[1] d076fb25d440dd4becc0cec66065e004cae3f052

#### This Pull Request (PR) fixes the following issues
N/A