### PR TITLE
docs: update contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This module is maintained by [Vox Pupuli](https://voxpupuli.org/). Voxpupuli
 welcomes new contributions to this module, especially those that include
 documentation and rspec tests. We are happy to provide guidance if necessary.
 
-Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for more details.
+Please see [CONTRIBUTING](https://github.com/voxpupuli/.github/blob/master/CONTRIBUTING.md) for more details.
 
 ### Authors
 * Jeff McCune <jeff@puppetlabs.com>


### PR DESCRIPTION
#### Pull Request (PR) description
8a857e14773fe6d4c09f0ac1ca618b46c0c79851 removed `.github/CONTRIBUTING.md` (https://github.com/voxpupuli/modulesync_config/pull/982).

However, the main README still linked to the old path.

@bastelfreak q: how is https://github.com/voxpupuli/puppet-rabbitmq?tab=contributing-ov-file#readme still working, and do we need to do something for it to continue to work? it seems to think that's coming from the repo level file if I'm not mistaken, despite that file no longer existing in the main branch.

Also, let me know if we have a cleaner way of linking to the top level contributing file that would account for a possible change to the default branch name in the future.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
