### PR TITLE
feat: use current upstream repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,4 @@ jobs:
       beaker_staging_url: ${{ inputs.beaker_staging_url }}
       beaker_collection: ${{ inputs.beaker_collection }}
       beaker_staging_version: ${{ inputs.beaker_staging_version }}
+      beaker_facter: 'rabbitmq_version:RabbitMQ:3.13'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,6 +18,7 @@ RSpec/BeEq:
 # Offense count: 13
 RSpec/LeakyLocalVariable:
   Exclude:
+    - 'spec/acceptance/class_spec.rb'
     - 'spec/classes/rabbitmq_spec.rb'
     - 'spec/unit/puppet/provider/rabbitmq_binding/rabbitmqadmin_spec.rb'
     - 'spec/unit/puppet/provider/rabbitmq_cli_spec.rb'

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -16,8 +16,10 @@
 * `rabbitmq::install`: Ensures that rabbitmq-server exists
 * `rabbitmq::install::rabbitmqadmin`: Install rabbitmq admin
 * `rabbitmq::management`: Manage presence / absence of user resource for guest management user.
-* `rabbitmq::repo::apt`: requires   puppetlabs-apt   puppetlabs-stdlib
-* `rabbitmq::repo::rhel`: Makes sure that the Packagecloud repo is installed
+* `rabbitmq::repo::apt`: Configure upstream RabbitMQ APT repositories in DEB-822 format and pin
+packages if necessary.
+* `rabbitmq::repo::rhel`: Configure upstream RabbitMQ RPM repositories and locks packages versions if
+necessary.
 * `rabbitmq::service`: This class manages the rabbitmq server service itself.
 
 ### Resource types
@@ -273,7 +275,9 @@ The following parameters are available in the `rabbitmq` class:
 * [`management_ssl`](#-rabbitmq--management_ssl)
 * [`node_ip_address`](#-rabbitmq--node_ip_address)
 * [`package_apt_pin`](#-rabbitmq--package_apt_pin)
+* [`package_yum_versionlock`](#-rabbitmq--package_yum_versionlock)
 * [`package_ensure`](#-rabbitmq--package_ensure)
+* [`rabbitmq_version`](#-rabbitmq--rabbitmq_version)
 * [`package_gpg_key`](#-rabbitmq--package_gpg_key)
 * [`package_source`](#-rabbitmq--package_source)
 * [`package_provider`](#-rabbitmq--package_provider)
@@ -810,7 +814,15 @@ Default value: `undef`
 
 Data type: `Optional[Variant[Numeric, String[1]]]`
 
-Whether to pin the package to a particular source
+Whether to pin the package to a particular major.minor version
+
+Default value: `undef`
+
+##### <a name="-rabbitmq--package_yum_versionlock"></a>`package_yum_versionlock`
+
+Data type: `Optional[Boolean]`
+
+Whether to yum-versionlock the package to a particular major.minor version
 
 Default value: `undef`
 
@@ -819,8 +831,17 @@ Default value: `undef`
 Data type: `String`
 
 Determines the ensure state of the package.  Set to installed by default, but could be changed to latest.
+Use rabbitmq_version parameter to handle correctly installed version and dependencies.
 
 Default value: `'installed'`
+
+##### <a name="-rabbitmq--rabbitmq_version"></a>`rabbitmq_version`
+
+Data type: `String`
+
+Version of RabbitMQ to install in major.minor format (3.13, 3.8, etc.) or 'latest'.
+
+Default value: `'latest'`
 
 ##### <a name="-rabbitmq--package_gpg_key"></a>`package_gpg_key`
 
@@ -944,12 +965,9 @@ Default value: `undef`
 
 Data type: `Boolean`
 
-Ensure that a repo with the official (and newer) RabbitMQ package is configured, along with its signing key.
-Defaults to false (use system packages). This does not ensure that soft dependencies are present.
-It also does not solve the erlang dependency. See https://www.rabbitmq.com/which-erlang.html for a good breakdown of the
-different ways of handling the erlang deps. See also https://github.com/voxpupuli/puppet-rabbitmq/issues/788
+Ensure that upstream repositories for RabbitMQ and Erlang are enabled.
 
-Default value: `false`
+Default value: `true`
 
 ##### <a name="-rabbitmq--service_ensure"></a>`service_ensure`
 

--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -2,4 +2,4 @@
 rabbitmq::python_package: 'python3'
 rabbitmq::package_name: 'rabbitmq-server'
 rabbitmq::service_name: 'rabbitmq-server'
-rabbitmq::package_gpg_key: 'https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey'
+rabbitmq::package_apt_pin: 1001

--- a/data/family/RedHat-9.yaml
+++ b/data/family/RedHat-9.yaml
@@ -1,0 +1,30 @@
+---
+rabbitmq::repo::rhel::rpm_repositories:
+  modern-erlang:
+    name: modern-erlang-el9
+    baseurl: https://yum1.rabbitmq.com/erlang/el/9/$basearch https://yum2.rabbitmq.com/erlang/el/9/$basearch
+    gpgkey: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key
+    gpgcheck: true
+    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    sslverify: true
+  modern-erlang-noarch:
+    name: modern-erlang-el9-noarch
+    baseurl: https://yum1.rabbitmq.com/erlang/el/9/noarch https://yum2.rabbitmq.com/erlang/el/9/noarch
+    gpgkey: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key https://github.com/rabbitmq/signing-keys/releases/download/3.0/rabbitmq-release-signing-key.asc
+    gpgcheck: true
+    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    sslverify: true
+  rabbitmq-el9:
+    name: rabbitmq-el9
+    baseurl: https://yum2.rabbitmq.com/rabbitmq/el/9/$basearch https://yum1.rabbitmq.com/rabbitmq/el/9/$basearch
+    gpgkey: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key https://github.com/rabbitmq/signing-keys/releases/download/3.0/rabbitmq-release-signing-key.asc
+    gpgcheck: true
+    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    sslverify: true
+  rabbitmq-el9-noarch:
+    name: rabbitmq-el9-noarch
+    baseurl: https://yum2.rabbitmq.com/rabbitmq/el/9/noarch https://yum1.rabbitmq.com/rabbitmq/el/9/noarch
+    gpgkey: https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key https://github.com/rabbitmq/signing-keys/releases/download/3.0/rabbitmq-release-signing-key.asc
+    gpgcheck: true
+    sslcacert: /etc/pki/tls/certs/ca-bundle.crt
+    sslverify: true

--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -1,5 +1,4 @@
 ---
 rabbitmq::package_name: 'rabbitmq-server'
 rabbitmq::service_name: 'rabbitmq-server'
-rabbitmq::package_gpg_key: 'https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc'
-rabbitmq::repo_gpg_key: 'https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey'
+rabbitmq::package_yum_versionlock: true

--- a/data/os/CentOS.yaml
+++ b/data/os/CentOS.yaml
@@ -1,1 +1,0 @@
-rabbitmq::enable_centos_release: true

--- a/data/os/Debian-11.yaml
+++ b/data/os/Debian-11.yaml
@@ -1,0 +1,6 @@
+---
+rabbitmq::repo::apt::location:
+  - https://deb1.rabbitmq.com/rabbitmq-erlang/debian/bullseye
+  - https://deb2.rabbitmq.com/rabbitmq-erlang/debian/bullseye
+  - https://deb1.rabbitmq.com/rabbitmq-server/debian/bullseye
+  - https://deb2.rabbitmq.com/rabbitmq-server/debian/bullseye

--- a/data/os/Debian-12.yaml
+++ b/data/os/Debian-12.yaml
@@ -1,0 +1,6 @@
+---
+rabbitmq::repo::apt::location:
+  - https://deb1.rabbitmq.com/rabbitmq-erlang/debian/bookworm
+  - https://deb2.rabbitmq.com/rabbitmq-erlang/debian/bookworm
+  - https://deb1.rabbitmq.com/rabbitmq-server/debian/bookworm
+  - https://deb2.rabbitmq.com/rabbitmq-server/debian/bookworm

--- a/data/os/Ubuntu-22.04.yaml
+++ b/data/os/Ubuntu-22.04.yaml
@@ -1,0 +1,6 @@
+---
+rabbitmq::repo::apt::location:
+  - https://deb1.rabbitmq.com/rabbitmq-erlang/ubuntu/jammy
+  - https://deb2.rabbitmq.com/rabbitmq-erlang/ubuntu/jammy
+  - https://deb1.rabbitmq.com/rabbitmq-server/ubuntu/jammy
+  - https://deb2.rabbitmq.com/rabbitmq-server/ubuntu/jammy

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -10,6 +10,8 @@ hierarchy:
     path: "os/%{facts.os.name}-%{facts.os.release.major}.yaml"
   - name: 'Distribution Name'
     path: "os/%{facts.os.name}.yaml"
+  - name: 'Operating System Family - Major Version'
+    path: "family/%{facts.os.family}-%{facts.os.release.major}.yaml"
   - name: 'Operating System Family'
     path: "family/%{facts.os.family}.yaml"
   - name: 'Common'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -249,9 +249,14 @@
 #   Allows you to set the IP for RabbitMQ service to bind to. Set to 127.0.0.1 to bind to localhost only, or 0.0.0.0
 #   to bind to all interfaces.
 # @param package_apt_pin
-#   Whether to pin the package to a particular source
+#   Whether to pin the package to a particular major.minor version
+# @param package_yum_versionlock
+#   Whether to yum-versionlock the package to a particular major.minor version
 # @param package_ensure
 #   Determines the ensure state of the package.  Set to installed by default, but could be changed to latest.
+#   Use rabbitmq_version parameter to handle correctly installed version and dependencies.
+# @param rabbitmq_version
+#   Version of RabbitMQ to install in major.minor format (3.13, 3.8, etc.) or 'latest'.
 # @param package_gpg_key
 #   RPM package GPG key to import. Uses source method. Should be a URL for Debian/RedHat OS family, or a file name for
 #   RedHat OS family. Set to https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc
@@ -291,10 +296,7 @@
 #   Controls the target group size for a quorum queue
 #   Important Note: This only takes affect if quorum_membership_reconciliation_enabled is set to true.
 # @param repos_ensure
-#   Ensure that a repo with the official (and newer) RabbitMQ package is configured, along with its signing key.
-#   Defaults to false (use system packages). This does not ensure that soft dependencies are present.
-#   It also does not solve the erlang dependency. See https://www.rabbitmq.com/which-erlang.html for a good breakdown of the
-#   different ways of handling the erlang deps. See also https://github.com/voxpupuli/puppet-rabbitmq/issues/788
+#   Ensure that upstream repositories for RabbitMQ and Erlang are enabled.
 # @param service_ensure
 #   The state of the service.
 # @param service_manage
@@ -434,7 +436,9 @@ class rabbitmq (
   Optional[String] $management_hostname                                                            = undef,
   Optional[String] $node_ip_address                                                                = undef,
   Optional[Variant[Numeric, String[1]]] $package_apt_pin                                           = undef,
+  Optional[Boolean] $package_yum_versionlock                                                       = undef,
   String $package_ensure                                                                           = 'installed',
+  String $rabbitmq_version                                                                         = 'latest',
   Optional[String] $package_gpg_key                                                                = undef,
   Optional[Integer] $quorum_cluster_size                                                           = undef,
   Optional[Boolean] $quorum_membership_reconciliation_enabled                                      = undef,
@@ -446,7 +450,7 @@ class rabbitmq (
   Variant[String, Array] $package_name                                                             = 'rabbitmq',
   Optional[String] $package_source                                                                 = undef,
   Optional[String] $package_provider                                                               = undef,
-  Boolean $repos_ensure                                                                            = false,
+  Boolean $repos_ensure                                                                            = true,
   Boolean $manage_python                                                                           = true,
   String $python_package                                                                           = 'python',
   String $rabbitmq_user                                                                            = 'rabbitmq',

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -1,47 +1,99 @@
-# requires
-#   puppetlabs-apt
-#   puppetlabs-stdlib
-#
 # @api private
 #
+# @summary
+#   Configure upstream RabbitMQ APT repositories in DEB-822 format and pin
+#   packages if necessary.
+#
+# @param key_id
+#   ID of the key used to sign packages.
+# @param key_server
+#   Server used to retrieve the key used to sign packages.
 # @param location
+#   Array of URLs that host the packages.
 # @param repos
-# @param include_src
-# @param key
-# @param key_source
-# @param key_content
-# @param architecture
+#   Repositories components to enable.
 #
 class rabbitmq::repo::apt (
-  String[1] $location            = 'https://packagecloud.io/rabbitmq/rabbitmq-server',
-  String[1] $repos               = 'main',
-  Boolean $include_src           = false,
-  String[1] $key                 = '8C695B0219AFDEB04A058ED8F4E789204D206F89',
-  String[1] $key_source          = $rabbitmq::package_gpg_key,
-  Optional[String[1]] $key_content  = $rabbitmq::key_content,
-  Optional[String[1]] $architecture = undef,
+  String[1]        $key_id     = '0A9AF2115F4687BD29803A206B73A36E6026DFCA',
+  String[1]        $key_server = 'keys.openpgp.org',
+  Array[String[1]] $location   = ['localhost'], # OS dependent, it's in Hiera
+  Array[String[1]] $repos      = ['main'],
 ) {
-  $osname = downcase($facts['os']['name'])
-  $pin    = $rabbitmq::package_apt_pin
+  # https://github.com/puppetlabs/puppetlabs-apt/issues/1184
+  include apt
 
-  apt::source { 'rabbitmq':
-    ensure       => present,
-    location     => "${location}/${osname}",
-    repos        => $repos,
-    include      => { 'src' => $include_src },
-    key          => {
-      'id'      => $key,
-      'source'  => $key_source,
-      'content' => $key_content,
-    },
-    architecture => $architecture,
+  # Uses legacy trusted.gpg, because apt::keyring does not de-armor the key
+  apt::key { 'com.rabbitmq.team.gpg':
+    id     => $key_id,
+    server => $key_server,
   }
 
+  apt::source { 'rabbitmq':
+    source_format => 'sources',
+    location      => $location,
+    repos         => $repos,
+    release       => [$facts['os']['distro']['codename']],
+    types         => ['deb'],
+    keyring       => '/etc/apt/trusted.gpg',
+    comment       => 'Modern Erlang/OTP and RabbitMQ releases',
+  }
+
+  $pin    = $rabbitmq::package_apt_pin
   if $pin {
-    apt::pin { 'rabbitmq':
-      packages => '*',
-      priority => $pin,
-      origin   => inline_template('<%= require \'uri\'; URI(@location).host %>'),
+    # Determine the Erlang compatible with RabbitMQ one, otherwise dependencies
+    # install fails
+    # https://www.rabbitmq.com/docs/which-erlang
+    case $rabbitmq::rabbitmq_version {
+      '3.13': {
+        $erlang_pin_version = '1:26.*'
+        $rabbitmq_pin_version = '3.13.*'
+      }
+      '3.12': {
+        $erlang_pin_version = '1:26.*'
+        $rabbitmq_pin_version = '3.12.*'
+      }
+      '3.11': {
+        $erlang_pin_version = '1:25.*'
+        $rabbitmq_pin_version = '3.11.*'
+      }
+      '3.10': {
+        $erlang_pin_version = '1:25.*'
+        $rabbitmq_pin_version = '3.10.*'
+      }
+      '3.9': {
+        $erlang_pin_version = '1:25.*'
+        $rabbitmq_pin_version = '3.9.*'
+      }
+      '3.8': {
+        $erlang_pin_version = '1:24.*'
+        $rabbitmq_pin_version = '3.8.*'
+      }
+      '3.7': {
+        $erlang_pin_version = '1:22.*'
+        $rabbitmq_pin_version = '3.7.*'
+      }
+      default: {
+        $erlang_pin_version = false
+        $rabbitmq_pin_version = false
+      }
+    }
+
+    if $rabbitmq_pin_version {
+      apt::pin { 'rabbitmq':
+        packages    => 'rabbitmq*',
+        explanation => "Pin RabbitMQ packages to ${rabbitmq::rabbitmq_version}",
+        priority    => $pin,
+        version     => $rabbitmq_pin_version,
+      }
+    }
+
+    if $erlang_pin_version {
+      apt::pin { 'erlang':
+        packages    => 'erlang*',
+        explanation => "Pin Erlang packages to versions compatible with RabbitMQ ${rabbitmq::rabbitmq_version}",
+        priority    => $pin,
+        version     => $erlang_pin_version,
+      }
     }
   }
 }

--- a/manifests/repo/rhel.pp
+++ b/manifests/repo/rhel.pp
@@ -1,40 +1,57 @@
-# Makes sure that the Packagecloud repo is installed
-#
 # @api private
 #
-# @param location
-# @param repo_key_source
-# @param package_key_source
+# @summary 
+#   Configure upstream RabbitMQ RPM repositories and locks packages versions if
+#   necessary.
+#
+# @param rpm_repositories
+#   Hash of RPM repositories to add to the system.
 #
 class rabbitmq::repo::rhel (
-  String[1] $location                  = "https://packagecloud.io/rabbitmq/rabbitmq-server/el/${facts['os'][release][major]}/\$basearch",
-  String[1] $repo_key_source    = $rabbitmq::repo_gpg_key,
-  String[1] $package_key_source = $rabbitmq::package_gpg_key,
+  Optional[Hash] $rpm_repositories = undef, # See Hiera
 ) {
-  # Import package key from rabbitmq to be able to
-  # sign the package and the repo.
-  # rabbitmq key is gpg-pubkey-6026dfca-573adfde
-  exec { "rpm --import ${package_key_source}":
-    path   => ['/bin','/usr/bin','/sbin','/usr/sbin'],
-    unless => 'rpm -q gpg-pubkey-6026dfca-573adfde 2>/dev/null',
-    before => YumRepo['rabbitmq'],
+  $rpm_repositories.each |String $repository, Hash $params| {
+    yumrepo { $repository:
+      name      => $params['name'],
+      baseurl   => $params['baseurl'],
+      gpgkey    => $params['gpgkey'],
+      gpgcheck  => $params['gpgcheck'],
+      sslcacert => $params['sslcacert'],
+      sslverify => $params['sslverify'],
+    }
   }
 
-  yumrepo { 'rabbitmq':
-    ensure        => present,
-    name          => 'rabbitmq_rabbitmq-server',
-    baseurl       => $location,
-    gpgkey        => $repo_key_source,
-    enabled       => 1,
-    gpgcheck      => 1,
-    repo_gpgcheck => 1,
+  case $rabbitmq::rabbitmq_version {
+    '3.13': {
+      $rabbitmq_pin_version = '3.13.*'
+    }
+    '3.12': {
+      $rabbitmq_pin_version = '3.12.*'
+    }
+    '3.11': {
+      $rabbitmq_pin_version = '3.11.*'
+    }
+    '3.10': {
+      $rabbitmq_pin_version = '3.10.*'
+    }
+    '3.9': {
+      $rabbitmq_pin_version = '3.9.*'
+    }
+    '3.8': {
+      $rabbitmq_pin_version = '3.8.*'
+    }
+    '3.7': {
+      $rabbitmq_pin_version = '3.7.*'
+    }
+    default: {
+      $rabbitmq_pin_version = false
+    }
   }
 
-  # This may still be needed to prevent warnings
-  # packagecloud key is gpg-pubkey-4d206f89-5bbb8d59
-  exec { "rpm --import ${repo_key_source}":
-    path    => ['/bin','/usr/bin','/sbin','/usr/sbin'],
-    unless  => 'rpm -q gpg-pubkey-4d206f89-5bbb8d59 2>/dev/null',
-    require => YumRepo['rabbitmq'],
+  $lock = $rabbitmq::package_yum_versionlock
+  if $lock and $rabbitmq_pin_version {
+    yum::versionlock { 'rabbitmq-server':
+      version => $rabbitmq_pin_version,
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "20.04",
         "22.04"
       ]
     },
@@ -70,6 +69,18 @@
     {
       "name": "puppet/systemd",
       "version_requirement": ">= 6.0.0 < 10.0.0"
+    },
+    {
+      "name": "puppetlabs/apt",
+      "version_requirement": ">= 10.0.0 < 12.0.0"
+    },
+    {
+      "name": "puppetlabs/yumrepo_core",
+      "version_requirement": ">= 2.0.0 < 4.0.0"
+    },
+    {
+      "name": "puppet/yum",
+      "version_requirement": ">= 6.1.0 < 9.0.0"
     }
   ],
   "tags": [

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper_acceptance'
 
 describe 'rabbitmq class:' do
+  rabbitmq_version = ENV.fetch('BEAKER_FACTER_rabbitmq_version', '3.13')
+
   case fact('os.family')
   when 'RedHat', 'SUSE', 'Debian'
     package_name = 'rabbitmq-server'
@@ -12,10 +14,12 @@ describe 'rabbitmq class:' do
     service_name = 'rabbitmq'
   end
 
-  context 'default class inclusion' do
+  context "default class inclusion with RabbitMQ #{rabbitmq_version}" do
     let(:pp) do
       <<-EOS
-      include rabbitmq
+      class { 'rabbitmq':
+        rabbitmq_version => '#{rabbitmq_version}',
+      }
       EOS
     end
 
@@ -69,8 +73,9 @@ describe 'rabbitmq class:' do
 
       pp = <<-EOS
         class { 'rabbitmq':
-          service_manage => false,
-          service_ensure  => 'stopped',
+          rabbitmq_version => '#{rabbitmq_version}',
+          service_manage   => false,
+          service_ensure   => 'stopped',
         }
       EOS
 
@@ -88,6 +93,7 @@ describe 'rabbitmq class:' do
     let(:pp) do
       <<-EOS
       class { 'rabbitmq':
+        rabbitmq_version  => '#{rabbitmq_version}',
         service_manage    => true,
         port              => 5672,
         admin_enable      => true,
@@ -119,6 +125,7 @@ describe 'rabbitmq class:' do
     let(:pp) do
       <<-EOS
         class { 'rabbitmq':
+          rabbitmq_version  => '#{rabbitmq_version}',
           service_manage    => true,
           port              => 5672,
           admin_enable      => true,
@@ -152,6 +159,7 @@ describe 'rabbitmq class:' do
     let(:pp) do
       <<-EOS
         class { 'rabbitmq':
+          rabbitmq_version => '#{rabbitmq_version}',
           service_manage  => true,
           admin_enable    => true,
           node_ip_address => '0.0.0.0',
@@ -183,6 +191,7 @@ describe 'rabbitmq class:' do
     let(:pp) do
       <<-EOS
         class { 'rabbitmq':
+          rabbitmq_version => '#{rabbitmq_version}',
           service_manage        => true,
           port                  => 5672,
           admin_enable          => true,

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -34,13 +34,12 @@ describe 'rabbitmq' do
       it { is_expected.to contain_package('rabbitmq-server-plugins') } if os_facts['os']['family'] == 'Suse'
 
       context 'with default params' do
-        it { is_expected.not_to contain_class('rabbitmq::repo::apt') }
-        it { is_expected.not_to contain_apt__source('rabbitmq') }
-        it { is_expected.not_to contain_class('rabbitmq::repo::rhel') }
-        it { is_expected.not_to contain_yumrepo('rabbitmq') }
+        it { is_expected.not_to contain_class('rabbitmq::repo::apt') } unless os_facts['os']['family'] == 'Debian'
+        it { is_expected.not_to contain_apt__source('rabbitmq') } unless os_facts['os']['family'] == 'Debian'
+        it { is_expected.not_to contain_class('rabbitmq::repo::rhel') } unless os_facts['os']['family'] == 'RedHat'
+        it { is_expected.not_to contain_yumrepo('rabbitmq') } unless os_facts['os']['family'] == 'RedHat'
 
-        it { is_expected.to contain_package('centos-release-rabbitmq-38') } if os_facts['os']['name'] == 'CentOS'
-        it { is_expected.not_to contain_package('centos-release-rabbitmq-38') } if os_facts['os']['name'] == 'RedHat'
+        it { is_expected.not_to contain_package('centos-release-rabbitmq-38') } if os_facts['os']['family'] == 'RedHat'
       end
 
       context 'with service_restart => false' do
@@ -61,16 +60,16 @@ describe 'rabbitmq' do
         if os_facts['os']['family'] == 'Debian'
           it 'includes rabbitmq::repo::apt' do
             is_expected.to contain_class('rabbitmq::repo::apt')
-              .with_key_source('https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey')
-              .with_key_content(nil)
+              .with_key_id('0A9AF2115F4687BD29803A206B73A36E6026DFCA')
+              .with_key_server('keys.openpgp.org')
           end
 
           it 'adds a repo with default values' do
             is_expected.to contain_apt__source('rabbitmq')
               .with_ensure('present')
-              .with_location("https://packagecloud.io/rabbitmq/rabbitmq-server/#{os_facts['os']['name'].downcase}")
-              .with_release(nil)
-              .with_repos('main')
+              .with_location(["https://deb1.rabbitmq.com/rabbitmq-erlang/#{os_facts['os']['distro']['id'].downcase}/#{os_facts['os']['distro']['codename'].downcase}", "https://deb2.rabbitmq.com/rabbitmq-erlang/#{os_facts['os']['distro']['id'].downcase}/#{os_facts['os']['distro']['codename'].downcase}", "https://deb1.rabbitmq.com/rabbitmq-server/#{os_facts['os']['distro']['id'].downcase}/#{os_facts['os']['distro']['codename'].downcase}", "https://deb2.rabbitmq.com/rabbitmq-server/#{os_facts['os']['distro']['id'].downcase}/#{os_facts['os']['distro']['codename'].downcase}"])
+              .with_release([os_facts['os']['distro']['codename'].to_s])
+              .with_repos(['main'])
           end
         else
           it { is_expected.not_to contain_class('rabbitmq::repo::apt') }
@@ -81,24 +80,11 @@ describe 'rabbitmq' do
           it { is_expected.to contain_class('rabbitmq::repo::rhel') }
 
           it 'the repo should be present, and contain the expected values' do
-            is_expected.to contain_yumrepo('rabbitmq')
-              .with_ensure('present')
-              .with_baseurl(%r{https://packagecloud.io/rabbitmq/rabbitmq-server/el/\d+/\$basearch$})
-              .with_gpgkey('https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey')
+            is_expected.to contain_yumrepo('modern-erlang')
+              .with_baseurl(%r{https://yum1\.rabbitmq\.com/erlang/el/\d+/\$basearch})
+              .with_baseurl(%r{https://yum2\.rabbitmq\.com/erlang/el/\d+/\$basearch})
+              .with_gpgkey('https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key')
           end
-
-          it {
-            is_expected.to contain_exec('rpm --import https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc').with(
-              unless: 'rpm -q gpg-pubkey-6026dfca-573adfde 2>/dev/null',
-            )
-          }
-
-          it {
-            is_expected.to contain_exec('rpm --import https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey').with(
-              unless: 'rpm -q gpg-pubkey-4d206f89-5bbb8d59 2>/dev/null',
-            )
-          }
-
         else
           it { is_expected.not_to contain_class('rabbitmq::repo::rhel') }
           it { is_expected.not_to contain_yumrepo('rabbitmq') }
@@ -110,32 +96,31 @@ describe 'rabbitmq' do
 
         describe 'it sets up an apt::source' do
           it {
-            is_expected.to contain_apt__source('rabbitmq').with(
-              'location' => "https://packagecloud.io/rabbitmq/rabbitmq-server/#{os_facts['os']['name'].downcase}",
-              'repos' => 'main',
-              'key' => '{"id"=>"8C695B0219AFDEB04A058ED8F4E789204D206F89", "source"=>"https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey", "content"=>nil}',
-            )
+            is_expected.to contain_apt__source('rabbitmq')
+              .with_ensure('present')
+              .with_release([os_facts['os']['distro']['codename'].to_s])
+              .with_repos(['main'])
           }
         end
       end
 
       context 'with pin', if: os_facts['os']['family'] == 'Debian' do
-        let(:params) { { repos_ensure: true, package_apt_pin: '700' } }
+        let(:params) { { repos_ensure: true, package_apt_pin: '700', rabbitmq_version: '3.13' } }
 
         describe 'it sets up an apt::source and pin' do
           it {
-            is_expected.to contain_apt__source('rabbitmq').with(
-              'location' => "https://packagecloud.io/rabbitmq/rabbitmq-server/#{os_facts['os']['name'].downcase}",
-              'repos' => 'main',
-              'key' => '{"id"=>"8C695B0219AFDEB04A058ED8F4E789204D206F89", "source"=>"https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey", "content"=>nil}',
-            )
+            is_expected.to contain_apt__source('rabbitmq')
+              .with_ensure('present')
+              .with_location(["https://deb1.rabbitmq.com/rabbitmq-erlang/#{os_facts['os']['distro']['id'].downcase}/#{os_facts['os']['distro']['codename'].downcase}", "https://deb2.rabbitmq.com/rabbitmq-erlang/#{os_facts['os']['distro']['id'].downcase}/#{os_facts['os']['distro']['codename'].downcase}", "https://deb1.rabbitmq.com/rabbitmq-server/#{os_facts['os']['distro']['id'].downcase}/#{os_facts['os']['distro']['codename'].downcase}", "https://deb2.rabbitmq.com/rabbitmq-server/#{os_facts['os']['distro']['id'].downcase}/#{os_facts['os']['distro']['codename'].downcase}"])
+              .with_release([os_facts['os']['distro']['codename'].to_s])
+              .with_repos(['main'])
           }
 
           it {
             is_expected.to contain_apt__pin('rabbitmq').with(
-              'packages' => '*',
-              'priority' => '700',
-              'origin' => 'packagecloud.io',
+              'packages' => 'rabbitmq*',
+              'priority' => 700,
+              'version'  => '3.13.*',
             )
           }
         end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,8 +4,6 @@ require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker do |host|
   case fact_on(host, 'os.family')
-  when 'Debian'
-    install_puppet_module_via_pmt_on(host, 'puppetlabs-apt', '>= 9.0.0 < 10.0.0')
   when 'RedHat'
     if fact_on(host, 'os.selinux.enabled')
       # Make sure selinux is disabled so the tests work.


### PR DESCRIPTION
#### Pull Request (PR) description

* Add current upstream repositories instead of deprecated PackageCloud ones [0]
* Add dependencies to manage DEB/RPM repositories
* Refactor test to really use latest 3.x version

All of this in one PR to not leave the module in a not-working state

#### This Pull Request (PR) fixes the following issues

Fixes #781
Fixes #935 
